### PR TITLE
add spdlog recipe

### DIFF
--- a/meta-oe/recipes-support/spdlog/spdlog_1.3.1.bb
+++ b/meta-oe/recipes-support/spdlog/spdlog_1.3.1.bb
@@ -1,0 +1,19 @@
+DESCRIPTION = "Very fast, header only, C++ logging library."
+HOMEPAGE = "https://github.com/gabime/spdlog/wiki"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+PR="r0"
+SRC_URI = "git://github.com/gabime/spdlog.git;protocol=git;branch=v1.x;tag=v${PV}"
+
+S = "${WORKDIR}/git"
+
+BBCLASSEXTEND = "native"
+# no need to build example&text&benchmarks on pure yocto
+EXTRA_OECMAKE += "-DSPDLOG_INSTALL=on -DSPDLOG_BUILD_EXAMPLES=off -DSPDLOG_BUILD_TESTS=off -DSPDLOG_BUILD_BENCH=off"
+
+inherit cmake
+
+# Header-only library
+RDEPENDS_${PN}-dev = ""
+RRECOMMENDS_${PN}-dbg = "${PN}-dev (= ${EXTENDPKGV})"


### PR DESCRIPTION
* Now, spdlog library is enable under recipes-support. Just install with "spdlog-dev".
* It's also tested with populate-sdk.