### PR TITLE
nftables: upgrade 0.9.2 -> 0.9.3

### DIFF
--- a/meta-networking/recipes-filter/nftables/files/0001-update-python3-nftables-reference.patch
+++ b/meta-networking/recipes-filter/nftables/files/0001-update-python3-nftables-reference.patch
@@ -1,0 +1,47 @@
+From ddbe652bf0f4ed300bae9497250130d68e4cbf5b Mon Sep 17 00:00:00 2001
+From: Arturo Borrero Gonzalez <arturo@netfilter.org>
+Date: Tue, 10 Dec 2019 12:00:45 +0100
+Subject: py: load the SONAME-versioned shared object
+
+Instruct the python module to load the SONAME versioned shared object.
+
+Normal end-user systems may only have available libnftables.so.1.0.0 and not
+libnftables.so which is usually only present in developer systems.
+
+In Debian systems, for example:
+
+ % dpkg -L libnftables1 | grep so.1
+ /usr/lib/x86_64-linux-gnu/libnftables.so.1.0.0
+ /usr/lib/x86_64-linux-gnu/libnftables.so.1
+
+ % dpkg -L libnftables-dev | grep so
+ /usr/lib/x86_64-linux-gnu/libnftables.so
+
+The "1" is not a magic number, is the SONAME of libnftables in the current
+version, as stated in Make_global.am.
+
+Reported-by: Michael Biebl <biebl@debian.org>
+Signed-off-by: Arturo Borrero Gonzalez <arturo@netfilter.org>
+Acked-by: Phil Sutter <phil@nwl.cc>
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ py/nftables.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/py/nftables.py b/py/nftables.py
+index 48eb54fe..2a0a1e89 100644
+--- a/py/nftables.py
++++ b/py/nftables.py
+@@ -64,7 +64,7 @@ class Nftables:
+ 
+     validator = None
+ 
+-    def __init__(self, sofile="libnftables.so"):
++    def __init__(self, sofile="libnftables.so.1"):
+         """Instantiate a new Nftables class object.
+ 
+         Accepts a shared object file to open, by default standard search path
+-- 
+cgit v1.2.1
+
+

--- a/meta-networking/recipes-filter/nftables/nftables_0.9.3.bb
+++ b/meta-networking/recipes-filter/nftables/nftables_0.9.3.bb
@@ -7,9 +7,10 @@ DEPENDS = "libmnl libnftnl readline gmp bison-native"
 
 UPSTREAM_CHECK_URI = "https://www.netfilter.org/projects/nftables/files/"
 
-SRC_URI = "http://www.netfilter.org/projects/nftables/files/${BP}.tar.bz2"
-SRC_URI[md5sum] = "dfe130724d7c998eb26b56447e932899"
-SRC_URI[sha256sum] = "5cb66180143e6bfc774f4eb316206d40ac1cb6df269a90882404cbf7165513f5"
+SRC_URI = "http://www.netfilter.org/projects/nftables/files/${BP}.tar.bz2 \
+           file://0001-update-python3-nftables-reference.patch"
+SRC_URI[md5sum] = "9913b2b46864394d41916b74638e0875"
+SRC_URI[sha256sum] = "956b915ce2a7aeaff123e49006be7a0690a0964e96c062703181a36e2e5edb78"
 
 inherit autotools manpages pkgconfig
 


### PR DESCRIPTION
New patch:
    0001-update-python3-nftables-reference.patch

Signed-off-by: Todd Cunningham <tcunningham07@gmail.com>