### PR TITLE
netperf: upgrade to 2.7.0+ with git version

### DIFF
--- a/meta-networking/recipes-support/netperf/netperf_git.bb
+++ b/meta-networking/recipes-support/netperf/netperf_git.bb
@@ -4,20 +4,20 @@ SECTION = "net"
 HOMEPAGE = "http://www.netperf.org/"
 LICENSE = "netperf"
 LICENSE_FLAGS = "non-commercial"
+LIC_FILES_CHKSUM = "file://COPYING;md5=a0ab17253e7a3f318da85382c7d5d5d6"
 
+PV = "2.7.0+git${SRCPV}"
 
-SRC_URI="ftp://ftp.netperf.org/netperf/archive/netperf-${PV}.tar.bz2 \
+SRC_URI="git://github.com/HewlettPackard/netperf.git \
          file://cpu_set.patch \
          file://vfork.patch \
          file://init"
-SRC_URI[md5sum] = "9654ffdfd4c4f2c93ce3733cd9ed9236"
-SRC_URI[sha256sum] = "cd8dac710d4273d29f70e8dbd09353a6362ac58a11926e0822233c0cb230323a"
 
-LIC_FILES_CHKSUM = "file://COPYING;md5=a0ab17253e7a3f318da85382c7d5d5d6"
+SRCREV = "f482bab49fcedee46fc5b755da127f608325cd13"
+
+S = "${WORKDIR}/git"
 
 inherit update-rc.d autotools
-
-S = "${WORKDIR}/netperf-${PV}"
 
 # cpu_set.patch plus _GNU_SOURCE makes src/netlib.c compile with CPU_ macros
 CFLAGS_append = " -DDO_UNIX -DDO_IPV6 -D_GNU_SOURCE"


### PR DESCRIPTION
The homepage of netperf has been moved to github. The original webpage
www.netperf.org is redirected to github and tarballs are removed. So use
git version of recipe instead.

netperf 2.7.0 was released in July 2015 which is too old. So upgrade to
latest commit of git repo which is on Nov 29, 2016.

Signed-off-by: Kai Kang <kai.kang@windriver.com>
Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
Signed-off-by: Joe MacDonald <joe_macdonald@mentor.com>
(cherry picked from commit f8e7e5af3578937f056dddbe104a08bb35c56c64)