### PR TITLE
Update the regex for PGMAJORVERSION to match v10+ clusters

### DIFF
--- a/meta-oe/recipes-dbs/postgresql/files/postgresql.init
+++ b/meta-oe/recipes-dbs/postgresql/files/postgresql.init
@@ -14,8 +14,8 @@
 # PGVERSION is the full package version, e.g., 8.4.0
 # Note: the specfile inserts the correct value during package build
 PGVERSION=9.2.4
-# PGMAJORVERSION is major version, e.g., 8.4 (this should match PG_VERSION)
-PGMAJORVERSION=`echo "$PGVERSION" | sed 's/^\([0-9]*\.[0-9]*\).*$/\1/'`
+# PGMAJORVERSION is major version, e.g., 10 (this should match PG_VERSION)
+PGMAJORVERSION=`echo "$PGVERSION" | sed 's/^\([0-9]*\).*$/\1/'`
 
 # Source function library.
 . /etc/init.d/functions


### PR DESCRIPTION
Older versions of postgresql would generate MAJVER.MINVER in new clusters. 10+ do not. Simplify the regex to match PGMAJORVERSION from a single int.