### PR TITLE
Add zeus compatibility to all layer.conf files

### DIFF
--- a/meta-filesystems/conf/layer.conf
+++ b/meta-filesystems/conf/layer.conf
@@ -15,4 +15,4 @@ LAYERVERSION_filesystems-layer = "1"
 
 LAYERDEPENDS_filesystems-layer = "core openembedded-layer"
 
-LAYERSERIES_COMPAT_filesystems-layer = "thud warrior"
+LAYERSERIES_COMPAT_filesystems-layer = "thud warrior zeus"

--- a/meta-gnome/conf/layer.conf
+++ b/meta-gnome/conf/layer.conf
@@ -14,4 +14,4 @@ LAYERVERSION_gnome-layer = "1"
 
 LAYERDEPENDS_gnome-layer = "core openembedded-layer networking-layer"
 
-LAYERSERIES_COMPAT_gnome-layer = "thud warrior"
+LAYERSERIES_COMPAT_gnome-layer = "thud warrior zeus"

--- a/meta-initramfs/conf/layer.conf
+++ b/meta-initramfs/conf/layer.conf
@@ -16,7 +16,7 @@ BBFILE_PATTERN_meta-initramfs := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-initramfs = "8"
 LAYERDEPENDS_meta-initramfs = "core"
 
-LAYERSERIES_COMPAT_meta-initramfs = "thud warrior"
+LAYERSERIES_COMPAT_meta-initramfs = "thud warrior zeus"
 
 SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS += " \
   dracut->virtual/kernel \

--- a/meta-multimedia/conf/layer.conf
+++ b/meta-multimedia/conf/layer.conf
@@ -31,4 +31,4 @@ LAYERVERSION_multimedia-layer = "1"
 
 LAYERDEPENDS_multimedia-layer = "core meta-python"
 
-LAYERSERIES_COMPAT_multimedia-layer = "thud warrior"
+LAYERSERIES_COMPAT_multimedia-layer = "thud warrior zeus"

--- a/meta-networking/conf/layer.conf
+++ b/meta-networking/conf/layer.conf
@@ -17,7 +17,7 @@ LAYERDEPENDS_networking-layer = "core"
 LAYERDEPENDS_networking-layer += "openembedded-layer"
 LAYERDEPENDS_networking-layer += "meta-python"
 
-LAYERSERIES_COMPAT_networking-layer = "thud warrior"
+LAYERSERIES_COMPAT_networking-layer = "thud warrior zeus"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 

--- a/meta-oe/conf/layer.conf
+++ b/meta-oe/conf/layer.conf
@@ -29,7 +29,7 @@ LAYERVERSION_openembedded-layer = "1"
 
 LAYERDEPENDS_openembedded-layer = "core"
 
-LAYERSERIES_COMPAT_openembedded-layer = "thud warrior"
+LAYERSERIES_COMPAT_openembedded-layer = "thud warrior zeus"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 

--- a/meta-perl/conf/layer.conf
+++ b/meta-perl/conf/layer.conf
@@ -15,4 +15,4 @@ LAYERVERSION_perl-layer = "1"
 
 LAYERDEPENDS_perl-layer = "core openembedded-layer"
 
-LAYERSERIES_COMPAT_perl-layer = "thud warrior"
+LAYERSERIES_COMPAT_perl-layer = "thud warrior zeus"

--- a/meta-python/conf/layer.conf
+++ b/meta-python/conf/layer.conf
@@ -14,6 +14,6 @@ LAYERVERSION_meta-python = "1"
 
 LAYERDEPENDS_meta-python = "core openembedded-layer"
 
-LAYERSERIES_COMPAT_meta-python = "thud warrior"
+LAYERSERIES_COMPAT_meta-python = "thud warrior zeus"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"

--- a/meta-webserver/conf/layer.conf
+++ b/meta-webserver/conf/layer.conf
@@ -17,7 +17,7 @@ LAYERVERSION_webserver = "1"
 
 LAYERDEPENDS_webserver = "core openembedded-layer"
 
-LAYERSERIES_COMPAT_webserver = "thud warrior"
+LAYERSERIES_COMPAT_webserver = "thud warrior zeus"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 

--- a/meta-xfce/conf/layer.conf
+++ b/meta-xfce/conf/layer.conf
@@ -19,4 +19,4 @@ LAYERDEPENDS_xfce-layer += "multimedia-layer"
 LAYERDEPENDS_xfce-layer += "meta-python"
 LAYERDEPENDS_xfce-layer += "networking-layer"
 
-LAYERSERIES_COMPAT_xfce-layer = "thud warrior"
+LAYERSERIES_COMPAT_xfce-layer = "thud warrior zeus"


### PR DESCRIPTION
I have no idea if this is the right thing to do, but without the patch I
can't actually buil OE because none of these layers are compatible
with the change in openembedded-core to move to zeus.

Fixes: a5c9709b8d ("layer.conf: Update for zeus series") # openembedded-core

Signed-off-by: Palmer Dabbelt <palmer@dabbelt.com>