### PR TITLE
change URIs on samba.org from http to https

### DIFF
--- a/meta-networking/recipes-connectivity/samba/samba_4.4.5.bb
+++ b/meta-networking/recipes-connectivity/samba/samba_4.4.5.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504 \
                     file://${COREBASE}/meta/files/common-licenses/LGPL-3.0;md5=bfccfe952269fff2b407dd11f2f3083b \
                     file://${COREBASE}/meta/files/common-licenses/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6 "
 
-SAMBA_MIRROR = "http://samba.org/samba/ftp"
+SAMBA_MIRROR = "https://samba.org/samba/ftp"
 MIRRORS += "\
 ${SAMBA_MIRROR}    http://mirror.internode.on.net/pub/samba \n \
 ${SAMBA_MIRROR}    http://www.mirrorservice.org/sites/ftp.samba.org \n \

--- a/meta-networking/recipes-support/libldb/libldb_1.1.29.bb
+++ b/meta-networking/recipes-support/libldb/libldb_1.1.29.bb
@@ -6,7 +6,7 @@ LICENSE = "LGPL-3.0+ & LGPL-2.1+ & GPL-3.0+"
 DEPENDS += "libtdb libtalloc libtevent popt"
 RDEPENDS_pyldb += "python"
 
-SRC_URI = "http://samba.org/ftp/ldb/ldb-${PV}.tar.gz \
+SRC_URI = "https://samba.org/ftp/ldb/ldb-${PV}.tar.gz \
            file://do-not-import-target-module-while-cross-compile.patch \
            file://ldb-Add-configure-options-for-packages.patch \
           "

--- a/meta-networking/recipes-support/libtalloc/libtalloc_2.1.8.bb
+++ b/meta-networking/recipes-support/libtalloc/libtalloc_2.1.8.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://talloc.samba.org"
 SECTION = "libs"
 LICENSE = "LGPL-3.0+ & GPL-3.0+"
 
-SRC_URI = "http://samba.org/ftp/talloc/talloc-${PV}.tar.gz \
+SRC_URI = "https://samba.org/ftp/talloc/talloc-${PV}.tar.gz \
            file://talloc-Add-configure-options-for-packages.patch \
 "
 LIC_FILES_CHKSUM = "file://talloc.h;beginline=3;endline=27;md5=a301712782cad6dd6d5228bfa7825249 \

--- a/meta-networking/recipes-support/libtdb/libtdb_1.3.12.bb
+++ b/meta-networking/recipes-support/libtdb/libtdb_1.3.12.bb
@@ -5,7 +5,7 @@ LICENSE = "LGPL-3.0+ & GPL-3.0+"
 LIC_FILES_CHKSUM = "file://tools/tdbdump.c;endline=18;md5=b59cd45aa8624578126a8c98f48018c4 \
                     file://include/tdb.h;endline=27;md5=f5bb544641d3081821bcc1dd58310be6"
 
-SRC_URI = "http://samba.org/ftp/tdb/tdb-${PV}.tar.gz \
+SRC_URI = "https://samba.org/ftp/tdb/tdb-${PV}.tar.gz \
            file://do-not-check-xsltproc-manpages.patch \
            file://tdb-Add-configure-options-for-packages.patch \
 "

--- a/meta-networking/recipes-support/libtevent/libtevent_0.9.31.bb
+++ b/meta-networking/recipes-support/libtevent/libtevent_0.9.31.bb
@@ -6,7 +6,7 @@ LICENSE = "LGPLv3+"
 DEPENDS += "libtalloc"
 RDEPENDS_python-tevent = "python"
 
-SRC_URI = "http://samba.org/ftp/tevent/tevent-${PV}.tar.gz \
+SRC_URI = "https://samba.org/ftp/tevent/tevent-${PV}.tar.gz \
            file://tevent-Add-configure-options-for-packages.patch \
 "
 LIC_FILES_CHKSUM = "file://tevent.h;endline=26;md5=4e458d658cb25e21efc16f720e78b85a"

--- a/meta-oe/recipes-benchmark/dbench/dbench_4.0.bb
+++ b/meta-oe/recipes-benchmark/dbench/dbench_4.0.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 DEPENDS = "popt"
 
 SRC_URI = "\
-    http://samba.org/ftp/tridge/dbench/dbench-${PV}.tar.gz \
+    https://samba.org/ftp/tridge/dbench/dbench-${PV}.tar.gz \
     file://destdir.patch \
     file://makefile.patch"
 


### PR DESCRIPTION
samba.org does not support http any more, switching to https

bitbake libtalloc -c fetch gives the following errors:
ERROR: libtalloc-2.1.8-r0 do_fetch: Fetcher failure: Fetch command export DBUS_SESSION_BUS_ADDRESS="unix:abstract=/tmp/dbus-Ps6CQSeGl0"; export SSH_AUTH_SOCK="/run/user/1000/keyring/ssh"; export PATH="/home/ydew/git/poky/test/tmp/sysroots-uninative/x86_64-linux/usr/bin:/home/ydew/git/poky/test/tmp/work/i586-poky-linux/libtalloc/2.1.8-r0/recipe-sysroot-native/usr/bin/python-native:/home/ydew/git/poky/scripts:/home/ydew/git/poky/test/tmp/work/i586-poky-linux/libtalloc/2.1.8-r0/recipe-sysroot-native/usr/bin/i586-poky-linux:/home/ydew/git/poky/test/tmp/work/i586-poky-linux/libtalloc/2.1.8-r0/recipe-sysroot/usr/bin/crossscripts:/home/ydew/git/poky/test/tmp/work/i586-poky-linux/libtalloc/2.1.8-r0/recipe-sysroot-native/usr/sbin:/home/ydew/git/poky/test/tmp/work/i586-poky-linux/libtalloc/2.1.8-r0/recipe-sysroot-native/usr/bin:/home/ydew/git/poky/test/tmp/work/i586-poky-linux/libtalloc/2.1.8-r0/recipe-sysroot-native/sbin:/home/ydew/git/poky/test/tmp/work/i586-poky-linux/libtalloc/2.1.8-r0/recipe-sysroot-native/bin:/home/ydew/git/poky/scripts:/home/ydew/git/poky/bitbake/bin:/opt/local/bin:/home/ydew/.nvm/versions/node/v5.9.1/bin:/home/ydew/.rbenv/shims:/home/ydew/.rbenv/bin:/home/ydew/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/ydew/.bash/bin"; export HOME="/home/ydew"; /usr/bin/env wget -t 2 -T 30 -nv --passive-ftp --no-check-certificate -P /home/ydew/git/poky/test/downloads 'http://samba.org/ftp/talloc/talloc-2.1.8.tar.gz' --progress=dot -v failed with exit code 4, output:
--2017-01-27 12:36:35--  http://samba.org/ftp/talloc/talloc-2.1.8.tar.gz
Resolving samba.org (samba.org)... 144.76.82.156, 2a01:4f8:192:486::443:2
Connecting to samba.org (samba.org)|144.76.82.156|:80... failed: Connection refused.
Connecting to samba.org (samba.org)|2a01:4f8:192:486::443:2|:80... failed: Network is unreachable.

ERROR: libtalloc-2.1.8-r0 do_fetch: Fetcher failure for URL: 'http://samba.org/ftp/talloc/talloc-2.1.8.tar.gz'. Unable to fetch URL from any source.
ERROR: libtalloc-2.1.8-r0 do_fetch: Function failed: base_do_fetch
ERROR: Logfile of failure stored in: /home/ydew/git/poky/test/tmp/work/i586-poky-linux/libtalloc/2.1.8-r0/temp/log.do_fetch.10484
ERROR: Task (/home/ydew/git/poky/meta-openembedded/meta-networking/recipes-support/libtalloc/libtalloc_2.1.8.bb:do_fetch) failed with exit code '1'

Signed-off-by: Yves Deweerdt <yves.deweerdt.linux@gmail.com>