### PR TITLE
Migrate from alioth of debian to salsa for pyro

### DIFF
--- a/meta-oe/recipes-extended/logcheck/logcheck_1.3.17.bb
+++ b/meta-oe/recipes-extended/logcheck/logcheck_1.3.17.bb
@@ -10,7 +10,7 @@ SECTION = "Applications/System"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c93c0550bd3173f4504b2cbd8991e50b"
 
-SRC_URI = "git://git.debian.org/git/logcheck/logcheck.git"
+SRC_URI = "git://salsa.debian.org/derobert-guest/logcheck.git;protocol=https"
 SRCREV = "2429e67ad875fee8a0234c64d504277b038c89cd"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/ccid/ccid_1.4.24.bb
+++ b/meta-oe/recipes-support/ccid/ccid_1.4.24.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=2d5025d4aa3495befef8f17206a5b0a1"
 DEPENDS = "virtual/libusb0 pcsc-lite"
 RDEPENDS_${PN} = "pcsc-lite"
 
-SRC_URI = "https://alioth.debian.org/frs/download.php/file/4171/ccid-${PV}.tar.bz2 \
+SRC_URI = "https://alioth-archive.debian.org/releases/pcsclite/ccid/${PV}/ccid-${PV}.tar.bz2 \
     file://no-dep-on-libfl.patch \
 "
 

--- a/meta-oe/recipes-support/pcsc-lite/pcsc-lite_1.8.13.bb
+++ b/meta-oe/recipes-support/pcsc-lite/pcsc-lite_1.8.13.bb
@@ -11,9 +11,9 @@ LICENSE_${PN}-spy-dev = "GPLv3+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bcfbd85230ac3c586fb294c8b627cf32"
 DEPENDS = "udev"
 
-SRC_URI = "https://alioth.debian.org/frs/download.php/file/4126/pcsc-lite-${PV}.tar.bz2"
-SRC_URI[md5sum] = "4dcd22d20a6df8810fac5480cc320b6d"
-SRC_URI[sha256sum] = "f315047e808d63a3262c4a040f77548af2e04d1fd707e0c2759369b926fbbc3b"
+SRC_URI = "https://salsa.debian.org/rousseau/PCSC/-/archive/pcsc-${PV}/PCSC-pcsc-${PV}.tar.bz2"
+SRC_URI[md5sum] = "6a4d3b0a74aa67f24dc5a9e10e6deb9f"
+SRC_URI[sha256sum] = "a0fb25747f6ad5448255da0578bb12236facc43acb8e0b5e378e20a731df37db"
 
 
 inherit autotools systemd pkgconfig


### PR DESCRIPTION
According to http://anonscm.debian.org/
> The alioth.debian.org service is discontinued. Its replacement is a GitLab instance at salsa.debian.org.