### PR TITLE
enca: fix broken automake

### DIFF
--- a/meta-oe/recipes-support/enca/enca/libenca-003-iconv.patch
+++ b/meta-oe/recipes-support/enca/enca/libenca-003-iconv.patch
@@ -1,0 +1,28 @@
+From 7e144495093187143a3d1589f74c2eac37e4d790 Mon Sep 17 00:00:00 2001
+From: Maxime Hadjinlian <maxime.hadjinlian@gmail.com>
+Date: Sun, 4 May 2014 15:49:28 +0200
+Subject: [PATCH] libiconv.m4: Fix AM_ICONV macro usage
+
+This patch come straight from the Buildroot source tree.
+
+Signed-off-by: Bernd Kuhls <berndkuhls@hotmail.com>
+Signed-off-by: Maxime Hadjinlian <maxime.hadjinlian@gmail.com>
+---
+ m4/libiconv.m4 | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/m4/libiconv.m4 b/m4/libiconv.m4
+index fc8c6f8..3a59549 100644
+--- a/m4/libiconv.m4
++++ b/m4/libiconv.m4
+@@ -17,7 +17,7 @@ AC_REQUIRE([AC_C_CONST])dnl
+ dnl
+ 
+ dnl Use standard iconv test
+-AM_ICONV
++m4_pattern_allow([AM_ICONV])
+ CONVERTOR_LIBS="$CONVERTOR_LIBS $LIBICONV"
+ 
+ dnl Compile iconvcap.c and run it to determine what encodings iconv actually
+-- 
+1.9.3

--- a/meta-oe/recipes-support/enca/enca_1.9.bb
+++ b/meta-oe/recipes-support/enca/enca_1.9.bb
@@ -11,7 +11,8 @@ SRC_URI = "http://www.sourcefiles.org/Networking/Tools/Miscellanenous/enca-${PV}
     file://configure-hack.patch \
     file://dont-run-tests.patch \
     file://configure-remove-dumbness.patch \
-    file://makefile-remove-tools.patch "
+    file://makefile-remove-tools.patch \
+    file://libenca-003-iconv.patch "
 
 SRC_URI[md5sum] = "b3581e28d68d452286fb0bfe58bed3b3"
 SRC_URI[sha256sum] = "02acfef2b24a9c842612da49338138311f909f1cd33933520c07b8b26c410f4d"


### PR DESCRIPTION
The added patch fixes the usage of AM_ICONV macro and
comes straight from the Buildroot source tree.

Signed-off-by: Drew Moseley drew_moseley@mentor.com
Signed-off-by: Awais Belal awais_belal@mentor.com
