### PR TITLE
add libgudev which is not provided by systemd anymore

### DIFF
--- a/meta-oe/recipes-connectivity/libmbim/libmbim_1.12.2.bb
+++ b/meta-oe/recipes-connectivity/libmbim/libmbim_1.12.2.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = " \
     file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c \
 "
 
-DEPENDS = "glib-2.0 udev"
+DEPENDS = "glib-2.0 libgudev"
 
 inherit autotools pkgconfig
 

--- a/meta-oe/recipes-connectivity/modemmanager/modemmanager_1.4.2.bb
+++ b/meta-oe/recipes-connectivity/modemmanager/modemmanager_1.4.2.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = " \
 
 inherit autotools gettext gtk-doc systemd
 
-DEPENDS = "glib-2.0 libmbim libqmi polkit udev dbus-glib"
+DEPENDS = "glib-2.0 libmbim libqmi polkit libgudev dbus-glib"
 
 SRC_URI = "http://www.freedesktop.org/software/ModemManager/ModemManager-${PV}.tar.xz"
 SRC_URI[md5sum] = "fe74eaa9a77e51e552b4356b4c7195cb"

--- a/meta-oe/recipes-connectivity/networkmanager/networkmanager_1.0.4.bb
+++ b/meta-oe/recipes-connectivity/networkmanager/networkmanager_1.0.4.bb
@@ -4,7 +4,7 @@ SECTION = "net/misc"
 LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=cbbffd568227ada506640fe950a4823b"
 
-DEPENDS = "libnl dbus dbus-glib udev wireless-tools nss util-linux libndp"
+DEPENDS = "libnl dbus dbus-glib libgudev wireless-tools nss util-linux libndp"
 
 inherit gnome gettext systemd
 

--- a/meta-oe/recipes-core/libgudev/libgudev_230.bb
+++ b/meta-oe/recipes-core/libgudev/libgudev_230.bb
@@ -1,0 +1,16 @@
+SUMMARY = "GObject bindings for libudev."
+DESCRIPTION = "This library provides GObject bindings for libudev. \
+It was originally part of udev-extras, then udev, then systemd. It's now a project on its own."
+HOMEPAGE = "https://wiki.gnome.org/Projects/libgudev"
+LICENSE = "LGPLv2.1"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
+
+RCONFLICTS_${PN} = "systemd (<= 220)"
+
+DEPENDS = "glib-2.0 udev"
+
+inherit autotools pkgconfig
+
+SRC_URI = "https://download.gnome.org/sources/${BPN}/${PV}/${BPN}-${PV}.tar.xz"
+SRC_URI[md5sum] = "e4dee8f3f349e9372213d33887819a4d"
+SRC_URI[sha256sum] = "a2e77faced0c66d7498403adefcc0707105e03db71a2b2abd620025b86347c18"


### PR DESCRIPTION
Systemd 225 does not provide gudev anymore. libgudev has been moved to a separate project. This patchset adds a bb for this new library. Further on networkmanager, modemmanager and libmbin depend now on libgudev instead of udev.