### PR TITLE
Mplayer fix build and warning

### DIFF
--- a/meta-oe/recipes-multimedia/mplayer/mplayer2_git.bb
+++ b/meta-oe/recipes-multimedia/mplayer/mplayer2_git.bb
@@ -142,4 +142,5 @@ do_install() {
     install ${S}/etc/input.conf ${D}/usr/etc/mplayer/
     install ${S}/etc/example.conf ${D}/usr/etc/mplayer/
     install ${S}/etc/codecs.conf ${D}/usr/etc/mplayer/
+    [ -e ${D}/usr/lib ] && rmdir ${D}/usr/lib
 }


### PR DESCRIPTION
The patches fix build/configuration issues and a packaging warning. The commit messages describe the issue and how the problem is fixed.
