### PR TITLE
Fix python-idna egg-info permissions

### DIFF
--- a/meta-python/recipes-devtools/python/python-idna.inc
+++ b/meta-python/recipes-devtools/python/python-idna.inc
@@ -11,3 +11,7 @@ RDEPENDS_${PN}_class-target = "\
 "
 
 BBCLASSEXTEND = "native nativesdk"
+
+do_install_append() {
+    chmod 664 -R ${D}${PYTHON_SITEPACKAGES_DIR}/*.egg-info/
+}


### PR DESCRIPTION
When installing python3-idna I got faced with the problem that the files in the `${PYTHON_SITEPACKAGES_DIR}/idna*.egg-info/` directory had the permissions set to 600 instead of 644.
This fix will set the permissions of the files in `${PYTHON_SITEPACKAGES_DIR}/*.egg-info/*` to 664 during the installation of the package.

I searched for a way to automatically fix the permissions for every python modules (like pip does) but since I'm not totally used to Yocto yet I didn't found a better solution.