### PR TITLE
usb-modeswitch recipy update

### DIFF
--- a/meta-oe/recipes-support/usb-modeswitch/usb-modeswitch-data_20140529.bb
+++ b/meta-oe/recipes-support/usb-modeswitch/usb-modeswitch-data_20140529.bb
@@ -5,8 +5,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 inherit allarch
 
 SRC_URI = "http://www.draisberghof.de/usb_modeswitch/usb-modeswitch-data-${PV}.tar.bz2"
-SRC_URI[md5sum] = "91feff51deba6e48e78506b8f4db2274"
-SRC_URI[sha256sum] = "a3114e2c1f38eed3ad0067df30e53a96313908a9539a8ea5d94a4d35651699eb"
+SRC_URI[md5sum] = "dff94177781298aaf0b3c2a3c3dea6b2"
+SRC_URI[sha256sum] = "53889157937109e04dafe897c098ec94f3f44f9c0c83fc6ec8417aa9a587e536"
+
 
 do_install() {
     oe_runmake install DESTDIR=${D}

--- a/meta-oe/recipes-support/usb-modeswitch/usb-modeswitch_2.2.0.bb
+++ b/meta-oe/recipes-support/usb-modeswitch/usb-modeswitch_2.2.0.bb
@@ -7,8 +7,8 @@ inherit autotools
 DEPENDS = "libusb1"
 
 SRC_URI = "http://www.draisberghof.de/usb_modeswitch/usb-modeswitch-${PV}.tar.bz2"
-SRC_URI[md5sum] = "e48d4419d0574d342bb183f7465556d0"
-SRC_URI[sha256sum] = "4706c9cfe825263e189f55730ea3d1d8634aeb15645a1098532e946e770f7f95"
+SRC_URI[md5sum] = "f323fe700edd6ea404c40934ddf32b22"
+SRC_URI[sha256sum] = "2752103de171ed5f6c8d6a6e3e73e16c9ee3e8e394dd39c5991f7680eb908a3a"
 
 EXTRA_OEMAKE = "TCL=${bindir}/tclsh"
 


### PR DESCRIPTION
## USB modeswitch recipy update 2.2.0
- usb-modeswitch recipe tarballs (2.0.1) were deleted and replaced them with 2.2.0 ones.
- Updated recipes to reflect this.
