### PR TITLE
plymouth: add conditional runtime dependency in libdrm

### DIFF
--- a/meta-oe/recipes-core/plymouth/plymouth_0.9.2.bb
+++ b/meta-oe/recipes-core/plymouth/plymouth_0.9.2.bb
@@ -12,7 +12,10 @@ LICENSE = "GPLv2+"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 
+PR = "r1"
+
 DEPENDS = "libcap libpng cairo dbus udev"
+RDEPENDS_${PN} = "${@bb.utils.contains('PACKAGECONFIG', 'drm', 'libdrm', '', d)}"
 PROVIDES = "virtual/psplash"
 RPROVIDES_${PN} = "virtual-psplash virtual-psplash-support"
 


### PR DESCRIPTION
The DRM backend tries to `dlopen` `libdrm2.so` during runtime.

This patch also increases the package release to reflect that only
packaging changed.