### PR TITLE
[meta-oe] Introduce recipe for sdbus-c++ library and its tools

### DIFF
--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-0.7.6/run-ptest
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-0.7.6/run-ptest
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+set -o pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+${SCRIPTPATH}/../tests/sdbus-c++-unit-tests 2>&1 | \
+sed -r 's/^\[\s+OK\s+\] (.*) \([0-9]+\sms\)$/OK: \1 /' | \
+sed -r 's/^\[\s+FAILED\s+\] (.*) \([0-9]+\sms\)$/FAILED: \1 /' | \
+awk '{if ($1 == "OK:" || $1 == "FAILED:") {print $0}}'
+
+${SCRIPTPATH}/../tests/sdbus-c++-integration-tests 2>&1 | \
+sed -r 's/^\[\s+OK\s+\] (.*) \([0-9]+\sms\)$/OK: \1 /' | \
+sed -r 's/^\[\s+FAILED\s+\] (.*) \([0-9]+\sms\)$/FAILED: \1 /' | \
+awk '{if ($1 == "OK:" || $1 == "FAILED:") {print $0}}' 

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0001-do-not-disable-buffer-in-writing-files.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0001-do-not-disable-buffer-in-writing-files.patch
@@ -1,0 +1,413 @@
+From 85e3c3046562ec24fc2f09ebfd08bf9f168091d5 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Fri, 1 Mar 2019 15:22:15 +0800
+Subject: [PATCH] do not disable buffer in writing files
+
+Do not disable buffer in writing files, otherwise we get
+failure at boot for musl like below.
+
+  [!!!!!!] Failed to allocate manager object.
+
+And there will be other failures, critical or not critical.
+This is specific to musl.
+
+Upstream-Status: Inappropriate [musl]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[Rebased for v242]
+Signed-off-by: Andrej Valek <andrej.valek@siemens.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ src/basic/cgroup-util.c                 | 14 +++++++-------
+ src/basic/procfs-util.c                 |  4 ++--
+ src/basic/smack-util.c                  |  2 +-
+ src/basic/util.c                        |  2 +-
+ src/binfmt/binfmt.c                     |  6 +++---
+ src/core/main.c                         |  4 ++--
+ src/core/smack-setup.c                  |  8 ++++----
+ src/hibernate-resume/hibernate-resume.c |  2 +-
+ src/libsystemd/sd-device/sd-device.c    |  2 +-
+ src/login/logind-dbus.c                 |  2 +-
+ src/nspawn/nspawn-cgroup.c              |  2 +-
+ src/nspawn/nspawn.c                     |  6 +++---
+ src/shared/sysctl-util.c                |  2 +-
+ src/sleep/sleep.c                       | 10 +++++-----
+ src/udev/udevadm-trigger.c              |  2 +-
+ src/udev/udevd.c                        |  2 +-
+ src/vconsole/vconsole-setup.c           |  2 +-
+ 17 files changed, 36 insertions(+), 36 deletions(-)
+
+diff --git a/src/basic/cgroup-util.c b/src/basic/cgroup-util.c
+index 7b5839ccd6..18f6e8ffc8 100644
+--- a/src/basic/cgroup-util.c
++++ b/src/basic/cgroup-util.c
+@@ -860,7 +860,7 @@ int cg_attach(const char *controller, const char *path, pid_t pid) {
+ 
+         xsprintf(c, PID_FMT "\n", pid);
+ 
+-        r = write_string_file(fs, c, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(fs, c, 0);
+         if (r < 0)
+                 return r;
+ 
+@@ -1142,7 +1142,7 @@ int cg_install_release_agent(const char *controller, const char *agent) {
+ 
+         sc = strstrip(contents);
+         if (isempty(sc)) {
+-                r = write_string_file(fs, agent, WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file(fs, agent, 0);
+                 if (r < 0)
+                         return r;
+         } else if (!path_equal(sc, agent))
+@@ -1160,7 +1160,7 @@ int cg_install_release_agent(const char *controller, const char *agent) {
+ 
+         sc = strstrip(contents);
+         if (streq(sc, "0")) {
+-                r = write_string_file(fs, "1", WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file(fs, "1", 0);
+                 if (r < 0)
+                         return r;
+ 
+@@ -1187,7 +1187,7 @@ int cg_uninstall_release_agent(const char *controller) {
+         if (r < 0)
+                 return r;
+ 
+-        r = write_string_file(fs, "0", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(fs, "0", 0);
+         if (r < 0)
+                 return r;
+ 
+@@ -1197,7 +1197,7 @@ int cg_uninstall_release_agent(const char *controller) {
+         if (r < 0)
+                 return r;
+ 
+-        r = write_string_file(fs, "", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(fs, "", 0);
+         if (r < 0)
+                 return r;
+ 
+@@ -2053,7 +2053,7 @@ int cg_set_attribute(const char *controller, const char *path, const char *attri
+         if (r < 0)
+                 return r;
+ 
+-        return write_string_file(p, value, WRITE_STRING_FILE_DISABLE_BUFFER);
++        return write_string_file(p, value, 0);
+ }
+ 
+ int cg_get_attribute(const char *controller, const char *path, const char *attribute, char **ret) {
+@@ -2697,7 +2697,7 @@ int cg_enable_everywhere(
+                                         return log_debug_errno(errno, "Failed to open cgroup.subtree_control file of %s: %m", p);
+                         }
+ 
+-                        r = write_string_stream(f, s, WRITE_STRING_FILE_DISABLE_BUFFER);
++                        r = write_string_stream(f, s, 0);
+                         if (r < 0) {
+                                 log_debug_errno(r, "Failed to %s controller %s for %s (%s): %m",
+                                                 FLAGS_SET(mask, bit) ? "enable" : "disable", n, p, fs);
+diff --git a/src/basic/procfs-util.c b/src/basic/procfs-util.c
+index 42ce53d5aa..57512532a6 100644
+--- a/src/basic/procfs-util.c
++++ b/src/basic/procfs-util.c
+@@ -86,13 +86,13 @@ int procfs_tasks_set_limit(uint64_t limit) {
+          * decrease it, as threads-max is the much more relevant sysctl. */
+         if (limit > pid_max-1) {
+                 sprintf(buffer, "%" PRIu64, limit+1); /* Add one, since PID 0 is not a valid PID */
+-                r = write_string_file("/proc/sys/kernel/pid_max", buffer, WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file("/proc/sys/kernel/pid_max", buffer, 0);
+                 if (r < 0)
+                         return r;
+         }
+ 
+         sprintf(buffer, "%" PRIu64, limit);
+-        r = write_string_file("/proc/sys/kernel/threads-max", buffer, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/kernel/threads-max", buffer, 0);
+         if (r < 0) {
+                 uint64_t threads_max;
+ 
+diff --git a/src/basic/smack-util.c b/src/basic/smack-util.c
+index 123d00e13e..e7ea78f349 100644
+--- a/src/basic/smack-util.c
++++ b/src/basic/smack-util.c
+@@ -115,7 +115,7 @@ int mac_smack_apply_pid(pid_t pid, const char *label) {
+                 return 0;
+ 
+         p = procfs_file_alloca(pid, "attr/current");
+-        r = write_string_file(p, label, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(p, label, 0);
+         if (r < 0)
+                 return r;
+ 
+diff --git a/src/basic/util.c b/src/basic/util.c
+index 93d610bc98..97dca64f73 100644
+--- a/src/basic/util.c
++++ b/src/basic/util.c
+@@ -294,7 +294,7 @@ void disable_coredumps(void) {
+         if (detect_container() > 0)
+                 return;
+ 
+-        r = write_string_file("/proc/sys/kernel/core_pattern", "|/bin/false", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/kernel/core_pattern", "|/bin/false", 0);
+         if (r < 0)
+                 log_debug_errno(r, "Failed to turn off coredumps, ignoring: %m");
+ }
+diff --git a/src/binfmt/binfmt.c b/src/binfmt/binfmt.c
+index aa9d811f2e..8c7f2dae7a 100644
+--- a/src/binfmt/binfmt.c
++++ b/src/binfmt/binfmt.c
+@@ -48,7 +48,7 @@ static int delete_rule(const char *rule) {
+         if (!fn)
+                 return log_oom();
+ 
+-        return write_string_file(fn, "-1", WRITE_STRING_FILE_DISABLE_BUFFER);
++        return write_string_file(fn, "-1", 0);
+ }
+ 
+ static int apply_rule(const char *rule) {
+@@ -56,7 +56,7 @@ static int apply_rule(const char *rule) {
+ 
+         (void) delete_rule(rule);
+ 
+-        r = write_string_file("/proc/sys/fs/binfmt_misc/register", rule, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/fs/binfmt_misc/register", rule, 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to add binary format: %m");
+ 
+@@ -213,7 +213,7 @@ static int run(int argc, char *argv[]) {
+                 }
+ 
+                 /* Flush out all rules */
+-                (void) write_string_file("/proc/sys/fs/binfmt_misc/status", "-1", WRITE_STRING_FILE_DISABLE_BUFFER);
++                (void) write_string_file("/proc/sys/fs/binfmt_misc/status", "-1", 0);
+ 
+                 STRV_FOREACH(f, files) {
+                         k = apply_file(*f, true);
+diff --git a/src/core/main.c b/src/core/main.c
+index bcce7178a8..4199cedab9 100644
+--- a/src/core/main.c
++++ b/src/core/main.c
+@@ -1285,7 +1285,7 @@ static int bump_unix_max_dgram_qlen(void) {
+         if (v >= DEFAULT_UNIX_MAX_DGRAM_QLEN)
+                 return 0;
+ 
+-        r = write_string_filef("/proc/sys/net/unix/max_dgram_qlen", WRITE_STRING_FILE_DISABLE_BUFFER, "%lu", DEFAULT_UNIX_MAX_DGRAM_QLEN);
++        r = write_string_filef("/proc/sys/net/unix/max_dgram_qlen", 0, "%lu", DEFAULT_UNIX_MAX_DGRAM_QLEN);
+         if (r < 0)
+                 return log_full_errno(IN_SET(r, -EROFS, -EPERM, -EACCES) ? LOG_DEBUG : LOG_WARNING, r,
+                                       "Failed to bump AF_UNIX datagram queue length, ignoring: %m");
+@@ -1509,7 +1509,7 @@ static void initialize_core_pattern(bool skip_setup) {
+         if (getpid_cached() != 1)
+                 return;
+ 
+-        r = write_string_file("/proc/sys/kernel/core_pattern", arg_early_core_pattern, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/kernel/core_pattern", arg_early_core_pattern, 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to write '%s' to /proc/sys/kernel/core_pattern, ignoring: %m", arg_early_core_pattern);
+ }
+diff --git a/src/core/smack-setup.c b/src/core/smack-setup.c
+index b95e6239d4..fdbdaaaccb 100644
+--- a/src/core/smack-setup.c
++++ b/src/core/smack-setup.c
+@@ -325,17 +325,17 @@ int mac_smack_setup(bool *loaded_policy) {
+         }
+ 
+ #ifdef SMACK_RUN_LABEL
+-        r = write_string_file("/proc/self/attr/current", SMACK_RUN_LABEL, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/self/attr/current", SMACK_RUN_LABEL, 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to set SMACK label \"" SMACK_RUN_LABEL "\" on self: %m");
+-        r = write_string_file("/sys/fs/smackfs/ambient", SMACK_RUN_LABEL, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/fs/smackfs/ambient", SMACK_RUN_LABEL, 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to set SMACK ambient label \"" SMACK_RUN_LABEL "\": %m");
+         r = write_string_file("/sys/fs/smackfs/netlabel",
+-                              "0.0.0.0/0 " SMACK_RUN_LABEL, WRITE_STRING_FILE_DISABLE_BUFFER);
++                              "0.0.0.0/0 " SMACK_RUN_LABEL, 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to set SMACK netlabel rule \"0.0.0.0/0 " SMACK_RUN_LABEL "\": %m");
+-        r = write_string_file("/sys/fs/smackfs/netlabel", "127.0.0.1 -CIPSO", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/fs/smackfs/netlabel", "127.0.0.1 -CIPSO", 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to set SMACK netlabel rule \"127.0.0.1 -CIPSO\": %m");
+ #endif
+diff --git a/src/hibernate-resume/hibernate-resume.c b/src/hibernate-resume/hibernate-resume.c
+index 17e7cd1a00..87a7667716 100644
+--- a/src/hibernate-resume/hibernate-resume.c
++++ b/src/hibernate-resume/hibernate-resume.c
+@@ -45,7 +45,7 @@ int main(int argc, char *argv[]) {
+                 return EXIT_FAILURE;
+         }
+ 
+-        r = write_string_file("/sys/power/resume", major_minor, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/power/resume", major_minor, 0);
+         if (r < 0) {
+                 log_error_errno(r, "Failed to write '%s' to /sys/power/resume: %m", major_minor);
+                 return EXIT_FAILURE;
+diff --git a/src/libsystemd/sd-device/sd-device.c b/src/libsystemd/sd-device/sd-device.c
+index c4a7f2f3d3..bcac758284 100644
+--- a/src/libsystemd/sd-device/sd-device.c
++++ b/src/libsystemd/sd-device/sd-device.c
+@@ -1849,7 +1849,7 @@ _public_ int sd_device_set_sysattr_value(sd_device *device, const char *sysattr,
+         if (!value)
+                 return -ENOMEM;
+ 
+-        r = write_string_file(path, value, WRITE_STRING_FILE_DISABLE_BUFFER | WRITE_STRING_FILE_NOFOLLOW);
++        r = write_string_file(path, value, 0 | WRITE_STRING_FILE_NOFOLLOW);
+         if (r < 0) {
+                 if (r == -ELOOP)
+                         return -EINVAL;
+diff --git a/src/login/logind-dbus.c b/src/login/logind-dbus.c
+index 30b9a66334..cc1d577933 100644
+--- a/src/login/logind-dbus.c
++++ b/src/login/logind-dbus.c
+@@ -1325,7 +1325,7 @@ static int trigger_device(Manager *m, sd_device *d) {
+                 if (!t)
+                         return -ENOMEM;
+ 
+-                (void) write_string_file(t, "change", WRITE_STRING_FILE_DISABLE_BUFFER);
++                (void) write_string_file(t, "change", 0);
+         }
+ 
+         return 0;
+diff --git a/src/nspawn/nspawn-cgroup.c b/src/nspawn/nspawn-cgroup.c
+index 0462b46413..7c53d41483 100644
+--- a/src/nspawn/nspawn-cgroup.c
++++ b/src/nspawn/nspawn-cgroup.c
+@@ -123,7 +123,7 @@ int sync_cgroup(pid_t pid, CGroupUnified unified_requested, uid_t uid_shift) {
+         fn = strjoina(tree, cgroup, "/cgroup.procs");
+ 
+         sprintf(pid_string, PID_FMT, pid);
+-        r = write_string_file(fn, pid_string, WRITE_STRING_FILE_DISABLE_BUFFER|WRITE_STRING_FILE_MKDIR_0755);
++        r = write_string_file(fn, pid_string, WRITE_STRING_FILE_MKDIR_0755);
+         if (r < 0) {
+                 log_error_errno(r, "Failed to move process: %m");
+                 goto finish;
+diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
+index 2aec8041f0..841542f2f3 100644
+--- a/src/nspawn/nspawn.c
++++ b/src/nspawn/nspawn.c
+@@ -2357,7 +2357,7 @@ static int reset_audit_loginuid(void) {
+         if (streq(p, "4294967295"))
+                 return 0;
+ 
+-        r = write_string_file("/proc/self/loginuid", "4294967295", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/self/loginuid", "4294967295", 0);
+         if (r < 0) {
+                 log_error_errno(r,
+                                 "Failed to reset audit login UID. This probably means that your kernel is too\n"
+@@ -3566,13 +3566,13 @@ static int setup_uid_map(pid_t pid) {
+ 
+         xsprintf(uid_map, "/proc/" PID_FMT "/uid_map", pid);
+         xsprintf(line, UID_FMT " " UID_FMT " " UID_FMT "\n", 0, arg_uid_shift, arg_uid_range);
+-        r = write_string_file(uid_map, line, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(uid_map, line, 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to write UID map: %m");
+ 
+         /* We always assign the same UID and GID ranges */
+         xsprintf(uid_map, "/proc/" PID_FMT "/gid_map", pid);
+-        r = write_string_file(uid_map, line, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(uid_map, line, 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to write GID map: %m");
+ 
+diff --git a/src/shared/sysctl-util.c b/src/shared/sysctl-util.c
+index 93bdcf11bf..68cddb7a9f 100644
+--- a/src/shared/sysctl-util.c
++++ b/src/shared/sysctl-util.c
+@@ -88,7 +88,7 @@ int sysctl_write_ip_property(int af, const char *ifname, const char *property, c
+ 
+         log_debug("Setting '%s' to '%s'", p, value);
+ 
+-        return write_string_file(p, value, WRITE_STRING_FILE_VERIFY_ON_FAILURE | WRITE_STRING_FILE_DISABLE_BUFFER);
++        return write_string_file(p, value, WRITE_STRING_FILE_VERIFY_ON_FAILURE | 0);
+ }
+ 
+ int sysctl_read(const char *property, char **content) {
+diff --git a/src/sleep/sleep.c b/src/sleep/sleep.c
+index b9fe96635d..f168d7f890 100644
+--- a/src/sleep/sleep.c
++++ b/src/sleep/sleep.c
+@@ -54,7 +54,7 @@ static int write_hibernate_location_info(void) {
+ 
+         /* if it's a swap partition, we just write the disk to /sys/power/resume */
+         if (streq(type, "partition")) {
+-                r = write_string_file("/sys/power/resume", device, WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file("/sys/power/resume", device, 0);
+                 if (r < 0)
+                         return log_debug_errno(r, "Failed to write partition device to /sys/power/resume: %m");
+ 
+@@ -98,14 +98,14 @@ static int write_hibernate_location_info(void) {
+ 
+         offset = fiemap->fm_extents[0].fe_physical / page_size();
+         xsprintf(offset_str, "%" PRIu64, offset);
+-        r = write_string_file("/sys/power/resume_offset", offset_str, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/power/resume_offset", offset_str, 0);
+         if (r < 0)
+                 return log_debug_errno(r, "Failed to write offset '%s': %m", offset_str);
+ 
+         log_debug("Wrote calculated resume_offset value to /sys/power/resume_offset: %s", offset_str);
+ 
+         xsprintf(device_str, "%lx", (unsigned long)stb.st_dev);
+-        r = write_string_file("/sys/power/resume", device_str, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/power/resume", device_str, 0);
+         if (r < 0)
+                 return log_debug_errno(r, "Failed to write device '%s': %m", device_str);
+ 
+@@ -121,7 +121,7 @@ static int write_mode(char **modes) {
+         STRV_FOREACH(mode, modes) {
+                 int k;
+ 
+-                k = write_string_file("/sys/power/disk", *mode, WRITE_STRING_FILE_DISABLE_BUFFER);
++                k = write_string_file("/sys/power/disk", *mode, 0);
+                 if (k >= 0)
+                         return 0;
+ 
+@@ -140,7 +140,7 @@ static int write_state(FILE **f, char **states) {
+         STRV_FOREACH(state, states) {
+                 int k;
+ 
+-                k = write_string_stream(*f, *state, WRITE_STRING_FILE_DISABLE_BUFFER);
++                k = write_string_stream(*f, *state, 0);
+                 if (k >= 0)
+                         return 0;
+                 log_debug_errno(k, "Failed to write '%s' to /sys/power/state: %m", *state);
+diff --git a/src/udev/udevadm-trigger.c b/src/udev/udevadm-trigger.c
+index 77d95e513f..25ce4abfb1 100644
+--- a/src/udev/udevadm-trigger.c
++++ b/src/udev/udevadm-trigger.c
+@@ -43,7 +43,7 @@ static int exec_list(sd_device_enumerator *e, const char *action, Set *settle_se
+                 if (!filename)
+                         return log_oom();
+ 
+-                r = write_string_file(filename, action, WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file(filename, action, 0);
+                 if (r < 0) {
+                         log_full_errno(r == -ENOENT ? LOG_DEBUG : LOG_ERR, r,
+                                        "Failed to write '%s' to '%s': %m", action, filename);
+diff --git a/src/udev/udevd.c b/src/udev/udevd.c
+index cb5123042a..ea309a9e7f 100644
+--- a/src/udev/udevd.c
++++ b/src/udev/udevd.c
+@@ -1113,7 +1113,7 @@ static int synthesize_change_one(sd_device *dev, const char *syspath) {
+ 
+         filename = strjoina(syspath, "/uevent");
+         log_device_debug(dev, "device is closed, synthesising 'change' on %s", syspath);
+-        r = write_string_file(filename, "change", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(filename, "change", 0);
+         if (r < 0)
+                 return log_device_debug_errno(dev, r, "Failed to write 'change' to %s: %m", filename);
+         return 0;
+diff --git a/src/vconsole/vconsole-setup.c b/src/vconsole/vconsole-setup.c
+index 75d052ae70..5a15c939d8 100644
+--- a/src/vconsole/vconsole-setup.c
++++ b/src/vconsole/vconsole-setup.c
+@@ -117,7 +117,7 @@ static int toggle_utf8_vc(const char *name, int fd, bool utf8) {
+ static int toggle_utf8_sysfs(bool utf8) {
+         int r;
+ 
+-        r = write_string_file("/sys/module/vt/parameters/default_utf8", one_zero(utf8), WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/module/vt/parameters/default_utf8", one_zero(utf8), 0);
+         if (r < 0)
+                 return log_warning_errno(r, "Failed to %s sysfs UTF-8 flag: %m", enable_disable(utf8));
+ 

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0002-don-t-use-glibc-specific-qsort_r.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0002-don-t-use-glibc-specific-qsort_r.patch
@@ -1,0 +1,163 @@
+From 1eb84534dea05d41afed1d898cba212ad7d310dd Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 13:41:41 +0800
+Subject: [PATCH 02/24] don't use glibc-specific qsort_r
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+[Rebased for v241]
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[Rebased for v242]
+Signed-off-by: Andrej Valek <andrej.valek@siemens.com>
+---
+ src/basic/sort-util.h              | 14 --------------
+ src/libsystemd/sd-hwdb/hwdb-util.c | 19 ++++++++++++++-----
+ src/shared/format-table.c          | 36 ++++++++++++++++++++++++------------
+ 3 files changed, 38 insertions(+), 31 deletions(-)
+
+diff --git a/src/basic/sort-util.h b/src/basic/sort-util.h
+index e029f8646e..27d68b341c 100644
+--- a/src/basic/sort-util.h
++++ b/src/basic/sort-util.h
+@@ -54,17 +54,3 @@ static inline void qsort_safe(void *base, size_t nmemb, size_t size, __compar_fn
+                 int (*_func_)(const typeof(p[0])*, const typeof(p[0])*) = func; \
+                 qsort_safe((p), (n), sizeof((p)[0]), (__compar_fn_t) _func_); \
+         })
+-
+-static inline void qsort_r_safe(void *base, size_t nmemb, size_t size, __compar_d_fn_t compar, void *userdata) {
+-        if (nmemb <= 1)
+-                return;
+-
+-        assert(base);
+-        qsort_r(base, nmemb, size, compar, userdata);
+-}
+-
+-#define typesafe_qsort_r(p, n, func, userdata)                          \
+-        ({                                                              \
+-                int (*_func_)(const typeof(p[0])*, const typeof(p[0])*, typeof(userdata)) = func; \
+-                qsort_r_safe((p), (n), sizeof((p)[0]), (__compar_d_fn_t) _func_, userdata); \
+-        })
+diff --git a/src/libsystemd/sd-hwdb/hwdb-util.c b/src/libsystemd/sd-hwdb/hwdb-util.c
+index c83575c7c8..72f8f3a050 100644
+--- a/src/libsystemd/sd-hwdb/hwdb-util.c
++++ b/src/libsystemd/sd-hwdb/hwdb-util.c
+@@ -128,9 +128,13 @@ static void trie_free(struct trie *trie) {
+ 
+ DEFINE_TRIVIAL_CLEANUP_FUNC(struct trie*, trie_free);
+ 
+-static int trie_values_cmp(const struct trie_value_entry *a, const struct trie_value_entry *b, struct trie *trie) {
+-        return strcmp(trie->strings->buf + a->key_off,
+-                      trie->strings->buf + b->key_off);
++static struct trie *trie_node_add_value_trie;
++static int trie_values_cmp(const void *v1, const void *v2) {
++        const struct trie_value_entry *a = v1;
++        const struct trie_value_entry *b = v2;
++
++        return strcmp(trie_node_add_value_trie->strings->buf + a->key_off,
++                      trie_node_add_value_trie->strings->buf + b->key_off);
+ }
+ 
+ static int trie_node_add_value(struct trie *trie, struct trie_node *node,
+@@ -158,7 +162,10 @@ static int trie_node_add_value(struct trie *trie, struct trie_node *node,
+                         .value_off = v,
+                 };
+ 
+-                val = typesafe_bsearch_r(&search, node->values, node->values_count, trie_values_cmp, trie);
++                trie_node_add_value_trie = trie;
++                val = bsearch(&search, node->values, node->values_count, sizeof(struct trie_value_entry), trie_values_cmp);
++                trie_node_add_value_trie = NULL;
++
+                 if (val) {
+                         /* At this point we have 2 identical properties on the same match-string.
+                          * Since we process files in order, we just replace the previous value. */
+@@ -184,7 +191,9 @@ static int trie_node_add_value(struct trie *trie, struct trie_node *node,
+                 .line_number = line_number,
+         };
+         node->values_count++;
+-        typesafe_qsort_r(node->values, node->values_count, trie_values_cmp, trie);
++        trie_node_add_value_trie = trie;
++        qsort(node->values, node->values_count, sizeof(struct trie_value_entry), trie_values_cmp);
++        trie_node_add_value_trie = NULL;
+         return 0;
+ }
+ 
+diff --git a/src/shared/format-table.c b/src/shared/format-table.c
+index a5c0a99b08..d595cbe372 100644
+--- a/src/shared/format-table.c
++++ b/src/shared/format-table.c
+@@ -850,31 +850,33 @@ static int cell_data_compare(TableData *a, size_t index_a, TableData *b, size_t
+         return CMP(index_a, index_b);
+ }
+ 
+-static int table_data_compare(const size_t *a, const size_t *b, Table *t) {
++static Table *user_table;
++static int table_data_compare(const void *x, const void *y) {
++        const size_t *a = x, *b=y;
+         size_t i;
+         int r;
+ 
+-        assert(t);
+-        assert(t->sort_map);
++        assert(user_table);
++        assert(user_table->sort_map);
+ 
+         /* Make sure the header stays at the beginning */
+-        if (*a < t->n_columns && *b < t->n_columns)
++        if (*a < user_table->n_columns && *b < user_table->n_columns)
+                 return 0;
+-        if (*a < t->n_columns)
++        if (*a < user_table->n_columns)
+                 return -1;
+-        if (*b < t->n_columns)
++        if (*b < user_table->n_columns)
+                 return 1;
+ 
+         /* Order other lines by the sorting map */
+-        for (i = 0; i < t->n_sort_map; i++) {
++        for (i = 0; i < user_table->n_sort_map; i++) {
+                 TableData *d, *dd;
+ 
+-                d = t->data[*a + t->sort_map[i]];
+-                dd = t->data[*b + t->sort_map[i]];
++                d = user_table->data[*a + user_table->sort_map[i]];
++                dd = user_table->data[*b + user_table->sort_map[i]];
+ 
+                 r = cell_data_compare(d, *a, dd, *b);
+                 if (r != 0)
+-                        return t->reverse_map && t->reverse_map[t->sort_map[i]] ? -r : r;
++                        return user_table->reverse_map && user_table->reverse_map[user_table->sort_map[i]] ? -r : r;
+         }
+ 
+         /* Order identical lines by the order there were originally added in */
+@@ -1107,7 +1109,12 @@ int table_print(Table *t, FILE *f) {
+                 for (i = 0; i < n_rows; i++)
+                         sorted[i] = i * t->n_columns;
+ 
+-                typesafe_qsort_r(sorted, n_rows, table_data_compare, t);
++                if (n_rows <= 1)
++                        return 0;
++                assert(sorted);
++                user_table = t;
++                qsort(sorted, n_rows, sizeof(size_t), table_data_compare);
++                user_table = NULL;
+         }
+ 
+         if (t->display_map)
+@@ -1534,7 +1541,12 @@ int table_to_json(Table *t, JsonVariant **ret) {
+                 for (i = 0; i < n_rows; i++)
+                         sorted[i] = i * t->n_columns;
+ 
+-                typesafe_qsort_r(sorted, n_rows, table_data_compare, t);
++                if (n_rows <= 1)
++                        return 0;
++                assert(sorted);
++                user_table = t;
++                qsort(sorted, n_rows, sizeof(size_t), table_data_compare);
++                user_table = NULL;
+         }
+ 
+         if (t->display_map)
+-- 
+2.11.0
+

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0002-src-login-brightness.c-include-sys-wait.h.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0002-src-login-brightness.c-include-sys-wait.h.patch
@@ -1,0 +1,25 @@
+Include sys/wait.h
+
+Fixes:
+src/login/logind-brightness.c:158:85: error: 'WEXITED' undeclared (first use in this function); did you mean 'WIFEXITED'?
+  158 |         r = sd_event_add_child(w->manager->event, &w->child_event_source, w->child, WEXITED, on_brightness_writer_exit, w);
+      |                                                                                     ^~~~~~~
+
+Upstream-Status: Pending
+
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ src/login/logind-brightness.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/login/logind-brightness.c b/src/login/logind-brightness.c
+index 8dfa97d7ae..bddd4a2727 100644
+--- a/src/login/logind-brightness.c
++++ b/src/login/logind-brightness.c
+@@ -1,5 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1+ */
+ 
++#include <sys/wait.h>
+ #include "bus-util.h"
+ #include "device-util.h"
+ #include "hash-funcs.h"

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0003-missing_type.h-add-__compare_fn_t-and-comparison_fn_.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0003-missing_type.h-add-__compare_fn_t-and-comparison_fn_.patch
@@ -1,0 +1,63 @@
+From a9421d55102fc84f77f7c21a2479fcd00652b896 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 13:55:12 +0800
+Subject: [PATCH 03/24] missing_type.h: add __compare_fn_t and comparison_fn_t
+
+Make it work with musl where comparison_fn_t and __compare_fn_t
+is not provided.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[Rebased for v242]
+Signed-off-by: Andrej Valek <andrej.valek@siemens.com>
+---
+ src/basic/missing_type.h | 9 +++++++++
+ src/basic/sort-util.h    | 1 +
+ src/journal/catalog.c    | 1 +
+ 3 files changed, 11 insertions(+)
+
+diff --git a/src/basic/missing_type.h b/src/basic/missing_type.h
+index bf8a6caa1b..2134fe5095 100644
+--- a/src/basic/missing_type.h
++++ b/src/basic/missing_type.h
+@@ -10,3 +10,12 @@
+ #if !HAVE_CHAR16_T
+ #define char16_t uint16_t
+ #endif
++
++#ifndef __GLIBC__
++typedef int (*comparison_fn_t)(const void *, const void *);
++#endif
++
++#ifndef __COMPAR_FN_T
++#define __COMPAR_FN_T
++typedef int (*__compar_fn_t)(const void *, const void *);
++#endif
+diff --git a/src/basic/sort-util.h b/src/basic/sort-util.h
+index e029f86..7247d40 100644
+--- a/src/basic/sort-util.h
++++ b/src/basic/sort-util.h
+@@ -4,6 +4,7 @@
+ #include <stdlib.h>
+ 
+ #include "macro.h"
++#include "missing.h"
+ 
+ void *xbsearch_r(const void *key, const void *base, size_t nmemb, size_t size,
+                  __compar_d_fn_t compar, void *arg);
+diff --git a/src/journal/catalog.c b/src/journal/catalog.c
+index 7beffc1e1a..4818a2e5cc 100644
+--- a/src/journal/catalog.c
++++ b/src/journal/catalog.c
+@@ -29,6 +29,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "tmpfile-util.h"
++#include "missing.h"
+ 
+ const char * const catalog_file_dirs[] = {
+         "/usr/local/lib/systemd/catalog/",
+-- 
+2.11.0
+

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0003-src-basic-copy.c-include-signal.h.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0003-src-basic-copy.c-include-signal.h.patch
@@ -1,0 +1,27 @@
+Include signal.h
+
+Fixes several signal set related errors:
+src/basic/copy.c:92:19: error: implicit declaration of function 'sigemptyset' [-Werror=implicit-function-declaration]
+src/basic/copy.c:93:19: error: implicit declaration of function 'sigaddset' [-Werror=implicit-function-declaration]
+src/basic/copy.c:93:34: error: 'SIGINT' undeclared (first use in this function)
+src/basic/copy.c:95:13: error: implicit declaration of function 'sigtimedwait' [-Werror=implicit-function-declaration]
+
+Upstream-Status: Pending
+
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ src/basic/copy.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/basic/copy.c b/src/basic/copy.c
+index ca311e021e..3cf7fc1697 100644
+--- a/src/basic/copy.c
++++ b/src/basic/copy.c
+@@ -12,6 +12,7 @@
+ #include <sys/xattr.h>
+ #include <time.h>
+ #include <unistd.h>
++#include <signal.h>
+ 
+ #include "alloc-util.h"
+ #include "btrfs-util.h"

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0004-add-fallback-parse_printf_format-implementation.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0004-add-fallback-parse_printf_format-implementation.patch
@@ -1,0 +1,432 @@
+From 7bcf3b166694090497a0acd2c5299e4e04fcc9b6 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 14:04:21 +0800
+Subject: [PATCH 04/24] add fallback parse_printf_format implementation
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Emil Renner Berthing <systemd@esmil.dk>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ meson.build                     |   1 +
+ src/basic/meson.build           |   5 +
+ src/basic/parse-printf-format.c | 273 ++++++++++++++++++++++++++++++++++++++++
+ src/basic/parse-printf-format.h |  57 +++++++++
+ src/basic/stdio-util.h          |   2 +-
+ src/journal/journal-send.c      |   2 +-
+ 6 files changed, 338 insertions(+), 2 deletions(-)
+ create mode 100644 src/basic/parse-printf-format.c
+ create mode 100644 src/basic/parse-printf-format.h
+
+diff --git a/meson.build b/meson.build
+index 79b762faeb..7f8c679411 100644
+--- a/meson.build
++++ b/meson.build
+@@ -613,6 +613,7 @@ endif
+ foreach header : ['crypt.h',
+                   'linux/memfd.h',
+                   'linux/vm_sockets.h',
++                  'printf.h',
+                   'sys/auxv.h',
+                   'valgrind/memcheck.h',
+                   'valgrind/valgrind.h',
+diff --git a/src/basic/meson.build b/src/basic/meson.build
+index d6caf28f14..32c1acf349 100644
+--- a/src/basic/meson.build
++++ b/src/basic/meson.build
+@@ -312,6 +312,11 @@ foreach item : [['af',     af_list_txt,     'af',         ''],
+ endforeach
+ 
+ basic_sources += generated_gperf_headers
++
++if conf.get('HAVE_PRINTF_H') != 1
++        basic_sources += [files('parse-printf-format.c')]
++endif
++
+ basic_gcrypt_sources = files(
+         'gcrypt-util.c',
+         'gcrypt-util.h')
+diff --git a/src/basic/parse-printf-format.c b/src/basic/parse-printf-format.c
+new file mode 100644
+index 0000000000..49437e5445
+--- /dev/null
++++ b/src/basic/parse-printf-format.c
+@@ -0,0 +1,273 @@
++/*-*- Mode: C; c-basic-offset: 8; indent-tabs-mode: nil -*-*/
++
++/***
++  This file is part of systemd.
++
++  Copyright 2014 Emil Renner Berthing <systemd@esmil.dk>
++
++  With parts from the musl C library
++  Copyright 2005-2014 Rich Felker, et al.
++
++  systemd is free software; you can redistribute it and/or modify it
++  under the terms of the GNU Lesser General Public License as published by
++  the Free Software Foundation; either version 2.1 of the License, or
++  (at your option) any later version.
++
++  systemd is distributed in the hope that it will be useful, but
++  WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public License
++  along with systemd; If not, see <http://www.gnu.org/licenses/>.
++***/
++
++#include <stddef.h>
++#include <string.h>
++
++#include "parse-printf-format.h"
++
++static const char *consume_nonarg(const char *fmt)
++{
++        do {
++                if (*fmt == '\0')
++                        return fmt;
++        } while (*fmt++ != '%');
++        return fmt;
++}
++
++static const char *consume_num(const char *fmt)
++{
++        for (;*fmt >= '0' && *fmt <= '9'; fmt++)
++                /* do nothing */;
++        return fmt;
++}
++
++static const char *consume_argn(const char *fmt, size_t *arg)
++{
++        const char *p = fmt;
++        size_t val = 0;
++
++        if (*p < '1' || *p > '9')
++                return fmt;
++        do {
++                val = 10*val + (*p++ - '0');
++        } while (*p >= '0' && *p <= '9');
++
++        if (*p != '$')
++                return fmt;
++        *arg = val;
++        return p+1;
++}
++
++static const char *consume_flags(const char *fmt)
++{
++        while (1) {
++                switch (*fmt) {
++                case '#':
++                case '0':
++                case '-':
++                case ' ':
++                case '+':
++                case '\'':
++                case 'I':
++                        fmt++;
++                        continue;
++                }
++                return fmt;
++        }
++}
++
++enum state {
++        BARE,
++        LPRE,
++        LLPRE,
++        HPRE,
++        HHPRE,
++        BIGLPRE,
++        ZTPRE,
++        JPRE,
++        STOP
++};
++
++enum type {
++        NONE,
++        PTR,
++        INT,
++        UINT,
++        ULLONG,
++        LONG,
++        ULONG,
++        SHORT,
++        USHORT,
++        CHAR,
++        UCHAR,
++        LLONG,
++        SIZET,
++        IMAX,
++        UMAX,
++        PDIFF,
++        UIPTR,
++        DBL,
++        LDBL,
++        MAXTYPE
++};
++
++static const short pa_types[MAXTYPE] = {
++        [NONE]   = PA_INT,
++        [PTR]    = PA_POINTER,
++        [INT]    = PA_INT,
++        [UINT]   = PA_INT,
++        [ULLONG] = PA_INT | PA_FLAG_LONG_LONG,
++        [LONG]   = PA_INT | PA_FLAG_LONG,
++        [ULONG]  = PA_INT | PA_FLAG_LONG,
++        [SHORT]  = PA_INT | PA_FLAG_SHORT,
++        [USHORT] = PA_INT | PA_FLAG_SHORT,
++        [CHAR]   = PA_CHAR,
++        [UCHAR]  = PA_CHAR,
++        [LLONG]  = PA_INT | PA_FLAG_LONG_LONG,
++        [SIZET]  = PA_INT | PA_FLAG_LONG,
++        [IMAX]   = PA_INT | PA_FLAG_LONG_LONG,
++        [UMAX]   = PA_INT | PA_FLAG_LONG_LONG,
++        [PDIFF]  = PA_INT | PA_FLAG_LONG_LONG,
++        [UIPTR]  = PA_INT | PA_FLAG_LONG,
++        [DBL]    = PA_DOUBLE,
++        [LDBL]   = PA_DOUBLE | PA_FLAG_LONG_DOUBLE
++};
++
++#define S(x) [(x)-'A']
++#define E(x) (STOP + (x))
++
++static const unsigned char states[]['z'-'A'+1] = {
++        { /* 0: bare types */
++                S('d') = E(INT), S('i') = E(INT),
++                S('o') = E(UINT),S('u') = E(UINT),S('x') = E(UINT), S('X') = E(UINT),
++                S('e') = E(DBL), S('f') = E(DBL), S('g') = E(DBL),  S('a') = E(DBL),
++                S('E') = E(DBL), S('F') = E(DBL), S('G') = E(DBL),  S('A') = E(DBL),
++                S('c') = E(CHAR),S('C') = E(INT),
++                S('s') = E(PTR), S('S') = E(PTR), S('p') = E(UIPTR),S('n') = E(PTR),
++                S('m') = E(NONE),
++                S('l') = LPRE,   S('h') = HPRE, S('L') = BIGLPRE,
++                S('z') = ZTPRE,  S('j') = JPRE, S('t') = ZTPRE
++        }, { /* 1: l-prefixed */
++                S('d') = E(LONG), S('i') = E(LONG),
++                S('o') = E(ULONG),S('u') = E(ULONG),S('x') = E(ULONG),S('X') = E(ULONG),
++                S('e') = E(DBL),  S('f') = E(DBL),  S('g') = E(DBL),  S('a') = E(DBL),
++                S('E') = E(DBL),  S('F') = E(DBL),  S('G') = E(DBL),  S('A') = E(DBL),
++                S('c') = E(INT),  S('s') = E(PTR),  S('n') = E(PTR),
++                S('l') = LLPRE
++        }, { /* 2: ll-prefixed */
++                S('d') = E(LLONG), S('i') = E(LLONG),
++                S('o') = E(ULLONG),S('u') = E(ULLONG),
++                S('x') = E(ULLONG),S('X') = E(ULLONG),
++                S('n') = E(PTR)
++        }, { /* 3: h-prefixed */
++                S('d') = E(SHORT), S('i') = E(SHORT),
++                S('o') = E(USHORT),S('u') = E(USHORT),
++                S('x') = E(USHORT),S('X') = E(USHORT),
++                S('n') = E(PTR),
++                S('h') = HHPRE
++        }, { /* 4: hh-prefixed */
++                S('d') = E(CHAR), S('i') = E(CHAR),
++                S('o') = E(UCHAR),S('u') = E(UCHAR),
++                S('x') = E(UCHAR),S('X') = E(UCHAR),
++                S('n') = E(PTR)
++        }, { /* 5: L-prefixed */
++                S('e') = E(LDBL),S('f') = E(LDBL),S('g') = E(LDBL), S('a') = E(LDBL),
++                S('E') = E(LDBL),S('F') = E(LDBL),S('G') = E(LDBL), S('A') = E(LDBL),
++                S('n') = E(PTR)
++        }, { /* 6: z- or t-prefixed (assumed to be same size) */
++                S('d') = E(PDIFF),S('i') = E(PDIFF),
++                S('o') = E(SIZET),S('u') = E(SIZET),
++                S('x') = E(SIZET),S('X') = E(SIZET),
++                S('n') = E(PTR)
++        }, { /* 7: j-prefixed */
++                S('d') = E(IMAX), S('i') = E(IMAX),
++                S('o') = E(UMAX), S('u') = E(UMAX),
++                S('x') = E(UMAX), S('X') = E(UMAX),
++                S('n') = E(PTR)
++        }
++};
++
++size_t parse_printf_format(const char *fmt, size_t n, int *types)
++{
++        size_t i = 0;
++        size_t last = 0;
++
++        memset(types, 0, n);
++
++        while (1) {
++                size_t arg;
++                unsigned int state;
++
++                fmt = consume_nonarg(fmt);
++                if (*fmt == '\0')
++                        break;
++                if (*fmt == '%') {
++                        fmt++;
++                        continue;
++                }
++                arg = 0;
++                fmt = consume_argn(fmt, &arg);
++                /* flags */
++                fmt = consume_flags(fmt);
++                /* width */
++                if (*fmt == '*') {
++                        size_t warg = 0;
++                        fmt = consume_argn(fmt+1, &warg);
++                        if (warg == 0)
++                                warg = ++i;
++                        if (warg > last)
++                                last = warg;
++                        if (warg <= n && types[warg-1] == NONE)
++                                types[warg-1] = INT;
++                } else
++                        fmt = consume_num(fmt);
++                /* precision */
++                if (*fmt == '.') {
++                        fmt++;
++                        if (*fmt == '*') {
++                                size_t parg = 0;
++                                fmt = consume_argn(fmt+1, &parg);
++                                if (parg == 0)
++                                        parg = ++i;
++                                if (parg > last)
++                                        last = parg;
++                                if (parg <= n && types[parg-1] == NONE)
++                                        types[parg-1] = INT;
++                        } else {
++                                if (*fmt == '-')
++                                        fmt++;
++                                fmt = consume_num(fmt);
++                        }
++                }
++                /* length modifier and conversion specifier */
++                state = BARE;
++                do {
++                        unsigned char c = *fmt++;
++
++                        if (c < 'A' || c > 'z')
++                                continue;
++                        state = states[state]S(c);
++                        if (state == 0)
++                                continue;
++                } while (state < STOP);
++
++                if (state == E(NONE))
++                        continue;
++
++                if (arg == 0)
++                        arg = ++i;
++                if (arg > last)
++                        last = arg;
++                if (arg <= n)
++                        types[arg-1] = state - STOP;
++        }
++
++        if (last > n)
++                last = n;
++        for (i = 0; i < last; i++)
++                types[i] = pa_types[types[i]];
++
++        return last;
++}
+diff --git a/src/basic/parse-printf-format.h b/src/basic/parse-printf-format.h
+new file mode 100644
+index 0000000000..47be7522d7
+--- /dev/null
++++ b/src/basic/parse-printf-format.h
+@@ -0,0 +1,57 @@
++/*-*- Mode: C; c-basic-offset: 8; indent-tabs-mode: nil -*-*/
++
++/***
++  This file is part of systemd.
++
++  Copyright 2014 Emil Renner Berthing <systemd@esmil.dk>
++
++  With parts from the GNU C Library
++  Copyright 1991-2014 Free Software Foundation, Inc.
++
++  systemd is free software; you can redistribute it and/or modify it
++  under the terms of the GNU Lesser General Public License as published by
++  the Free Software Foundation; either version 2.1 of the License, or
++  (at your option) any later version.
++
++  systemd is distributed in the hope that it will be useful, but
++  WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public License
++  along with systemd; If not, see <http://www.gnu.org/licenses/>.
++***/
++
++#pragma once
++
++#include "config.h"
++
++#if HAVE_PRINTF_H
++#include <printf.h>
++#else
++
++#include <stddef.h>
++
++enum {				/* C type: */
++  PA_INT,			/* int */
++  PA_CHAR,			/* int, cast to char */
++  PA_WCHAR,			/* wide char */
++  PA_STRING,			/* const char *, a '\0'-terminated string */
++  PA_WSTRING,			/* const wchar_t *, wide character string */
++  PA_POINTER,			/* void * */
++  PA_FLOAT,			/* float */
++  PA_DOUBLE,			/* double */
++  PA_LAST
++};
++
++/* Flag bits that can be set in a type returned by `parse_printf_format'.  */
++#define	PA_FLAG_MASK		0xff00
++#define	PA_FLAG_LONG_LONG	(1 << 8)
++#define	PA_FLAG_LONG_DOUBLE	PA_FLAG_LONG_LONG
++#define	PA_FLAG_LONG		(1 << 9)
++#define	PA_FLAG_SHORT		(1 << 10)
++#define	PA_FLAG_PTR		(1 << 11)
++
++size_t parse_printf_format(const char *fmt, size_t n, int *types);
++
++#endif /* HAVE_PRINTF_H */
+diff --git a/src/basic/stdio-util.h b/src/basic/stdio-util.h
+index c3b9448d4f..2937aa13b1 100644
+--- a/src/basic/stdio-util.h
++++ b/src/basic/stdio-util.h
+@@ -1,13 +1,13 @@
+ /* SPDX-License-Identifier: LGPL-2.1+ */
+ #pragma once
+ 
+-#include <printf.h>
+ #include <stdarg.h>
+ #include <stdio.h>
+ #include <sys/types.h>
+ 
+ #include "macro.h"
+ #include "memory-util.h"
++#include "parse-printf-format.h"
+ 
+ #define snprintf_ok(buf, len, fmt, ...) \
+         ((size_t) snprintf(buf, len, fmt, __VA_ARGS__) < (len))
+diff --git a/src/journal/journal-send.c b/src/journal/journal-send.c
+index 5ef11fa1a4..6384ab620c 100644
+--- a/src/journal/journal-send.c
++++ b/src/journal/journal-send.c
+@@ -2,7 +2,6 @@
+ 
+ #include <errno.h>
+ #include <fcntl.h>
+-#include <printf.h>
+ #include <stddef.h>
+ #include <sys/socket.h>
+ #include <sys/un.h>
+@@ -21,6 +20,7 @@
+ #include "stdio-util.h"
+ #include "string-util.h"
+ #include "tmpfile-util.h"
++#include "parse-printf-format.h"
+ 
+ #define SNDBUF_SIZE (8*1024*1024)
+ 

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0004-src-shared-cpu-set-util.h-add-__cpu_mask-definition.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0004-src-shared-cpu-set-util.h-add-__cpu_mask-definition.patch
@@ -1,0 +1,54 @@
+Handle __cpu_mask usage
+
+Fixes errors:
+
+src/test/test-cpu-set-util.c:18:54: error: '__cpu_mask' undeclared (first use in this function)
+src/test/test-sizeof.c:73:14: error: '__cpu_mask' undeclared (first use in this function)
+
+__cpu_mask is an internal type of glibc's cpu_set implementation, not
+part of the POSIX definition, which is problematic when building with
+musl, which does not define a matching type.  From inspection of musl's
+sched.h, however, it is clear that the corresponding type would be
+unsigned long, which does match glibc's actual __CPU_MASK_TYPE.  So,
+add a typedef to cpu-set-util.h defining __cpu_mask appropriately.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ src/shared/cpu-set-util.h | 2 ++
+ src/test/test-sizeof.c    | 2 +-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/shared/cpu-set-util.h b/src/shared/cpu-set-util.h
+index 27812dfd59..f698f9df83 100644
+--- a/src/shared/cpu-set-util.h
++++ b/src/shared/cpu-set-util.h
+@@ -6,6 +6,8 @@
+ #include "macro.h"
+ #include "missing_syscall.h"
+ 
++typedef unsigned long __cpu_mask;
++
+ /* This wraps the libc interface with a variable to keep the allocated size. */
+ typedef struct CPUSet {
+         cpu_set_t *set;
+diff --git a/src/test/test-sizeof.c b/src/test/test-sizeof.c
+index a710db5370..d1601ad929 100644
+--- a/src/test/test-sizeof.c
++++ b/src/test/test-sizeof.c
+@@ -1,6 +1,5 @@
+ /* SPDX-License-Identifier: LGPL-2.1+ */
+ 
+-#include <sched.h>
+ #include <stdio.h>
+ #include <string.h>
+ 
+@@ -8,6 +7,7 @@
+ #include <float.h>
+ 
+ #include "time-util.h"
++#include "cpu-set-util.h"
+ 
+ /* Print information about various types. Useful when diagnosing
+  * gcc diagnostics on an unfamiliar architecture. */

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0005-src-basic-missing.h-check-for-missing-strndupa.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0005-src-basic-missing.h-check-for-missing-strndupa.patch
@@ -1,0 +1,442 @@
+From 399fd3eda3045636a70da438a0fd1406cc332ed1 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 14:18:21 +0800
+Subject: [PATCH 05/24] src/basic/missing.h: check for missing strndupa
+
+include missing.h  for definition of strndupa
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[Rebased for v242]
+Signed-off-by: Andrej Valek <andrej.valek@siemens.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ meson.build                                |  1 +
+ src/backlight/backlight.c                  |  1 +
+ src/basic/env-util.c                       |  1 +
+ src/basic/missing_stdlib.h                 | 12 ++++++++++++
+ src/basic/mkdir.c                          |  1 +
+ src/basic/parse-util.c                     |  1 +
+ src/basic/proc-cmdline.c                   |  1 +
+ src/basic/procfs-util.c                    |  1 +
+ src/basic/time-util.c                      |  1 +
+ src/core/dbus-cgroup.c                     |  1 +
+ src/core/dbus-util.c                       |  1 +
+ src/core/kmod-setup.c                      |  1 +
+ src/core/service.c                         |  1 +
+ src/journal/journalctl.c                   |  1 +
+ src/libsystemd/sd-bus/bus-message.c        |  1 +
+ src/libsystemd/sd-bus/bus-objects.c        |  1 +
+ src/libsystemd/sd-bus/test-bus-benchmark.c |  1 +
+ src/locale/keymap-util.c                   |  1 +
+ src/login/pam_systemd.c                    |  1 +
+ src/network/generator/network-generator.c  |  1 +
+ src/nspawn/nspawn-settings.c               |  1 +
+ src/shared/dns-domain.c                    |  1 +
+ src/shared/journal-importer.c              |  1 +
+ src/shared/logs-show.c                     |  1 +
+ src/shared/pager.c                         |  1 +
+ src/shared/path-lookup.c                   |  1 +
+ src/shared/uid-range.c                     |  1 +
+ src/socket-proxy/socket-proxyd.c           |  1 +
+ src/test/test-hexdecoct.c                  |  1 +
+ src/udev/udev-builtin-path_id.c            |  1 +
+ src/udev/udev-event.c                      |  1 +
+ src/udev/udev-rules.c                      |  1 +
+ 32 files changed, 43 insertions(+)
+
+diff --git a/meson.build b/meson.build
+index 7f8c679411..81c061b768 100644
+--- a/meson.build
++++ b/meson.build
+@@ -506,6 +506,7 @@ foreach ident : [
+                                  #include <unistd.h>'''],
+         ['get_mempolicy',     '''#include <stdlib.h>
+                                  #include <unistd.h>'''],
++        ['strndupa' ,         '''#include <string.h>'''],
+ ]
+ 
+         have = cc.has_function(ident[0], prefix : ident[1], args : '-D_GNU_SOURCE')
+diff --git a/src/backlight/backlight.c b/src/backlight/backlight.c
+index dfd6805398..c2b2ace6ec 100644
+--- a/src/backlight/backlight.c
++++ b/src/backlight/backlight.c
+@@ -17,6 +17,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "util.h"
++#include "missing.h"
+ 
+ static int find_pci_or_platform_parent(sd_device *device, sd_device **ret) {
+         const char *subsystem, *sysname, *value;
+diff --git a/src/basic/env-util.c b/src/basic/env-util.c
+index a6503cf2b6..ceef9a62c8 100644
+--- a/src/basic/env-util.c
++++ b/src/basic/env-util.c
+@@ -16,6 +16,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "utf8.h"
++#include "missing.h"
+ 
+ #define VALID_CHARS_ENV_NAME                    \
+         DIGITS LETTERS                          \
+diff --git a/src/basic/missing_stdlib.h b/src/basic/missing_stdlib.h
+index 188a8d4406..1e16ec287a 100644
+--- a/src/basic/missing_stdlib.h
++++ b/src/basic/missing_stdlib.h
+@@ -11,3 +11,15 @@
+ #    error "neither secure_getenv nor __secure_getenv are available"
+ #  endif
+ #endif
++
++/* string.h */
++#if ! HAVE_STRNDUPA
++#define strndupa(s, n) \
++  ({ \
++    const char *__old = (s); \
++    size_t __len = strnlen(__old, (n)); \
++    char *__new = (char *)alloca(__len + 1); \
++    __new[__len] = '\0'; \
++    (char *)memcpy(__new, __old, __len); \
++  })
++#endif
+diff --git a/src/basic/mkdir.c b/src/basic/mkdir.c
+index 6b82eab640..51c6b78615 100644
+--- a/src/basic/mkdir.c
++++ b/src/basic/mkdir.c
+@@ -14,6 +14,7 @@
+ #include "stat-util.h"
+ #include "stdio-util.h"
+ #include "user-util.h"
++#include "missing.h"
+ 
+ int mkdir_safe_internal(const char *path, mode_t mode, uid_t uid, gid_t gid, MkdirFlags flags, mkdir_func_t _mkdir) {
+         struct stat st;
+diff --git a/src/basic/parse-util.c b/src/basic/parse-util.c
+index 115a1494a2..07a34bfd53 100644
+--- a/src/basic/parse-util.c
++++ b/src/basic/parse-util.c
+@@ -20,6 +20,7 @@
+ #include "process-util.h"
+ #include "stat-util.h"
+ #include "string-util.h"
++#include "missing.h"
+ 
+ int parse_boolean(const char *v) {
+         if (!v)
+diff --git a/src/basic/proc-cmdline.c b/src/basic/proc-cmdline.c
+index 09169cf963..f411ba897f 100644
+--- a/src/basic/proc-cmdline.c
++++ b/src/basic/proc-cmdline.c
+@@ -15,6 +15,7 @@
+ #include "string-util.h"
+ #include "util.h"
+ #include "virt.h"
++#include "missing.h"
+ 
+ int proc_cmdline(char **ret) {
+         const char *e;
+diff --git a/src/basic/procfs-util.c b/src/basic/procfs-util.c
+index 7aaf95bfce..42ce53d5aa 100644
+--- a/src/basic/procfs-util.c
++++ b/src/basic/procfs-util.c
+@@ -11,6 +11,7 @@
+ #include "procfs-util.h"
+ #include "stdio-util.h"
+ #include "string-util.h"
++#include "missing.h"
+ 
+ int procfs_tasks_get_limit(uint64_t *ret) {
+         _cleanup_free_ char *value = NULL;
+diff --git a/src/basic/time-util.c b/src/basic/time-util.c
+index 3018e81acb..4e2b3b66c1 100644
+--- a/src/basic/time-util.c
++++ b/src/basic/time-util.c
+@@ -28,6 +28,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "time-util.h"
++#include "missing.h"
+ 
+ static clockid_t map_clock_id(clockid_t c) {
+ 
+diff --git a/src/core/dbus-cgroup.c b/src/core/dbus-cgroup.c
+index 2f2313c599..c9937f9d62 100644
+--- a/src/core/dbus-cgroup.c
++++ b/src/core/dbus-cgroup.c
+@@ -15,6 +15,7 @@
+ #include "fileio.h"
+ #include "limits-util.h"
+ #include "path-util.h"
++#include "missing.h"
+ 
+ static BUS_DEFINE_PROPERTY_GET_ENUM(property_get_cgroup_device_policy, cgroup_device_policy, CGroupDevicePolicy);
+ 
+diff --git a/src/core/dbus-util.c b/src/core/dbus-util.c
+index 7862beaacb..19f6968cfe 100644
+--- a/src/core/dbus-util.c
++++ b/src/core/dbus-util.c
+@@ -7,6 +7,7 @@
+ #include "unit-printf.h"
+ #include "user-util.h"
+ #include "unit.h"
++#include "missing.h"
+ 
+ int bus_property_get_triggered_unit(
+                 sd_bus *bus,
+diff --git a/src/core/kmod-setup.c b/src/core/kmod-setup.c
+index a91cfebc67..a45961013f 100644
+--- a/src/core/kmod-setup.c
++++ b/src/core/kmod-setup.c
+@@ -11,6 +11,7 @@
+ #include "kmod-setup.h"
+ #include "macro.h"
+ #include "string-util.h"
++#include "missing.h"
+ 
+ #if HAVE_KMOD
+ #include <libkmod.h>
+diff --git a/src/core/service.c b/src/core/service.c
+index 73b3c9c316..ef74f00a08 100644
+--- a/src/core/service.c
++++ b/src/core/service.c
+@@ -43,6 +43,7 @@
+ #include "unit.h"
+ #include "utf8.h"
+ #include "util.h"
++#include "missing.h"
+ 
+ static const UnitActiveState state_translation_table[_SERVICE_STATE_MAX] = {
+         [SERVICE_DEAD] = UNIT_INACTIVE,
+diff --git a/src/journal/journalctl.c b/src/journal/journalctl.c
+index 6d6bb1cf63..6666349a35 100644
+--- a/src/journal/journalctl.c
++++ b/src/journal/journalctl.c
+@@ -70,6 +70,7 @@
+ #include "unit-name.h"
+ #include "user-util.h"
+ #include "varlink.h"
++#include "missing.h"
+ 
+ #define DEFAULT_FSS_INTERVAL_USEC (15*USEC_PER_MINUTE)
+ 
+diff --git a/src/libsystemd/sd-bus/bus-message.c b/src/libsystemd/sd-bus/bus-message.c
+index eb029e4453..f31fe9d5a8 100644
+--- a/src/libsystemd/sd-bus/bus-message.c
++++ b/src/libsystemd/sd-bus/bus-message.c
+@@ -21,6 +21,7 @@
+ #include "strv.h"
+ #include "time-util.h"
+ #include "utf8.h"
++#include "missing.h"
+ 
+ static int message_append_basic(sd_bus_message *m, char type, const void *p, const void **stored);
+ 
+diff --git a/src/libsystemd/sd-bus/bus-objects.c b/src/libsystemd/sd-bus/bus-objects.c
+index ae643cacc7..1b752271a5 100644
+--- a/src/libsystemd/sd-bus/bus-objects.c
++++ b/src/libsystemd/sd-bus/bus-objects.c
+@@ -13,6 +13,7 @@
+ #include "set.h"
+ #include "string-util.h"
+ #include "strv.h"
++#include "missing.h"
+ 
+ static int node_vtable_get_userdata(
+                 sd_bus *bus,
+diff --git a/src/libsystemd/sd-bus/test-bus-benchmark.c b/src/libsystemd/sd-bus/test-bus-benchmark.c
+index 8de0a859ee..4fd0a2e692 100644
+--- a/src/libsystemd/sd-bus/test-bus-benchmark.c
++++ b/src/libsystemd/sd-bus/test-bus-benchmark.c
+@@ -14,6 +14,7 @@
+ #include "missing_resource.h"
+ #include "time-util.h"
+ #include "util.h"
++#include "missing.h"
+ 
+ #define MAX_SIZE (2*1024*1024)
+ 
+diff --git a/src/locale/keymap-util.c b/src/locale/keymap-util.c
+index f8c36c94f5..41f5606aea 100644
+--- a/src/locale/keymap-util.c
++++ b/src/locale/keymap-util.c
+@@ -22,6 +22,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "tmpfile-util.h"
++#include "missing.h"
+ 
+ static bool startswith_comma(const char *s, const char *prefix) {
+         s = startswith(s, prefix);
+diff --git a/src/login/pam_systemd.c b/src/login/pam_systemd.c
+index 3f762cbbc3..005cfea658 100644
+--- a/src/login/pam_systemd.c
++++ b/src/login/pam_systemd.c
+@@ -28,6 +28,7 @@
+ #include "hostname-util.h"
+ #include "login-util.h"
+ #include "macro.h"
++#include "missing.h"
+ #include "parse-util.h"
+ #include "path-util.h"
+ #include "process-util.h"
+diff --git a/src/network/generator/network-generator.c b/src/network/generator/network-generator.c
+index 0b5af33566..9c808cd014 100644
+--- a/src/network/generator/network-generator.c
++++ b/src/network/generator/network-generator.c
+@@ -13,6 +13,7 @@
+ #include "string-table.h"
+ #include "string-util.h"
+ #include "strv.h"
++#include "missing.h"
+ 
+ /*
+   # .network
+diff --git a/src/nspawn/nspawn-settings.c b/src/nspawn/nspawn-settings.c
+index 3a99736813..279fea4d88 100644
+--- a/src/nspawn/nspawn-settings.c
++++ b/src/nspawn/nspawn-settings.c
+@@ -16,6 +16,7 @@
+ #include "strv.h"
+ #include "user-util.h"
+ #include "util.h"
++#include "missing.h"
+ 
+ Settings *settings_new(void) {
+         Settings *s;
+diff --git a/src/shared/dns-domain.c b/src/shared/dns-domain.c
+index f62ad0a0f5..f1a27e158d 100644
+--- a/src/shared/dns-domain.c
++++ b/src/shared/dns-domain.c
+@@ -24,6 +24,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "utf8.h"
++#include "missing.h"
+ 
+ int dns_label_unescape(const char **name, char *dest, size_t sz, DNSLabelFlags flags) {
+         const char *n;
+diff --git a/src/shared/journal-importer.c b/src/shared/journal-importer.c
+index 7c4fc7021d..a6ff2214df 100644
+--- a/src/shared/journal-importer.c
++++ b/src/shared/journal-importer.c
+@@ -14,6 +14,7 @@
+ #include "parse-util.h"
+ #include "string-util.h"
+ #include "unaligned.h"
++#include "missing.h"
+ 
+ enum {
+         IMPORTER_STATE_LINE = 0,    /* waiting to read, or reading line */
+diff --git a/src/shared/logs-show.c b/src/shared/logs-show.c
+index b615c70dff..75b26e9c21 100644
+--- a/src/shared/logs-show.c
++++ b/src/shared/logs-show.c
+@@ -39,6 +39,7 @@
+ #include "time-util.h"
+ #include "utf8.h"
+ #include "util.h"
++#include "missing.h"
+ 
+ /* up to three lines (each up to 100 characters) or 300 characters, whichever is less */
+ #define PRINT_LINE_THRESHOLD 3
+diff --git a/src/shared/pager.c b/src/shared/pager.c
+index 7c20b100b4..e4209d3a95 100644
+--- a/src/shared/pager.c
++++ b/src/shared/pager.c
+@@ -25,6 +25,7 @@
+ #include "strv.h"
+ #include "terminal-util.h"
+ #include "util.h"
++#include "missing.h"
+ 
+ static pid_t pager_pid = 0;
+ 
+diff --git a/src/shared/path-lookup.c b/src/shared/path-lookup.c
+index 6bf0ff0316..f6c8009cd2 100644
+--- a/src/shared/path-lookup.c
++++ b/src/shared/path-lookup.c
+@@ -20,6 +20,7 @@
+ #include "tmpfile-util.h"
+ #include "user-util.h"
+ #include "util.h"
++#include "missing.h"
+ 
+ int xdg_user_runtime_dir(char **ret, const char *suffix) {
+         const char *e;
+diff --git a/src/shared/uid-range.c b/src/shared/uid-range.c
+index 7cb7d8a477..8b12b91084 100644
+--- a/src/shared/uid-range.c
++++ b/src/shared/uid-range.c
+@@ -9,6 +9,7 @@
+ #include "sort-util.h"
+ #include "uid-range.h"
+ #include "user-util.h"
++#include "missing.h"
+ 
+ static bool uid_range_intersect(UidRange *range, uid_t start, uid_t nr) {
+         assert(range);
+diff --git a/src/socket-proxy/socket-proxyd.c b/src/socket-proxy/socket-proxyd.c
+index abbbc9f2d6..6179b5851e 100644
+--- a/src/socket-proxy/socket-proxyd.c
++++ b/src/socket-proxy/socket-proxyd.c
+@@ -28,6 +28,7 @@
+ #include "socket-util.h"
+ #include "string-util.h"
+ #include "util.h"
++#include "missing.h"
+ 
+ #define BUFFER_SIZE (256 * 1024)
+ 
+diff --git a/src/test/test-hexdecoct.c b/src/test/test-hexdecoct.c
+index 52217429b1..a05e7782f6 100644
+--- a/src/test/test-hexdecoct.c
++++ b/src/test/test-hexdecoct.c
+@@ -6,6 +6,7 @@
+ #include "hexdecoct.h"
+ #include "macro.h"
+ #include "string-util.h"
++#include "missing.h"
+ 
+ static void test_hexchar(void) {
+         assert_se(hexchar(0xa) == 'a');
+diff --git a/src/udev/udev-builtin-path_id.c b/src/udev/udev-builtin-path_id.c
+index e8f1ce1354..8693cb02a4 100644
+--- a/src/udev/udev-builtin-path_id.c
++++ b/src/udev/udev-builtin-path_id.c
+@@ -23,6 +23,7 @@
+ #include "strv.h"
+ #include "sysexits.h"
+ #include "udev-builtin.h"
++#include "missing.h"
+ 
+ _printf_(2,3)
+ static void path_prepend(char **path, const char *fmt, ...) {
+diff --git a/src/udev/udev-event.c b/src/udev/udev-event.c
+index 8cfa2cdf23..b0670c77ec 100644
+--- a/src/udev/udev-event.c
++++ b/src/udev/udev-event.c
+@@ -35,6 +35,7 @@
+ #include "udev-util.h"
+ #include "udev-watch.h"
+ #include "user-util.h"
++#include "missing.h"
+ 
+ typedef struct Spawn {
+         sd_device *device;
+diff --git a/src/udev/udev-rules.c b/src/udev/udev-rules.c
+index 1642f10535..fe2aa75478 100644
+--- a/src/udev/udev-rules.c
++++ b/src/udev/udev-rules.c
+@@ -28,6 +28,7 @@
+ #include "udev-event.h"
+ #include "udev-rules.h"
+ #include "user-util.h"
++#include "missing.h"
+ 
+ #define RULES_DIRS (const char* const*) CONF_PATHS_STRV("udev/rules.d")
+ 

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0006-Include-netinet-if_ether.h.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0006-Include-netinet-if_ether.h.patch
@@ -1,0 +1,227 @@
+Include netinet/if_ether.h
+
+Fixes
+/path/to/systemd/recipe-sysroot/usr/include/netinet/if_ether.h:101:8: error: redefinition of 'struct ethhdr'
+ struct ethhdr {
+        ^~~~~~
+
+and related arphdr, arpreq, and arpreq_old errors
+/path/to/systemd/recipe-sysroot/usr/include/net/if_arp.h:22:8: error: redefinition of 'struct arphdr'
+ struct arphdr {
+        ^~~~~~
+
+The latter requires removing some includes of net/if_arp.h to avoid
+conflicting with netinet/if_ether.h.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ src/libsystemd-network/sd-dhcp6-client.c  | 1 -
+ src/libsystemd/sd-netlink/netlink-types.c | 1 +
+ src/machine/machine-dbus.c                | 1 +
+ src/network/netdev/macsec.c               | 1 +
+ src/network/netdev/netdev.c               | 1 +
+ src/network/networkd-brvlan.c             | 1 +
+ src/network/networkd-dhcp-common.c        | 1 +
+ src/network/networkd-dhcp4.c              | 2 +-
+ src/network/networkd-dhcp6.c              | 2 +-
+ src/network/networkd-link.c               | 2 +-
+ src/network/networkd-network.c            | 1 +
+ src/shared/ethtool-util.c                 | 1 +
+ src/shared/ethtool-util.h                 | 1 +
+ src/udev/net/link-config.c                | 1 +
+ src/udev/udev-builtin-net_setup_link.c    | 1 +
+ 15 files changed, 14 insertions(+), 4 deletions(-)
+
+diff --git a/src/libsystemd-network/sd-dhcp6-client.c b/src/libsystemd-network/sd-dhcp6-client.c
+index d7a5349c70..68b41dfb6c 100644
+--- a/src/libsystemd-network/sd-dhcp6-client.c
++++ b/src/libsystemd-network/sd-dhcp6-client.c
+@@ -6,7 +6,6 @@
+ #include <errno.h>
+ #include <string.h>
+ #include <sys/ioctl.h>
+-#include <linux/if_arp.h>
+ #include <linux/if_infiniband.h>
+ 
+ #include "sd-dhcp6-client.h"
+diff --git a/src/libsystemd/sd-netlink/netlink-types.c b/src/libsystemd/sd-netlink/netlink-types.c
+index de9b8b21ab..f64f6500f7 100644
+--- a/src/libsystemd/sd-netlink/netlink-types.c
++++ b/src/libsystemd/sd-netlink/netlink-types.c
+@@ -3,6 +3,7 @@
+ #include <netinet/in.h>
+ #include <stdint.h>
+ #include <sys/socket.h>
++#include <netinet/if_ether.h>
+ #include <linux/can/vxcan.h>
+ #include <linux/netlink.h>
+ #include <linux/rtnetlink.h>
+diff --git a/src/machine/machine-dbus.c b/src/machine/machine-dbus.c
+index 0d58b5eb8b..01093c1f62 100644
+--- a/src/machine/machine-dbus.c
++++ b/src/machine/machine-dbus.c
+@@ -4,6 +4,7 @@
+ #include <string.h>
+ #include <sys/mount.h>
+ #include <sys/wait.h>
++#include <netinet/if_ether.h>
+ 
+ /* When we include libgen.h because we need dirname() we immediately
+  * undefine basename() since libgen.h defines it as a macro to the POSIX
+diff --git a/src/network/netdev/macsec.c b/src/network/netdev/macsec.c
+index cf281e75a6..269dc618ff 100644
+--- a/src/network/netdev/macsec.c
++++ b/src/network/netdev/macsec.c
+@@ -1,5 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1+ */
+ 
++#include <netinet/if_ether.h>
+ #include <netinet/in.h>
+ #include <linux/if_ether.h>
+ #include <linux/if_macsec.h>
+diff --git a/src/network/netdev/netdev.c b/src/network/netdev/netdev.c
+index 7735b455b7..ed4eda4a44 100644
+--- a/src/network/netdev/netdev.c
++++ b/src/network/netdev/netdev.c
+@@ -1,5 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1+ */
+ 
++#include <netinet/if_ether.h>
+ #include <net/if.h>
+ #include <netinet/in.h>
+ 
+diff --git a/src/network/networkd-brvlan.c b/src/network/networkd-brvlan.c
+index c3c5d535ac..ebea408c89 100644
+--- a/src/network/networkd-brvlan.c
++++ b/src/network/networkd-brvlan.c
+@@ -4,6 +4,7 @@
+ ***/
+ 
+ #include <netinet/in.h>
++#include <netinet/if_ether.h>
+ #include <linux/if_bridge.h>
+ #include <stdbool.h>
+ 
+diff --git a/src/network/networkd-dhcp-common.c b/src/network/networkd-dhcp-common.c
+index 626b975839..42fe92f320 100644
+--- a/src/network/networkd-dhcp-common.c
++++ b/src/network/networkd-dhcp-common.c
+@@ -1,6 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1+ */
+ 
+ #include "networkd-dhcp-common.h"
++#include <netinet/if_ether.h>
+ #include "networkd-network.h"
+ #include "parse-util.h"
+ #include "string-table.h"
+diff --git a/src/network/networkd-dhcp4.c b/src/network/networkd-dhcp4.c
+index 662770b50e..c6ab62a94d 100644
+--- a/src/network/networkd-dhcp4.c
++++ b/src/network/networkd-dhcp4.c
+@@ -1,8 +1,8 @@
+ /* SPDX-License-Identifier: LGPL-2.1+ */
+ 
++#include <netinet/if_ether.h>
+ #include <netinet/in.h>
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
+ 
+ #include "alloc-util.h"
+ #include "hostname-util.h"
+diff --git a/src/network/networkd-dhcp6.c b/src/network/networkd-dhcp6.c
+index 8ad736a82b..f41b4d834e 100644
+--- a/src/network/networkd-dhcp6.c
++++ b/src/network/networkd-dhcp6.c
+@@ -3,9 +3,9 @@
+   Copyright © 2014 Intel Corporation. All rights reserved.
+ ***/
+ 
++#include <netinet/if_ether.h>
+ #include <netinet/in.h>
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
+ #include "sd-radv.h"
+ 
+ #include "sd-dhcp6-client.h"
+diff --git a/src/network/networkd-link.c b/src/network/networkd-link.c
+index f5bb78890a..f13a36b791 100644
+--- a/src/network/networkd-link.c
++++ b/src/network/networkd-link.c
+@@ -1,8 +1,8 @@
+ /* SPDX-License-Identifier: LGPL-2.1+ */
+ 
++#include <netinet/if_ether.h>
+ #include <netinet/in.h>
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
+ #include <unistd.h>
+ 
+ #include "alloc-util.h"
+diff --git a/src/network/networkd-network.c b/src/network/networkd-network.c
+index 2b8d0eb2fb..2f79ef25cd 100644
+--- a/src/network/networkd-network.c
++++ b/src/network/networkd-network.c
+@@ -1,5 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1+ */
+ 
++#include <netinet/if_ether.h>
+ #include <net/if.h>
+ #include <netinet/in.h>
+ #include <linux/netdevice.h>
+diff --git a/src/shared/ethtool-util.c b/src/shared/ethtool-util.c
+index b0961df72e..53fcbbd84b 100644
+--- a/src/shared/ethtool-util.c
++++ b/src/shared/ethtool-util.c
+@@ -1,5 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1+ */
+ 
++#include <netinet/if_ether.h>
+ #include <net/if.h>
+ #include <sys/ioctl.h>
+ #include <linux/ethtool.h>
+diff --git a/src/shared/ethtool-util.h b/src/shared/ethtool-util.h
+index 8b32b243f3..262b819976 100644
+--- a/src/shared/ethtool-util.h
++++ b/src/shared/ethtool-util.h
+@@ -2,6 +2,7 @@
+ #pragma once
+ 
+ #include <macro.h>
++#include <netinet/if_ether.h>
+ #include <linux/ethtool.h>
+ 
+ #include "conf-parser.h"
+diff --git a/src/udev/net/link-config.c b/src/udev/net/link-config.c
+index d44af64d5e..fd052f1591 100644
+--- a/src/udev/net/link-config.c
++++ b/src/udev/net/link-config.c
+@@ -1,5 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1+ */
+ 
++#include <netinet/if_ether.h>
+ #include <linux/netdevice.h>
+ #include <netinet/ether.h>
+ 
+diff --git a/src/udev/udev-builtin-net_setup_link.c b/src/udev/udev-builtin-net_setup_link.c
+index ee3ca9fa38..9aa4e82874 100644
+--- a/src/udev/udev-builtin-net_setup_link.c
++++ b/src/udev/udev-builtin-net_setup_link.c
+@@ -1,5 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1+ */
+ 
++#include <netinet/if_ether.h>
+ #include "device-util.h"
+ #include "alloc-util.h"
+ #include "link-config.h"

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0007-don-t-fail-if-GLOB_BRACE-and-GLOB_ALTDIRFUNC-is-not.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0007-don-t-fail-if-GLOB_BRACE-and-GLOB_ALTDIRFUNC-is-not.patch
@@ -1,0 +1,153 @@
+From f8a239b182158ca0a537ba053cb0e6bad9c3a2fb Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 14:56:21 +0800
+Subject: [PATCH 07/24] don't fail if GLOB_BRACE and GLOB_ALTDIRFUNC is not 
+ defined
+
+If the standard library doesn't provide brace
+expansion users just won't get it.
+
+Dont use GNU GLOB extentions on non-glibc systems
+
+Conditionalize use of GLOB_ALTDIRFUNC
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ src/basic/glob-util.c     | 12 ++++++++++++
+ src/test/test-glob-util.c | 16 ++++++++++++++++
+ src/tmpfiles/tmpfiles.c   | 10 ++++++++++
+ 3 files changed, 38 insertions(+)
+
+diff --git a/src/basic/glob-util.c b/src/basic/glob-util.c
+index b335af8d97..2cdfc11f16 100644
+--- a/src/basic/glob-util.c
++++ b/src/basic/glob-util.c
+@@ -14,6 +14,12 @@
+ #include "path-util.h"
+ #include "strv.h"
+ 
++/* Don't fail if the standard library
++ * doesn't provide brace expansion */
++#ifndef GLOB_BRACE
++#define GLOB_BRACE 0
++#endif
++
+ static void closedir_wrapper(void* v) {
+         (void) closedir(v);
+ }
+@@ -21,6 +27,7 @@ static void closedir_wrapper(void* v) {
+ int safe_glob(const char *path, int flags, glob_t *pglob) {
+         int k;
+ 
++#ifdef GLOB_ALTDIRFUNC
+         /* We want to set GLOB_ALTDIRFUNC ourselves, don't allow it to be set. */
+         assert(!(flags & GLOB_ALTDIRFUNC));
+ 
+@@ -34,9 +41,14 @@ int safe_glob(const char *path, int flags, glob_t *pglob) {
+                 pglob->gl_lstat = lstat;
+         if (!pglob->gl_stat)
+                 pglob->gl_stat = stat;
++#endif
+ 
+         errno = 0;
++#ifdef GLOB_ALTDIRFUNC
+         k = glob(path, flags | GLOB_ALTDIRFUNC, NULL, pglob);
++#else
++        k = glob(path, flags, NULL, pglob);
++#endif
+         if (k == GLOB_NOMATCH)
+                 return -ENOENT;
+         if (k == GLOB_NOSPACE)
+diff --git a/src/test/test-glob-util.c b/src/test/test-glob-util.c
+index b4f41445fe..f0d474ed14 100644
+--- a/src/test/test-glob-util.c
++++ b/src/test/test-glob-util.c
+@@ -13,6 +13,12 @@
+ #include "rm-rf.h"
+ #include "tmpfile-util.h"
+ 
++/* Don't fail if the standard library
++ * doesn't provide brace expansion */
++#ifndef GLOB_BRACE
++#define GLOB_BRACE 0
++#endif
++
+ static void test_glob_exists(void) {
+         char name[] = "/tmp/test-glob_exists.XXXXXX";
+         int fd = -1;
+@@ -40,11 +46,13 @@ static void test_glob_no_dot(void) {
+         const char *fn;
+ 
+         _cleanup_globfree_ glob_t g = {
++#ifdef GLOB_ALTDIRFUNC
+                 .gl_closedir = closedir_wrapper,
+                 .gl_readdir = (struct dirent *(*)(void *)) readdir_no_dot,
+                 .gl_opendir = (void *(*)(const char *)) opendir,
+                 .gl_lstat = lstat,
+                 .gl_stat = stat,
++#endif
+         };
+ 
+         int r;
+@@ -52,11 +60,19 @@ static void test_glob_no_dot(void) {
+         assert_se(mkdtemp(template));
+ 
+         fn = strjoina(template, "/*");
++#ifdef GLOB_ALTDIRFUNC
+         r = glob(fn, GLOB_NOSORT|GLOB_BRACE|GLOB_ALTDIRFUNC, NULL, &g);
++#else
++        r = glob(fn, GLOB_NOSORT|GLOB_BRACE, NULL, &g);
++#endif
+         assert_se(r == GLOB_NOMATCH);
+ 
+         fn = strjoina(template, "/.*");
++#ifdef GLOB_ALTDIRFUNC
+         r = glob(fn, GLOB_NOSORT|GLOB_BRACE|GLOB_ALTDIRFUNC, NULL, &g);
++#else
++        r = glob(fn, GLOB_NOSORT|GLOB_BRACE, NULL, &g);
++#endif
+         assert_se(r == GLOB_NOMATCH);
+ 
+         (void) rm_rf(template, REMOVE_ROOT|REMOVE_PHYSICAL);
+diff --git a/src/tmpfiles/tmpfiles.c b/src/tmpfiles/tmpfiles.c
+index 3c30612af1..14bc428085 100644
+--- a/src/tmpfiles/tmpfiles.c
++++ b/src/tmpfiles/tmpfiles.c
+@@ -63,6 +63,12 @@
+ #include "umask-util.h"
+ #include "user-util.h"
+ 
++/* Don't fail if the standard library
++ * doesn't provide brace expansion */
++#ifndef GLOB_BRACE
++#define GLOB_BRACE 0
++#endif
++
+ /* This reads all files listed in /etc/tmpfiles.d/?*.conf and creates
+  * them in the file system. This is intended to be used to create
+  * properly owned directories beneath /tmp, /var/tmp, /run, which are
+@@ -1853,7 +1859,9 @@ finish:
+ 
+ static int glob_item(Item *i, action_t action) {
+         _cleanup_globfree_ glob_t g = {
++#ifdef GLOB_ALTDIRFUNC
+                 .gl_opendir = (void *(*)(const char *)) opendir_nomod,
++#endif
+         };
+         int r = 0, k;
+         char **fn;
+@@ -1873,7 +1881,9 @@ static int glob_item(Item *i, action_t action) {
+ 
+ static int glob_item_recursively(Item *i, fdaction_t action) {
+         _cleanup_globfree_ glob_t g = {
++#ifdef GLOB_ALTDIRFUNC
+                 .gl_opendir = (void *(*)(const char *)) opendir_nomod,
++#endif
+         };
+         int r = 0, k;
+         char **fn;

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0008-add-missing-FTW_-macros-for-musl.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0008-add-missing-FTW_-macros-for-musl.patch
@@ -1,0 +1,47 @@
+From 6cd17c753d2c0a90fc791f69bbc694cbc8556a4f Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 15:00:06 +0800
+Subject: [PATCH 08/24] add missing FTW_ macros for musl
+
+This is to avoid build failures like below for musl.
+
+  locale-util.c:296:24: error: 'FTW_STOP' undeclared
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/basic/missing_type.h | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/src/basic/missing_type.h b/src/basic/missing_type.h
+index c487e65..23602eb 100644
+--- a/src/basic/missing_type.h
++++ b/src/basic/missing_type.h
+@@ -19,3 +19,23 @@ typedef int (*comparison_fn_t)(const void *, const void *);
+ #define __COMPAR_FN_T
+ typedef int (*__compar_fn_t)(const void *, const void *);
+ #endif
++
++#ifndef FTW_ACTIONRETVAL
++#define FTW_ACTIONRETVAL 16
++#endif
++
++#ifndef FTW_CONTINUE
++#define FTW_CONTINUE 0
++#endif
++
++#ifndef FTW_STOP
++#define FTW_STOP 1
++#endif
++
++#ifndef FTW_SKIP_SUBTREE
++#define FTW_SKIP_SUBTREE 2
++#endif
++
++#ifndef FTW_SKIP_SIBLINGS
++#define FTW_SKIP_SIBLINGS 3
++#endif
+-- 
+2.7.4
+

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0010-fix-missing-of-__register_atfork-for-non-glibc-build.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0010-fix-missing-of-__register_atfork-for-non-glibc-build.patch
@@ -1,0 +1,45 @@
+From f1f4b4f9684fed185bfa8b9ed409cdf241657e99 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 15:03:47 +0800
+Subject: [PATCH 10/24] fix missing of __register_atfork for non-glibc builds
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/basic/process-util.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/basic/process-util.c b/src/basic/process-util.c
+index 78ce43b..aec2daf 100644
+--- a/src/basic/process-util.c
++++ b/src/basic/process-util.c
+@@ -22,6 +22,9 @@
+ #if HAVE_VALGRIND_VALGRIND_H
+ #include <valgrind/valgrind.h>
+ #endif
++#ifndef __GLIBC__
++#include <pthread.h>
++#endif
+ 
+ #include "alloc-util.h"
+ #include "architecture.h"
+@@ -1160,11 +1163,15 @@ void reset_cached_pid(void) {
+         cached_pid = CACHED_PID_UNSET;
+ }
+ 
++#ifdef __GLIBC__
+ /* We use glibc __register_atfork() + __dso_handle directly here, as they are not included in the glibc
+  * headers. __register_atfork() is mostly equivalent to pthread_atfork(), but doesn't require us to link against
+  * libpthread, as it is part of glibc anyway. */
+ extern int __register_atfork(void (*prepare) (void), void (*parent) (void), void (*child) (void), void *dso_handle);
+ extern void* __dso_handle _weak_;
++#else
++#define __register_atfork(prepare,parent,child,dso) pthread_atfork(prepare,parent,child)
++#endif
+ 
+ pid_t getpid_cached(void) {
+         static bool installed = false;
+-- 
+2.7.4
+

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0011-Use-uintmax_t-for-handling-rlim_t.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0011-Use-uintmax_t-for-handling-rlim_t.patch
@@ -1,0 +1,97 @@
+From e3f847bd0338d27aff3335b42661d8a4b66b965e Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 15:12:41 +0800
+Subject: [PATCH 11/24] Use uintmax_t for handling rlim_t
+
+PRIu{32,64} is not right format to represent rlim_t type
+therefore use %ju and typecast the rlim_t variables to
+uintmax_t.
+
+Fixes portablility errors like
+
+execute.c:3446:36: error: format '%lu' expects argument of type 'long unsigned int', but argument 5 has type 'rlim_t {aka long long unsigned int}' [-Werror=format=]
+|                          fprintf(f, "%s%s: " RLIM_FMT "\n",
+|                                     ^~~~~~~~
+|                                  prefix, rlimit_to_string(i), c->rlimit[i]->rlim_max);
+|                                                               ~~~~~~~~~~~~~~~~~~~~~~
+
+Upstream-Status: Denied [https://github.com/systemd/systemd/pull/7199]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+[Rebased for v241]
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/basic/format-util.h |  8 +-------
+ src/basic/rlimit-util.c | 10 +++++-----
+ src/core/execute.c      |  4 ++--
+ 3 files changed, 8 insertions(+), 14 deletions(-)
+
+diff --git a/src/basic/format-util.h b/src/basic/format-util.h
+index dece5d3..dbb87bc 100644
+--- a/src/basic/format-util.h
++++ b/src/basic/format-util.h
+@@ -42,13 +42,7 @@
+ #  define PRI_TIMEX "li"
+ #endif
+ 
+-#if SIZEOF_RLIM_T == 8
+-#  define RLIM_FMT "%" PRIu64
+-#elif SIZEOF_RLIM_T == 4
+-#  define RLIM_FMT "%" PRIu32
+-#else
+-#  error Unknown rlim_t size
+-#endif
++#define RLIM_FMT "%ju"
+ 
+ #if SIZEOF_DEV_T == 8
+ #  define DEV_FMT "%" PRIu64
+diff --git a/src/basic/rlimit-util.c b/src/basic/rlimit-util.c
+index 74b3a02..b02c03c 100644
+--- a/src/basic/rlimit-util.c
++++ b/src/basic/rlimit-util.c
+@@ -307,13 +307,13 @@ int rlimit_format(const struct rlimit *rl, char **ret) {
+         if (rl->rlim_cur >= RLIM_INFINITY && rl->rlim_max >= RLIM_INFINITY)
+                 s = strdup("infinity");
+         else if (rl->rlim_cur >= RLIM_INFINITY)
+-                (void) asprintf(&s, "infinity:" RLIM_FMT, rl->rlim_max);
++                (void) asprintf(&s, "infinity:" RLIM_FMT, (uintmax_t)rl->rlim_max);
+         else if (rl->rlim_max >= RLIM_INFINITY)
+-                (void) asprintf(&s, RLIM_FMT ":infinity", rl->rlim_cur);
++                (void) asprintf(&s, RLIM_FMT ":infinity", (uintmax_t)rl->rlim_cur);
+         else if (rl->rlim_cur == rl->rlim_max)
+-                (void) asprintf(&s, RLIM_FMT, rl->rlim_cur);
++                (void) asprintf(&s, RLIM_FMT, (uintmax_t)rl->rlim_cur);
+         else
+-                (void) asprintf(&s, RLIM_FMT ":" RLIM_FMT, rl->rlim_cur, rl->rlim_max);
++                (void) asprintf(&s, RLIM_FMT ":" RLIM_FMT, (uintmax_t)rl->rlim_cur, (uintmax_t)rl->rlim_max);
+ 
+         if (!s)
+                 return -ENOMEM;
+@@ -404,7 +404,7 @@ int rlimit_nofile_safe(void) {
+ 
+         rl.rlim_cur = FD_SETSIZE;
+         if (setrlimit(RLIMIT_NOFILE, &rl) < 0)
+-                return log_debug_errno(errno, "Failed to lower RLIMIT_NOFILE's soft limit to " RLIM_FMT ": %m", rl.rlim_cur);
++                return log_debug_errno(errno, "Failed to lower RLIMIT_NOFILE's soft limit to " RLIM_FMT ": %m", (uintmax_t)rl.rlim_cur);
+ 
+         return 1;
+ }
+diff --git a/src/core/execute.c b/src/core/execute.c
+index a708231..e2b8748 100644
+--- a/src/core/execute.c
++++ b/src/core/execute.c
+@@ -4220,9 +4220,9 @@ void exec_context_dump(const ExecContext *c, FILE* f, const char *prefix) {
+         for (i = 0; i < RLIM_NLIMITS; i++)
+                 if (c->rlimit[i]) {
+                         fprintf(f, "%sLimit%s: " RLIM_FMT "\n",
+-                                prefix, rlimit_to_string(i), c->rlimit[i]->rlim_max);
++                                prefix, rlimit_to_string(i), (uintmax_t)c->rlimit[i]->rlim_max);
+                         fprintf(f, "%sLimit%sSoft: " RLIM_FMT "\n",
+-                                prefix, rlimit_to_string(i), c->rlimit[i]->rlim_cur);
++                                prefix, rlimit_to_string(i), (uintmax_t)c->rlimit[i]->rlim_cur);
+                 }
+ 
+         if (c->ioprio_set) {
+-- 
+2.7.4
+

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0014-test-sizeof.c-Disable-tests-for-missing-typedefs-in-.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0014-test-sizeof.c-Disable-tests-for-missing-typedefs-in-.patch
@@ -1,0 +1,42 @@
+From d3d65d4036670cbd5129fe55c09ca391286ef4b3 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Wed, 28 Feb 2018 21:25:22 -0800
+Subject: [PATCH 14/24] test-sizeof.c: Disable tests for missing typedefs in
+ musl
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/test/test-sizeof.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/test/test-sizeof.c b/src/test/test-sizeof.c
+index 35b0876..e78e7ca 100644
+--- a/src/test/test-sizeof.c
++++ b/src/test/test-sizeof.c
+@@ -41,8 +41,10 @@ int main(void) {
+         info(unsigned);
+         info(long unsigned);
+         info(long long unsigned);
++#ifdef __GLIBC__
+         info(__syscall_ulong_t);
+         info(__syscall_slong_t);
++#endif
+ 
+         info(float);
+         info(double);
+@@ -60,7 +62,9 @@ int main(void) {
+         info(ssize_t);
+         info(time_t);
+         info(usec_t);
++#ifdef __GLIBC__
+         info(__time_t);
++#endif
+         info(pid_t);
+         info(uid_t);
+         info(gid_t);
+-- 
+2.7.4
+

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0015-don-t-pass-AT_SYMLINK_NOFOLLOW-flag-to-faccessat.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0015-don-t-pass-AT_SYMLINK_NOFOLLOW-flag-to-faccessat.patch
@@ -1,0 +1,99 @@
+From 48c628f532f6025c2d1646b6819cd81eb789d7fb Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Tue, 10 Oct 2017 14:33:30 -0700
+Subject: [PATCH 15/24] don't pass AT_SYMLINK_NOFOLLOW flag to faccessat()
+
+Avoid using AT_SYMLINK_NOFOLLOW flag. It doesn't seem like the right
+thing to do and it's not portable (not supported by musl). See:
+
+  http://lists.landley.net/pipermail/toybox-landley.net/2014-September/003610.html
+  http://www.openwall.com/lists/musl/2015/02/05/2
+
+Note that laccess() is never passing AT_EACCESS so a lot of the
+discussion in the links above doesn't apply. Note also that
+(currently) all systemd callers of laccess() pass mode as F_OK, so
+only check for existence of a file, not access permissions.
+Therefore, in this case, the only distiction between faccessat()
+with (flag == 0) and (flag == AT_SYMLINK_NOFOLLOW) is the behaviour
+for broken symlinks; laccess() on a broken symlink will succeed with
+(flag == AT_SYMLINK_NOFOLLOW) and fail (flag == 0).
+
+The laccess() macros was added to systemd some time ago and it's not
+clear if or why it needs to return success for broken symlinks. Maybe
+just historical and not actually necessary or desired behaviour?
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+---
+ src/basic/fs-util.h          | 22 +++++++++++++++++++++-
+ src/shared/base-filesystem.c |  6 +++---
+ 2 files changed, 24 insertions(+), 4 deletions(-)
+
+diff --git a/src/basic/fs-util.h b/src/basic/fs-util.h
+index 7ad030b..d4cb1e9 100644
+--- a/src/basic/fs-util.h
++++ b/src/basic/fs-util.h
+@@ -32,7 +32,27 @@ int fchmod_opath(int fd, mode_t m);
+ 
+ int fd_warn_permissions(const char *path, int fd);
+ 
+-#define laccess(path, mode) faccessat(AT_FDCWD, (path), (mode), AT_SYMLINK_NOFOLLOW)
++/*
++   Avoid using AT_SYMLINK_NOFOLLOW flag. It doesn't seem like the right thing to
++   do and it's not portable (not supported by musl). See:
++
++     http://lists.landley.net/pipermail/toybox-landley.net/2014-September/003610.html
++     http://www.openwall.com/lists/musl/2015/02/05/2
++
++   Note that laccess() is never passing AT_EACCESS so a lot of the discussion in
++   the links above doesn't apply. Note also that (currently) all systemd callers
++   of laccess() pass mode as F_OK, so only check for existence of a file, not
++   access permissions. Therefore, in this case, the only distiction between
++   faccessat() with (flag == 0) and (flag == AT_SYMLINK_NOFOLLOW) is the
++   behaviour for broken symlinks; laccess() on a broken symlink will succeed
++   with (flag == AT_SYMLINK_NOFOLLOW) and fail (flag == 0).
++
++   The laccess() macros was added to systemd some time ago and it's not clear if
++   or why it needs to return success for broken symlinks. Maybe just historical
++   and not actually necessary or desired behaviour?
++*/
++
++#define laccess(path, mode) faccessat(AT_FDCWD, (path), (mode), 0)
+ 
+ int touch_file(const char *path, bool parents, usec_t stamp, uid_t uid, gid_t gid, mode_t mode);
+ int touch(const char *path);
+diff --git a/src/shared/base-filesystem.c b/src/shared/base-filesystem.c
+index 89d7a7d..34b4ad5 100644
+--- a/src/shared/base-filesystem.c
++++ b/src/shared/base-filesystem.c
+@@ -53,7 +53,7 @@ int base_filesystem_create(const char *root, uid_t uid, gid_t gid) {
+                 return log_error_errno(errno, "Failed to open root file system: %m");
+ 
+         for (i = 0; i < ELEMENTSOF(table); i ++) {
+-                if (faccessat(fd, table[i].dir, F_OK, AT_SYMLINK_NOFOLLOW) >= 0)
++                if (faccessat(fd, table[i].dir, F_OK, 0) >= 0)
+                         continue;
+ 
+                 if (table[i].target) {
+@@ -61,7 +61,7 @@ int base_filesystem_create(const char *root, uid_t uid, gid_t gid) {
+ 
+                         /* check if one of the targets exists */
+                         NULSTR_FOREACH(s, table[i].target) {
+-                                if (faccessat(fd, s, F_OK, AT_SYMLINK_NOFOLLOW) < 0)
++                                if (faccessat(fd, s, F_OK, 0) < 0)
+                                         continue;
+ 
+                                 /* check if a specific file exists at the target path */
+@@ -72,7 +72,7 @@ int base_filesystem_create(const char *root, uid_t uid, gid_t gid) {
+                                         if (!p)
+                                                 return log_oom();
+ 
+-                                        if (faccessat(fd, p, F_OK, AT_SYMLINK_NOFOLLOW) < 0)
++                                        if (faccessat(fd, p, F_OK, 0) < 0)
+                                                 continue;
+                                 }
+ 
+-- 
+2.7.4
+

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0016-Define-glibc-compatible-basename-for-non-glibc-syste.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0016-Define-glibc-compatible-basename-for-non-glibc-syste.patch
@@ -1,0 +1,34 @@
+From af76c973e41929360a6e021f2ff9a7fc1d7994e9 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 27 May 2018 08:36:44 -0700
+Subject: [PATCH 16/24] Define glibc compatible basename() for non-glibc
+ systems
+
+Fixes builds with musl, even though systemd is adamant about
+using non-posix basename implementation, we have a way out
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/machine/machine-dbus.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/machine/machine-dbus.c b/src/machine/machine-dbus.c
+index 7a558df..eca7d4b 100644
+--- a/src/machine/machine-dbus.c
++++ b/src/machine/machine-dbus.c
+@@ -11,6 +11,10 @@
+ #include <libgen.h>
+ #undef basename
+ 
++#if !defined(__GLIBC__)
++#define basename(src) (strrchr(src,'/') ? strrchr(src,'/')+1 : src)
++#endif
++
+ #include "alloc-util.h"
+ #include "bus-common-errors.h"
+ #include "bus-internal.h"
+-- 
+2.7.4
+

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0017-Do-not-disable-buffering-when-writing-to-oom_score_a.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0017-Do-not-disable-buffering-when-writing-to-oom_score_a.patch
@@ -1,0 +1,38 @@
+From c7a4efb8bccb52e1714c151929c23e12bde59b82 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Wed, 4 Jul 2018 15:00:44 +0800
+Subject: [PATCH 17/24] Do not disable buffering when writing to oom_score_adj
+
+On musl, disabling buffering when writing to oom_score_adj will
+cause the following error.
+
+  Failed to adjust OOM setting: Invalid argument
+
+This error appears for systemd-udevd.service and dbus.service.
+This is because kernel receives '-' instead of the whole '-900'
+if buffering is disabled.
+
+This is libc implementation specific, as glibc does not have this issue.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ src/basic/process-util.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/basic/process-util.c b/src/basic/process-util.c
+index b1c08fcade..0a7a1f7d89 100644
+--- a/src/basic/process-util.c
++++ b/src/basic/process-util.c
+@@ -1474,7 +1474,7 @@ int set_oom_score_adjust(int value) {
+         sprintf(t, "%i", value);
+ 
+         return write_string_file("/proc/self/oom_score_adj", t,
+-                                 WRITE_STRING_FILE_VERIFY_ON_FAILURE|WRITE_STRING_FILE_DISABLE_BUFFER);
++                                 WRITE_STRING_FILE_VERIFY_ON_FAILURE);
+ }
+ 
+ static const char *const ioprio_class_table[] = {

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0018-distinguish-XSI-compliant-strerror_r-from-GNU-specif.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0018-distinguish-XSI-compliant-strerror_r-from-GNU-specif.patch
@@ -1,0 +1,62 @@
+From fffb2810611b4a26f5c6c0958093b5b3b7d4cd99 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Tue, 10 Jul 2018 15:40:17 +0800
+Subject: [PATCH 18/24] distinguish XSI-compliant strerror_r from GNU-specifi
+ strerror_r
+
+XSI-compliant strerror_r and GNU-specifi strerror_r are different.
+
+       int strerror_r(int errnum, char *buf, size_t buflen);
+                   /* XSI-compliant */
+
+       char *strerror_r(int errnum, char *buf, size_t buflen);
+                   /* GNU-specific */
+
+We need to distinguish between them. Otherwise, we'll get an int value
+assigned to (char *) variable, resulting in segment fault.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/journal/journal-send.c        | 5 +++++
+ src/libsystemd/sd-bus/bus-error.c | 5 +++++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/src/journal/journal-send.c b/src/journal/journal-send.c
+index 3fea912..4f1e592 100644
+--- a/src/journal/journal-send.c
++++ b/src/journal/journal-send.c
+@@ -337,7 +337,12 @@ static int fill_iovec_perror_and_send(const char *message, int skip, struct iove
+                 char* j;
+ 
+                 errno = 0;
++#ifndef __GLIBC__
++                strerror_r(_saved_errno_, buffer + 8 + k, n - 8 - k);
++                j = buffer + 8 + k;
++#else
+                 j = strerror_r(_saved_errno_, buffer + 8 + k, n - 8 - k);
++#endif
+                 if (errno == 0) {
+                         char error[STRLEN("ERRNO=") + DECIMAL_STR_MAX(int) + 1];
+ 
+diff --git a/src/libsystemd/sd-bus/bus-error.c b/src/libsystemd/sd-bus/bus-error.c
+index dc95237..bdda30f 100644
+--- a/src/libsystemd/sd-bus/bus-error.c
++++ b/src/libsystemd/sd-bus/bus-error.c
+@@ -379,7 +379,12 @@ static void bus_error_strerror(sd_bus_error *e, int error) {
+                         return;
+ 
+                 errno = 0;
++#ifndef __GLIBC__
++                strerror_r(error, m, k);
++                x = m;
++#else
+                 x = strerror_r(error, m, k);
++#endif
+                 if (errno == ERANGE || strlen(x) >= k - 1) {
+                         free(m);
+                         k *= 2;
+-- 
+2.7.4
+

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0019-Hide-__start_BUS_ERROR_MAP-and-__stop_BUS_ERROR_MAP.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0019-Hide-__start_BUS_ERROR_MAP-and-__stop_BUS_ERROR_MAP.patch
@@ -1,0 +1,35 @@
+From 969ab9e68249fd383f4b513b1c9306bdac4ae9b2 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 15:18:00 +0800
+Subject: [PATCH 19/24] Hide __start_BUS_ERROR_MAP and __stop_BUS_ERROR_MAP
+
+for currently unknown reasons they get exported to the shared libries
+even without being listed in the sym file
+
+Upstream-Status: Pending
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+[Rebased for v241]
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/libsystemd/sd-bus/bus-error.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/libsystemd/sd-bus/bus-error.c b/src/libsystemd/sd-bus/bus-error.c
+index bdda30f..e21853c 100644
+--- a/src/libsystemd/sd-bus/bus-error.c
++++ b/src/libsystemd/sd-bus/bus-error.c
+@@ -54,8 +54,8 @@ BUS_ERROR_MAP_ELF_REGISTER const sd_bus_error_map bus_standard_errors[] = {
+ };
+ 
+ /* GCC maps this magically to the beginning and end of the BUS_ERROR_MAP section */
+-extern const sd_bus_error_map __start_SYSTEMD_BUS_ERROR_MAP[];
+-extern const sd_bus_error_map __stop_SYSTEMD_BUS_ERROR_MAP[];
++extern const sd_bus_error_map __start_SYSTEMD_BUS_ERROR_MAP[] _hidden_;
++extern const sd_bus_error_map __stop_SYSTEMD_BUS_ERROR_MAP[] _hidden_;
+ 
+ /* Additional maps registered with sd_bus_error_add_map() are in this
+  * NULL terminated array */
+-- 
+2.7.4
+

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0020-missing_type.h-add-__compar_d_fn_t-definition.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0020-missing_type.h-add-__compar_d_fn_t-definition.patch
@@ -1,0 +1,30 @@
+From 75c06e3e2a4760b36fffd95cdf5535b8ad73c481 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 15:27:54 +0800
+Subject: [PATCH 20/24] missing_type.h: add __compar_d_fn_t definition
+
+Fix the following compile failure:
+src/basic/util.h:71:18: error: unknown type name '__compar_d_fn_t'; did you mean '__compar_fn_t'?
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/basic/missing_type.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/basic/missing_type.h b/src/basic/missing_type.h
+index 7d7c1e4..85902ab 100644
+--- a/src/basic/missing_type.h
++++ b/src/basic/missing_type.h
+@@ -13,6 +13,7 @@
+ 
+ #ifndef __GLIBC__
+ typedef int (*comparison_fn_t)(const void *, const void *);
++typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+ #endif
+ 
+ #ifndef __COMPAR_FN_T
+-- 
+2.7.4
+

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0021-avoid-redefinition-of-prctl_mm_map-structure.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0021-avoid-redefinition-of-prctl_mm_map-structure.patch
@@ -1,0 +1,32 @@
+From 3fbf61d54b82fc9bf21d8039bfd89dc9efc5bbcd Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 15:44:54 +0800
+Subject: [PATCH 21/24] avoid redefinition of prctl_mm_map structure
+
+Fix the following compile failure:
+error: redefinition of 'struct prctl_mm_map'
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/basic/missing_prctl.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/basic/missing_prctl.h b/src/basic/missing_prctl.h
+index f80cd17..47e4893 100644
+--- a/src/basic/missing_prctl.h
++++ b/src/basic/missing_prctl.h
+@@ -1,7 +1,9 @@
+ /* SPDX-License-Identifier: LGPL-2.1+ */
+ #pragma once
+ 
++#ifdef __GLIBC__
+ #include <linux/prctl.h>
++#endif
+ 
+ /* 58319057b7847667f0c9585b9de0e8932b0fdb08 (4.3) */
+ #ifndef PR_CAP_AMBIENT
+-- 
+2.11.0
+

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0024-test-json.c-define-M_PIl.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/0024-test-json.c-define-M_PIl.patch
@@ -1,0 +1,33 @@
+From 902412c271e0c5d9cb93b10ec0fb5b119b393474 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 16:53:06 +0800
+Subject: [PATCH 24/24] test-json.c: define M_PIl
+
+Fix the following compile failure:
+src/test/test-json.c:305:50: error: 'M_PIl' undeclared (first use in this function); did you mean 'M_PI'?
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/test/test-json.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/test/test-json.c b/src/test/test-json.c
+index 9b8a2a9..efc746c 100644
+--- a/src/test/test-json.c
++++ b/src/test/test-json.c
+@@ -11,6 +11,10 @@
+ #include "tests.h"
+ #include "util.h"
+ 
++#ifndef M_PIl
++#define M_PIl 3.141592653589793238462643383279502884L
++#endif
++
+ static void test_tokenizer(const char *data, ...) {
+         unsigned line = 0, column = 0;
+         void *state = NULL;
+-- 
+2.11.0
+

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/static-libsystemd-pkgconfig.patch
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd-243/static-libsystemd-pkgconfig.patch
@@ -1,0 +1,11 @@
+Index: git/src/libsystemd/libsystemd.pc.in
+===================================================================
+--- git.orig/src/libsystemd/libsystemd.pc.in
++++ git/src/libsystemd/libsystemd.pc.in
+@@ -16,5 +16,5 @@ Name: systemd
+ Description: systemd Library
+ URL: @PROJECT_URL@
+ Version: @PROJECT_VERSION@
+-Libs: -L${libdir} -lsystemd
++Libs: -L${libdir} -lsystemd -lrt -lmount -lcap
+ Cflags: -I${includedir}

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd_243.bb
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd_243.bb
@@ -1,0 +1,69 @@
+SUMMARY = "libsystemd static library"
+DESCRIPTION = "libsystemd static library built specifically as an integral component of sdbus-c++"
+
+SECTION = "libs"
+
+LICENSE = "LGPLv2.1+"
+LIC_FILES_CHKSUM = "file://LICENSE.LGPL2.1;md5=4fbd65380cdd255951079008b364516c"
+
+inherit meson pkgconfig
+
+DEPENDS += "gperf-native gettext-native util-linux libcap"
+
+SRCREV = "efb536d0cbe2e58f80e501d19999928c75e08f6a"
+SRCBRANCH = "v243-stable"
+SRC_URI = "git://github.com/systemd/systemd-stable.git;protocol=git;branch=${SRCBRANCH}"
+
+SRC_URI += "file://static-libsystemd-pkgconfig.patch"
+
+# patches needed by musl
+SRC_URI_append_libc-musl = " ${SRC_URI_MUSL}"
+SRC_URI_MUSL = "\
+               file://0002-don-t-use-glibc-specific-qsort_r.patch \
+               file://0003-missing_type.h-add-__compare_fn_t-and-comparison_fn_.patch \
+               file://0004-add-fallback-parse_printf_format-implementation.patch \
+               file://0005-src-basic-missing.h-check-for-missing-strndupa.patch \
+               file://0006-Include-netinet-if_ether.h.patch \
+               file://0007-don-t-fail-if-GLOB_BRACE-and-GLOB_ALTDIRFUNC-is-not.patch \
+               file://0008-add-missing-FTW_-macros-for-musl.patch \
+               file://0010-fix-missing-of-__register_atfork-for-non-glibc-build.patch \
+               file://0011-Use-uintmax_t-for-handling-rlim_t.patch \
+               file://0014-test-sizeof.c-Disable-tests-for-missing-typedefs-in-.patch \
+               file://0015-don-t-pass-AT_SYMLINK_NOFOLLOW-flag-to-faccessat.patch \
+               file://0016-Define-glibc-compatible-basename-for-non-glibc-syste.patch \
+               file://0017-Do-not-disable-buffering-when-writing-to-oom_score_a.patch \
+               file://0018-distinguish-XSI-compliant-strerror_r-from-GNU-specif.patch \
+               file://0019-Hide-__start_BUS_ERROR_MAP-and-__stop_BUS_ERROR_MAP.patch \
+               file://0020-missing_type.h-add-__compar_d_fn_t-definition.patch \
+               file://0021-avoid-redefinition-of-prctl_mm_map-structure.patch \
+               file://0024-test-json.c-define-M_PIl.patch \
+               file://0001-do-not-disable-buffer-in-writing-files.patch \
+               file://0002-src-login-brightness.c-include-sys-wait.h.patch \
+               file://0003-src-basic-copy.c-include-signal.h.patch \
+               file://0004-src-shared-cpu-set-util.h-add-__cpu_mask-definition.patch \
+               "
+
+PACKAGECONFIG ??= "gshadow idn"
+PACKAGECONFIG_remove_libc-musl = " gshadow idn"
+PACKAGECONFIG[gshadow] = "-Dgshadow=true,-Dgshadow=false"
+PACKAGECONFIG[idn] = "-Didn=true,-Didn=false"
+
+EXTRA_OEMESON += "-Dstatic-libsystemd=pic"
+
+S = "${WORKDIR}/git"
+
+do_compile() {
+    ninja -v ${PARALLEL_MAKE} version.h
+    ninja -v ${PARALLEL_MAKE} libsystemd.a
+}
+
+do_install () {
+    install -d ${D}${libdir}
+    install ${B}/libsystemd.a ${D}${libdir}
+
+    install -d ${D}${includedir}/systemd
+    install ${S}/src/systemd/*.h ${D}${includedir}/systemd
+
+    install -d ${D}${libdir}/pkgconfig
+    install ${B}/src/libsystemd/libsystemd.pc ${D}${libdir}/pkgconfig
+}

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-tools-native_0.7.6.bb
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-tools-native_0.7.6.bb
@@ -1,0 +1,14 @@
+SUMMARY = "sdbus-c++ native tools"
+DESCRIPTION = "Native interface code generator for development with sdbus-c++"
+
+LICENSE = "LGPLv2.1"
+LIC_FILES_CHKSUM = "file://${S}/COPYING;md5=1803fa9c2c3ce8cb06b4861d75310742"
+
+inherit cmake native
+
+DEPENDS += "expat"
+
+SRCREV = "5121d46eed42231285c18d317a9f48e0b2849d5e"
+SRC_URI = "git://github.com/Kistler-Group/sdbus-cpp.git;protocol=https;branch=master;subpath=tools"
+
+S = "${WORKDIR}/tools"

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++_0.7.6.bb
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++_0.7.6.bb
@@ -1,0 +1,32 @@
+SUMMARY = "sdbus-c++"
+DESCRIPTION = "High-level C++ D-Bus library designed to provide easy-to-use yet powerful API in modern C++"
+
+SECTION = "libs"
+
+LICENSE = "LGPLv2.1"
+LIC_FILES_CHKSUM = "file://COPYING;md5=1803fa9c2c3ce8cb06b4861d75310742"
+
+inherit cmake pkgconfig systemd ptest
+
+PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'with-external-libsystemd', 'with-builtin-libsystemd', d)} \
+                   ${@bb.utils.contains('PTEST_ENABLED', '1', 'with-tests', '', d)}"
+PACKAGECONFIG[with-builtin-libsystemd] = ",,sdbus-c++-libsystemd,libcap"
+PACKAGECONFIG[with-external-libsystemd] = ",,systemd,libsystemd"
+PACKAGECONFIG[with-tests] = "-DBUILD_TESTS=ON -DTESTS_INSTALL_PATH=${libdir}/${BPN}/tests,-DBUILD_TESTS=OFF"
+
+DEPENDS += "expat"
+
+SRCREV = "5121d46eed42231285c18d317a9f48e0b2849d5e"
+SRC_URI = "git://github.com/Kistler-Group/sdbus-cpp.git;protocol=https;branch=master"
+SRC_URI += "file://run-ptest"
+
+EXTRA_OECMAKE = "-DBUILD_CODE_GEN=ON \
+                 -DBUILD_DOC=ON \
+                 -DBUILD_DOXYGEN_DOC=OFF"
+
+S = "${WORKDIR}/git"
+
+FILES_${PN}_remove = "${sysconfdir}"
+FILES_${PN}-ptest += "${sysconfdir}/dbus-1/system.d/"
+FILES_${PN}-ptest += "${libdir}/${BPN}/tests"
+FILES_${PN}-dev += "${bindir}/sdbus-c++-xml2cpp"


### PR DESCRIPTION
sdbus-c++ is a high-level C++ D-Bus library written on top of systemd D-Bus implementation originally as a modern, robust replacement for dbus-c++.

There are two main recipes and one helper recipe:
* Recipe for sdbus-c++ itself. It detects whether systemd feature is turned on. If so, it depends on systemd and links against libsystemd. Otherwise it builds libsystemd as part of building sdbus-c++. (Building of libsystemd for sdbus-c++ is performed by helper `sdbus-c++-libsystemd` recipe.) The recipe also supports ptest.
* Recipe for sdbus-c++ native tools, namely sdbus-c++ code generator to generate C++ adaptor and proxy binding classes.

The recipes have been tested on yocto master.