### PR TITLE
Update cups-filters packaging according to oe-core

### DIFF
--- a/meta-oe/recipes-printing/cups/cups-filters.inc
+++ b/meta-oe/recipes-printing/cups/cups-filters.inc
@@ -47,8 +47,7 @@ PACKAGES =+ "\
         "
 
 FILES_${PN}-gst = "\
-	${libdir}/cups/filter/gstopxl \
-	${libdir}/cups/filter/gstoraster \
+	${libexecdir}/cups/filter/gsto* \
 	"
 
 FILES_${PN}-data = "\
@@ -56,37 +55,24 @@ FILES_${PN}-data = "\
 	"
 
 FILES_${PN}-dbg += "\
-	${libdir}/cups/filter/.debug \
-	${libdir}/cups/backend/.debug \
+	${libexecdir}/cups/backend/.debug \
+	${libexecdir}/cups/driver/.debug \
+	${libexecdir}/cups/filter/.debug \
 	"
 
 FILES_${PN} += "\
-        ${libdir}/cups/filter \
-        ${libdir}/cups/backend \
-        ${libdir}/cups/driver \
+        ${libexecdir}/cups \
+        ${datadir}/ppd/ \
         ${datadir}/cups/charsets \
         ${datadir}/cups/drv \
         ${datadir}/cups/mime \
         ${datadir}/cups/ppdc \
-        ${datadir}/ppd/cupsfilters \
-        ${datadir}/cups/braille \
         ${datadir}/cups/banners \
-        ${datadir}/cups/braille/index.sh \
-        ${datadir}/cups/braille/cups-braille.sh \
-        ${datadir}/cups/braille/indexv3.sh \
-        ${datadir}/cups/braille/indexv4.sh \
-        ${datadir}/cups/banners/topsecret \
-        ${datadir}/cups/banners/secret \
-        ${datadir}/cups/banners/confidential \
-        ${datadir}/cups/banners/unclassified \
-        ${datadir}/cups/banners/form \
-        ${datadir}/cups/banners/classified \
-        ${datadir}/cups/banners/standard \
 "
 
 do_install_append() {
-	# remove banners, braille dirs
-	rm -rf ${D}${datadir}/cups/{banners,braille}
+	# remove braille dir
+	rm -rf ${D}${datadir}/cups/braille
 
 	# remove sysroot path contamination from pkgconfig file
 	sed -i -e 's:${STAGING_DIR_TARGET}::' ${D}/${libdir}/pkgconfig/libcupsfilters.pc

--- a/meta-oe/recipes-printing/cups/cups-filters_1.26.0.bb
+++ b/meta-oe/recipes-printing/cups/cups-filters_1.26.0.bb
@@ -1,4 +1,0 @@
-include cups-filters.inc
-
-SRC_URI[md5sum] = "afb278c77bb195c2a32fc64e5c8378fb"
-SRC_URI[sha256sum] = "ff8679fcd0c31c25d229262c7ad100ba161ef6b2aa455a2df673dd74ef93f488"

--- a/meta-oe/recipes-printing/cups/cups-filters_1.26.2.bb
+++ b/meta-oe/recipes-printing/cups/cups-filters_1.26.2.bb
@@ -1,0 +1,4 @@
+include cups-filters.inc
+
+SRC_URI[md5sum] = "970095596bf2b8cfe91ac91c0b51297a"
+SRC_URI[sha256sum] = "0069aef1358522f1901a64749ec753d28a2d6a832758bce58ffcd722b28c0e66"


### PR DESCRIPTION
As the crossscript is now fixed in oe-core:
http://git.openembedded.org/openembedded-core/commit/?id=2ce6ef29b9bb4f16ed9d78e166d455b7a6d968bf
adjust packaging accordingly by using libexecdir instead of libdir.
Additionally update cups-filters to latest version.