### PR TITLE
ltp-ddt sometimes cannot find scripts/basic/fixdep

### DIFF
--- a/meta-oe/recipes-devtools/ltp-ddt/ltp-ddt_0.0.4.bb
+++ b/meta-oe/recipes-devtools/ltp-ddt/ltp-ddt_0.0.4.bb
@@ -63,6 +63,10 @@ do_configure() {
 
 kmoddir = "/lib/modules/${KERNEL_VERSION}/kernel/drivers/ddt"
 
+addtask make_scripts after do_patch before do_compile
+do_make_scripts[lockfiles] = "${TMPDIR}/kernel-scripts.lock"
+do_make_scripts[deptask] = "do_populate_sysroot"
+
 do_compile_append () {
     oe_runmake DESTDIR=${D} modules
 }


### PR DESCRIPTION
Added the make_scripts task to the ltp-ddt bitbake recipe.

If no task has created the kernel scripts before ltp-ddt is run, there is a compile error complaining that it cannot find scripts/basic/fixdep. This patch ensures that these scripts are built before compiling starts.