### PR TITLE
Fix nano's license to GPLv3.

### DIFF
--- a/meta-oe/recipes-support/nano/nano.inc
+++ b/meta-oe/recipes-support/nano/nano.inc
@@ -2,7 +2,7 @@ DESCRIPTION = "GNU nano (Nano's ANOther editor, or \
 Not ANOther editor) is an enhanced clone of the \
 Pico text editor."
 HOMEPAGE = "http://www.nano-editor.org/"
-LICENSE = "GPLv2"
+LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=f27defe1e96c2e1ecd4e0c9be8967949"
 SECTION = "console/utils"
 DEPENDS = "ncurses"


### PR DESCRIPTION
Nano recipe has incorrectly stated GPLv2 license where actually it is GPLv3.

Signed-off-by: Vesa Jääskeläinen <dachaac@gmail.com>