### PR TITLE
samba: add dynamic packages regexp for auth and pdb modules

### DIFF
--- a/meta-networking/recipes-connectivity/samba/samba_4.7.6.bb
+++ b/meta-networking/recipes-connectivity/samba/samba_4.7.6.bb
@@ -218,6 +218,7 @@ python samba_populate_packages() {
 }
 
 PACKAGESPLITFUNCS_prepend = "samba_populate_packages "
+PACKAGES_DYNAMIC = "samba-auth-.* samba-pdb-.*"
 
 RDEPENDS_${PN} += "${PN}-base ${PN}-python ${PN}-dsdb-modules"
 RDEPENDS_${PN}-python += "pytalloc python-tdb"


### PR DESCRIPTION
Since those modules are dynamically split into sub-packages, they need
a regexp added to PACKAGES_DYNAMIC in order for the samba recipe to
RPROVIDE those packages. Without that, those packages are only known as
RRECOMMENDS for samba-base, which can be an issue when building an image
with NO_RECOMMENDATIONS = "1".