### PR TITLE
audiofile: Inherit pkgconfig

### DIFF
--- a/meta-oe/recipes-multimedia/audiofile/audiofile_0.3.6.bb
+++ b/meta-oe/recipes-multimedia/audiofile/audiofile_0.3.6.bb
@@ -17,7 +17,7 @@ SRC_URI = " \
 SRC_URI[md5sum] = "235dde14742317328f0109e9866a8008"
 SRC_URI[sha256sum] = "ea2449ad3f201ec590d811db9da6d02ffc5e87a677d06b92ab15363d8cb59782"
 
-inherit autotools lib_package binconfig
+inherit autotools lib_package binconfig pkgconfig
 
 DEPENDS = " \
     asciidoc-native \


### PR DESCRIPTION
Without this the build fails with the following error:

configure: line 16964: PKG_PROG_PKG_CONFIG: command not found
configure: line 16971: syntax error near unexpected token `FLAC,'
configure: line 16971: PKG_CHECK_MODULES(FLAC, flac >= 1.2.1, ac_cv_flac=yes, ac_cv_flac=no)'

Signed-off-by: Piotr Tworek <tworaz@tworaz.net>