### PR TITLE
recipes-support/libutempter: Fix the macro string concatenation.

### DIFF
--- a/meta-networking/recipes-connectivity/blueman/blueman/0001-Fix-building-on-musl.patch
+++ b/meta-networking/recipes-connectivity/blueman/blueman/0001-Fix-building-on-musl.patch
@@ -1,0 +1,56 @@
+From ff03542e1ff24646ef16754157a6eb6437172153 Mon Sep 17 00:00:00 2001
+From: Kylie McClain <somasis@exherbo.org>
+Date: Sun, 13 Dec 2015 21:32:05 -0500
+Subject: [PATCH] Fix building on musl libc
+
+The addition of sys/time.h to libblueman.c is needed for `tv`'s usage,
+which is defined by musl's time.h.
+
+In addition, XCASE must be defined since it is normally provided by
+glibc's termios.h.
+---
+ blueman/main/PPPConnection.py | 2 +-
+ module/libblueman.c           | 1 +
+ module/modem-prober.c         | 4 ++++
+ 3 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/blueman/main/PPPConnection.py b/blueman/main/PPPConnection.py
+index 0aab1d98..1a3a9925 100644
+--- a/blueman/main/PPPConnection.py
++++ b/blueman/main/PPPConnection.py
+@@ -131,7 +131,7 @@ def Connect(self):
+         attrs[0] &= ~(termios.IGNCR | termios.ICRNL | termios.IUCLC | termios.INPCK | termios.IXON | termios.IXANY |
+                       termios.IGNPAR)
+         attrs[1] &= ~(termios.OPOST | termios.OLCUC | termios.OCRNL | termios.ONLCR | termios.ONLRET)
+-        attrs[3] &= ~(termios.ICANON | termios.XCASE | termios.ECHO | termios.ECHOE | termios.ECHONL)
++        attrs[3] &= ~(termios.ICANON | getattr(termios, 'XCASE', 4) | termios.ECHO | termios.ECHOE | termios.ECHONL)
+         attrs[3] &= ~(termios.ECHO | termios.ECHOE)
+         attrs[6][termios.VMIN] = 1
+         attrs[6][termios.VTIME] = 0
+diff --git a/module/libblueman.c b/module/libblueman.c
+index 7f1626bc..a86fad59 100644
+--- a/module/libblueman.c
++++ b/module/libblueman.c
+@@ -28,6 +28,7 @@
+ #include <string.h>
+ #include <sys/ioctl.h>
+ #include <sys/socket.h>
++#include <sys/time.h>
+ #include <unistd.h>
+ #include <linux/sockios.h>
+ #include <linux/if.h>
+diff --git a/module/modem-prober.c b/module/modem-prober.c
+index daffaa4e..972ec146 100644
+--- a/module/modem-prober.c
++++ b/module/modem-prober.c
+@@ -34,6 +34,10 @@
+ 
+ #include "modem-prober.h"
+ 
++#ifndef XCASE
++#define XCASE 0000004
++#endif
++
+ #if PY_MAJOR_VERSION >= 3
+ #define PyString_FromString PyUnicode_FromString
+ #endif

--- a/meta-networking/recipes-connectivity/blueman/blueman_2.0.8.bb
+++ b/meta-networking/recipes-connectivity/blueman/blueman_2.0.8.bb
@@ -7,12 +7,12 @@ DEPENDS = "bluez5 python3-pygobject python3-cython-native python3-setuptools-nat
 inherit autotools systemd gsettings python3native gtk-icon-cache
 
 SRC_URI = " \
-    git://github.com/blueman-project/blueman.git \
+    https://github.com/blueman-project/blueman/releases/download/${PV}/blueman-${PV}.tar.xz \
     file://0001-Search-for-cython3.patch \
+    file://0001-Fix-building-on-musl.patch \
 "
-SRCREV = "c4a03417e81e21543d4568e8e7f7de307582eb50"
-PV = "2.0.5+git${SRCPV}"
-S = "${WORKDIR}/git"
+SRC_URI[md5sum] = "51dc07d48125ee9600e7f6168d6e67f6"
+SRC_URI[sha256sum] = "04afd07b4c900a401f39e711dedbf8b9cf12000ddeda0d8ef3c3327caf34704e"
 
 EXTRA_OECONF = " \
     --disable-runtime-deps-check \

--- a/meta-oe/recipes-support/libutempter/libutempter.bb
+++ b/meta-oe/recipes-support/libutempter/libutempter.bb
@@ -12,6 +12,7 @@ PV = "1.1.6-alt2+git${SRCPV}"
 
 SRC_URI = "git://git.altlinux.org/people/ldv/packages/libutempter.git \
            file://0001-Fix-macro-error.patch \
+           file://0002-Proper-macro-path-generation.patch \
            file://libutempter-remove-glibc-assumption.patch \
           "
 

--- a/meta-oe/recipes-support/libutempter/libutempter/0002-Proper-macro-path-generation.patch
+++ b/meta-oe/recipes-support/libutempter/libutempter/0002-Proper-macro-path-generation.patch
@@ -1,0 +1,34 @@
+From 48b6bcf9f5d8a05eace4bc463c47e8a4715d3000 Mon Sep 17 00:00:00 2001
+From: iddinev <xidinev@gmail.com>
+Date: Mon, 18 Mar 2019 15:45:20 +0200
+Subject: [PATCH] Proper macro path generation.
+
+Signed-off-by: iddinev <xidinev@gmail.com>
+---
+ libutempter/iface.c | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git libutempter/iface.c libutempter/iface.c
+index 27793f0..c1c0ee9 100644
+--- libutempter/iface.c
++++ libutempter/iface.c
+@@ -44,13 +44,12 @@
+ #endif
+ 
+ #ifdef  LIBEXECDIR
+-#  define CAT_PATH(DIR1,DIR2)           DIR1##DIR2
+-#  define RAW_UTEMPTER_PATH             CAT_PATH(LIBEXECDIR,/utempter/utempter)
++#  define UTEMPTER_DEFAULT_PATHNAME     XSTR_PATH(LIBEXECDIR)"/utempter/utempter"
+ #else
+-#  define RAW_UTEMPTER_PATH             /usr/lib/libtempter/utempter/utempter
++#  define UTEMPTER_DEFAULT_PATHNAME     STR_PATH(/usr/lib/libtempter/utempter/utempter)
+ #endif
+ #define STR_PATH(RAW_STR)               #RAW_STR
+-#define UTEMPTER_DEFAULT_PATHNAME       STR_PATH(RAW_UTEMPTER_PATH)
++#define XSTR_PATH(STR)                  STR_PATH(STR)
+ 
+ static const char *utempter_pathname;
+ static int saved_fd = -1;
+-- 
+2.7.4
+

--- a/meta-python/recipes-devtools/gyp/gyp_git.bb
+++ b/meta-python/recipes-devtools/gyp/gyp_git.bb
@@ -1,0 +1,15 @@
+DESCRIPTION = "GYP is a Meta-Build system: a build system that generates other build systems."
+HOMEPAGE = "https://gyp.gsrc.io/"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ab828cb8ce4c62ee82945a11247b6bbd"
+SECTION = "devel"
+
+SRC_URI = "git://chromium.googlesource.com/external/gyp;protocol=https"
+SRCREV = "8bee09f4a57807136593ddc906b0b213c21f9014"
+
+S = "${WORKDIR}/git"
+PV = "0.1+git${SRCPV}"
+
+inherit setuptools3
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-python/recipes-devtools/python/python-kconfiglib-10.42.0.inc
+++ b/meta-python/recipes-devtools/python/python-kconfiglib-10.42.0.inc
@@ -1,0 +1,8 @@
+DESCRIPTION = "Kconfiglib is a Kconfig implementation in Python"
+LICENSE = "ISC"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=712177a72a3937909543eda3ad1bfb7c"
+
+SRC_URI[md5sum] = "2306279a050c6a888f34a5719047f217"
+SRC_URI[sha256sum] = "0070eb9061f924e1fa7bc2b1f0aeea1d38e1ddf9bbdbd4b5c346bcf1a0848674"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-python/recipes-devtools/python/python3-kconfiglib_10.42.0.bb
+++ b/meta-python/recipes-devtools/python/python3-kconfiglib_10.42.0.bb
@@ -1,0 +1,2 @@
+require python-kconfiglib-${PV}.inc
+inherit pypi setuptools3

--- a/meta-python/recipes-devtools/python/python3-pylyrics_1.1.0.bb
+++ b/meta-python/recipes-devtools/python/python3-pylyrics_1.1.0.bb
@@ -1,0 +1,12 @@
+SUMMARY = "Pythonic Implementation of lyrics.wikia.com"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://setup.py;beginline=14;endline=14;md5=95d480cd6f8471abaeae21bd0ed277ba"
+
+SRC_URI[md5sum] = "1f3c997edeba149a8fb2b861cbad89c3"
+SRC_URI[sha256sum] = "c5f36e8ef0ed3b487a9242ce34c19f9684e418a5bbffd5d367dc1d1604b4cd0b"
+
+PYPI_PACKAGE = "PyLyrics"
+PYPI_PACKAGE_EXT = "zip"
+
+inherit pypi setuptools3


### PR DESCRIPTION
The previous openembedded patch [0001-Fix-macro-error.patch](https://github.com/openembedded/meta-openembedded/blob/da4dab68d601b9bd2903f761f043f0d438033bd5/meta-oe/recipes-support/libutempter/libutempter/0001-Fix-macro-error.patch) fixes the compile time macro expansion error but introduces another one in the form of erroneous 'MACRO1##MACRO2' concatenation. This patch fixes that error.
Edit: Had to rebase my branch so I recreated the pull request.