### PR TITLE
opencv: fix runtime dependencies.

### DIFF
--- a/meta-oe/recipes-support/opencv/opencv_3.2.bb
+++ b/meta-oe/recipes-support/opencv/opencv_3.2.bb
@@ -126,7 +126,7 @@ python populate_packages_prepend () {
 
     metapkg =  pn
     d.setVar('ALLOW_EMPTY_' + metapkg, "1")
-    blacklist = [ metapkg ]
+    blacklist = [ metapkg, "libopencv-ts" ]
     metapkg_rdepends = [ ]
     for pkg in packages[1:]:
         if not pkg in blacklist and not pkg in metapkg_rdepends and not pkg.endswith('-dev') and not pkg.endswith('-dbg') and not pkg.endswith('-doc') and not pkg.endswith('-locale') and not pkg.endswith('-staticdev'):


### PR DESCRIPTION
The newly split "libopencv-ts" package is empty (and thus not created),
because all ts files are installed in the development package. So, do
not add a runtime dependency to libopencv-ts.

Signed-off-by: Ismo Puustinen <ismo.puustinen@intel.com>
Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>