### PR TITLE
dhcpcd: Install to /sbin instead of /usr/sbin

### DIFF
--- a/meta-networking/recipes-connectivity/dhcpcd/dhcpcd_7.0.8.bb
+++ b/meta-networking/recipes-connectivity/dhcpcd/dhcpcd_7.0.8.bb
@@ -21,6 +21,9 @@ PACKAGECONFIG ?= "udev ${@bb.utils.filter('DISTRO_FEATURES', 'ipv6', d)}"
 PACKAGECONFIG[udev] = "--with-udev,--without-udev,udev,udev"
 PACKAGECONFIG[ipv6] = "--enable-ipv6,--disable-ipv6"
 
-EXTRA_OECONF = "--enable-ipv4"
+EXTRA_OECONF = " \
+	--enable-ipv4 \
+	--sbindir=${base_sbindir} \
+"
 
 FILES_${PN}-dbg += "${libdir}/dhcpcd/dev/.debug"


### PR DESCRIPTION
ifupdown expects dhcpcd to be in /sbin, so we install it in /sbin
instead of /usr/sbin.

Signed-off-by: Oliver Stäbler <oliver.staebler@bytesatwork.ch>