### PR TITLE
gitver: Pass git directory argument to gitrev_run

### DIFF
--- a/meta-oe/classes/gitver.bbclass
+++ b/meta-oe/classes/gitver.bbclass
@@ -48,7 +48,7 @@ def get_git_hash(d):
     srcdir = d.getVar("EXTERNALSRC") or d.getVar("S")
     gitdir = os.path.abspath(os.path.join(srcdir, ".git"))
     try:
-        rev = gitrev_run("git rev-list HEAD -1")
+        rev = gitrev_run("git rev-list HEAD -1", gitdir)
         return rev[:7]
     except Exception as exc:
         bb.fatal(str(exc))


### PR DESCRIPTION
${GITSHA} gives the following error otherwise
gitrev_run() missing 1 required positional argument: 'path'

Signed-off-by: Saikiran Madugula <hummerbliss@gmail.com>