### PR TITLE
Add a new version of python psutil

### DIFF
--- a/meta-python/recipes-devtools/python/python-psutil_2.1.3.bb
+++ b/meta-python/recipes-devtools/python/python-psutil_2.1.3.bb
@@ -1,0 +1,13 @@
+SUMMARY = "A cross-platform process and system utilities module for Python"
+SECTION = "devel/python"
+HOMEPAGE = "https://github.com/giampaolo/psutil"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=0f02e99f7f3c9a7fe8ecfc5d44c2be62"
+
+SRC_URI = "https://pypi.python.org/packages/source/p/psutil/psutil-${PV}.tar.gz"
+SRC_URI[md5sum] = "015a013c46bb9bc30b5c344f26dea0d3"
+SRC_URI[sha256sum] = "b434c75f01715777391f10f456002e33d0ca14633f96fdbd9ff9139b42d9452c"
+
+S = "${WORKDIR}/psutil-${PV}"
+
+inherit setuptools


### PR DESCRIPTION
This is a simple addition of a new version of psutil. Should I create a pull request for other branches as well? I am not too familiar with the branch naming structure, but I would like to push it to dizzy as well as branches for releases scheduled after dizzy.

Note, that the python API between the old and this version are different.

Signed-off-by: Ignas Anikevicius <ignas.anikevicius@realvnc.com>