### PR TITLE
bdwgc: upgrade 7.6.12 -> 8.0.4

### DIFF
--- a/meta-oe/recipes-support/bdwgc/bdwgc_8.0.4.bb
+++ b/meta-oe/recipes-support/bdwgc/bdwgc_8.0.4.bb
@@ -19,10 +19,10 @@ DESCRIPTION = "The Boehm-Demers-Weiser conservative garbage collector can be\
 HOMEPAGE = "http://www.hboehm.info/gc/"
 SECTION = "devel"
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://README.QUICK;md5=728501f233050290314d33fb07d883eb"
+LIC_FILES_CHKSUM = "file://README.QUICK;md5=81b447d779e278628c843aef92f088fa"
 
-SRCREV = "a46546f40d18e60c31077c2e7c8bb4e44bf1bef1"
-SRC_URI = "git://github.com/ivmai/bdwgc.git;branch=release-7_6 \
+SRCREV = "d3dede3ce4462cd82a15f161af797ca51654546a"
+SRC_URI = "git://github.com/ivmai/bdwgc.git;branch=release-8_0 \
           "
 
 FILES_${PN}-doc = "${datadir}"


### PR DESCRIPTION
Highlights of this upgrade:
* Add initial RISC-V support
* Enable handle-fork and memory unmapping by default
* New API to turn on manual VDB at runtime
* Turn on parallel marker by default for all multi-threaded builds
* Use thread-local allocations for all multi-threaded builds

See the following for detailed changes:
* https://github.com/ivmai/bdwgc/releases/tag/v8.0.0
* https://github.com/ivmai/bdwgc/releases/tag/v8.0.2
* https://github.com/ivmai/bdwgc/releases/tag/v8.0.4

Signed-off-by: Ivan Maidanski <ivmai@mail.ru>