### PR TITLE
[meta-oe][morty] risk-free cherry-pick fixes for gitver.bbclass and devmem.bb

### DIFF
--- a/meta-oe/classes/gitver.bbclass
+++ b/meta-oe/classes/gitver.bbclass
@@ -27,13 +27,13 @@ def get_git_pv(path, d, tagadjust=None):
     gitdir = os.path.abspath(os.path.join(d.getVar("S", True), ".git"))
     try:
         ver = gitrev_run("git describe --tags", gitdir)
-    except Exception, exc:
+    except Exception as exc:
         bb.fatal(str(exc))
 
     if not ver:
         try:
             ver = gitrev_run("git rev-parse --short HEAD", gitdir)
-        except Exception, exc:
+        except Exception as exc:
             bb.fatal(str(exc))
 
         if ver:

--- a/meta-oe/recipes-support/devmem2/devmem2.bb
+++ b/meta-oe/recipes-support/devmem2/devmem2.bb
@@ -1,9 +1,9 @@
 SUMMARY = "Simple program to read/write from/to any location in memory"
 LICENSE = "GPLv2+"
-LIC_FILES_CHKSUM = "file://devmem2.c;endline=28;md5=dd68f2b0a5184b3db3dc25c99e0bd0cd"
+LIC_FILES_CHKSUM = "file://devmem2.c;endline=38;md5=a9eb9f3890384519f435aedf986297cf"
 PR = "r7"
 
-SRC_URI = "http://www.lartmaker.nl/lartware/port/devmem2.c \
+SRC_URI = "http://www.free-electrons.com/pub/mirror/devmem2.c \
            file://devmem2-fixups-2.patch;apply=yes;striplevel=0"
 S = "${WORKDIR}"
 
@@ -18,5 +18,5 @@ do_install() {
     install devmem2 ${D}${bindir}
 }
 
-SRC_URI[md5sum] = "be12c0132a1ae118cbf5e79d98427c1d"
-SRC_URI[sha256sum] = "ec382c90af3ef2f49695ff14a4d6521e58ac482c4e29d6c9ebca8768f699c191"
+SRC_URI[md5sum] = "e23f236e94be4c429aa1ceac0f01544b"
+SRC_URI[sha256sum] = "3b15515693bae1ebd14d914e46d388edfec2175829ea1576a7a0c8606ebbe639"

--- a/meta-oe/recipes-support/devmem2/devmem2.bb
+++ b/meta-oe/recipes-support/devmem2/devmem2.bb
@@ -3,11 +3,15 @@ LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://devmem2.c;endline=38;md5=a9eb9f3890384519f435aedf986297cf"
 PR = "r7"
 
-SRC_URI = "http://www.free-electrons.com/pub/mirror/devmem2.c \
+SRC_URI = "http://www.free-electrons.com/pub/mirror/devmem2.c;downloadfilename=devmem2-new.c \
            file://devmem2-fixups-2.patch;apply=yes;striplevel=0"
 S = "${WORKDIR}"
 
 CFLAGS += "-DFORCE_STRICT_ALIGNMENT"
+
+python do_unpack_append() {
+    os.rename("devmem2-new.c", "devmem2.c")
+}
 
 do_compile() {
     ${CC} -o devmem2 devmem2.c ${CFLAGS} ${LDFLAGS}


### PR DESCRIPTION
The following commits have been cherry-picked from master:
```
fc801961457fe2fbb24973bb43b302ad46044cb8 devmem2: Change source URL to regain access to it
6c584374a599f6f8d3607f20ecfc13a67ccf1da1 devmem2: use different filename to avoid checksum conflicts
b17bbbe2245f72144e3d036aa273c1b67434fa1c gitver: fix try/except syntax for python3 support
```
