### PR TITLE
switch from Google Code to Github for vim 7.4.481 in fido

### DIFF
--- a/meta-oe/recipes-support/vim/vim_7.4.481.bb
+++ b/meta-oe/recipes-support/vim/vim_7.4.481.bb
@@ -6,13 +6,15 @@ RSUGGESTS_${PN} = "diffutils"
 LICENSE = "vim"
 LIC_FILES_CHKSUM = "file://../runtime/doc/uganda.txt;md5=b779e18be6ed77facc770691c967b8f8"
 
-SRC_URI = "hg://vim.googlecode.com/hg/;protocol=https;module=vim \
+SRC_URI = "git://github.com/vim/vim.git \
            file://disable_acl_header_check.patch;patchdir=.. \
            file://vim-add-knob-whether-elf.h-are-checked.patch;patchdir=.. \
 "
-SRCREV = "v7-4-481"
 
-S = "${WORKDIR}/vim/src"
+# 861d80a671747e6535c83356bcffcf80a72f543b == v7.4.481
+SRCREV = "861d80a671747e6535c83356bcffcf80a72f543b"
+
+S = "${WORKDIR}/git/src"
 
 VIMDIR = "vim${@d.getVar('PV',1).split('.')[0]}${@d.getVar('PV',1).split('.')[1]}"
 


### PR DESCRIPTION
Google Code is being decommissioned.  vim has already moved to Github and they have also changed their tag names to use dots instead of dashes. 

Intermittently for some reason, we are seeing yocto build failures with an inability to fetch the vim source from Google Code.  

I see that the openembedded master branch has already switched to github for the vim recipe.  This change is implementing that same migration, but for the fido branch retaining the same version of vim that was already in use in fido. 