### PR TITLE
gtest: add -fPIC

### DIFF
--- a/meta-oe/recipes-test/gtest/gtest_1.8.0.bb
+++ b/meta-oe/recipes-test/gtest/gtest_1.8.0.bb
@@ -19,6 +19,15 @@ S = "${WORKDIR}/googletest-release-${PV}"
 
 inherit cmake
 
+# -fPIC is needed to prevent relocation errors when we compile with Yocto
+# security flags. See this issue for more details:
+#
+# https://github.com/google/googletest/issues/854
+#
+# If that issue is fixed, we can probably remove the manual -fPIC flags here.
+OECMAKE_C_FLAGS += " -fPIC"
+OECMAKE_CXX_FLAGS += " -fPIC"
+
 ALLOW_EMPTY_${PN} = "1"
 ALLOW_EMPTY_${PN}-dbg = "1"
 


### PR DESCRIPTION
I tried turning on the Yocto security flags and hit a compilation
error due to gtest not compiling. Adding -fPIC fixes the issue.

Signed-off-by: Martin Kelly <mkelly@xevo.com>