### PR TITLE
zchunk: add recipe

### DIFF
--- a/meta-oe/recipes-support/zchunk/zchunk/0001-zck.h-fix-build-on-musl.patch
+++ b/meta-oe/recipes-support/zchunk/zchunk/0001-zck.h-fix-build-on-musl.patch
@@ -1,0 +1,39 @@
+From 78247d478cec254bad27f4ed97b532f4f54bf1b0 Mon Sep 17 00:00:00 2001
+From: Pierre-Jean Texier <pjtexier@koncepto.io>
+Date: Thu, 23 Jan 2020 19:14:40 +0100
+Subject: [PATCH 1/2] zck.h: fix build on musl
+
+The ssize_t type requires the <sys/types.h> header. This fixes build with musl
+libc:
+
+include/zck.h:68:1: error: unknown type name 'ssize_t'; did you mean 'size_t'?
+   68 | ssize_t zck_read(zckCtx *zck, char *dst, size_t dst_size)
+      | ^~~~~~~
+      | size_t
+include/zck.h:81:1: error: unknown type name 'ssize_t'; did you mean 'size_t'?
+   81 | ssize_t zck_write(zckCtx *zck, const char *src, const size_t src_size)
+      | ^~~~~~~
+      | size_t
+      
+Upstream-Status: Submitted [https://github.com/zchunk/zchunk/pull/23]
+
+Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>
+---
+ include/zck.h.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/zck.h.in b/include/zck.h.in
+index 91d2557..b847576 100644
+--- a/include/zck.h.in
++++ b/include/zck.h.in
+@@ -5,6 +5,7 @@
+ 
+ #include <stdlib.h>
+ #include <stdbool.h>
++#include <sys/types.h>
+ 
+ typedef enum zck_hash {
+     ZCK_HASH_SHA1,
+-- 
+2.7.4
+

--- a/meta-oe/recipes-support/zchunk/zchunk/0002-unzck-fix-build-with-musl-libc.patch
+++ b/meta-oe/recipes-support/zchunk/zchunk/0002-unzck-fix-build-with-musl-libc.patch
@@ -1,0 +1,61 @@
+From 72c55e3da59eccdfea3778d11f83862b58af723d Mon Sep 17 00:00:00 2001
+From: Pierre-Jean Texier <pjtexier@koncepto.io>
+Date: Thu, 23 Jan 2020 22:42:40 +0100
+Subject: [PATCH 2/2] unzck: fix build with musl libc
+
+On musl libc "stdout" is a preprocessor macro whose expansion leads to
+compilation errors.
+
+Fixes:
+
+| In file included from ../git/src/unzck.c:31:
+| ../git/src/unzck.c: In function 'parse_opt':
+| ../git/src/unzck.c:78:24: error: expected identifier before '(' token
+|    78 |             arguments->stdout = true;
+|       |                        ^~~~~~
+| ../git/src/unzck.c: In function 'main':
+| ../git/src/unzck.c:141:20: error: expected identifier before '(' token
+|   141 |     if(!(arguments.stdout)) {
+|       |                    ^~~~~~
+
+Upstream-Status: Submitted [https://github.com/zchunk/zchunk/pull/23]
+
+Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>
+---
+ src/unzck.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/unzck.c b/src/unzck.c
+index 8d6c62a..002492c 100644
+--- a/src/unzck.c
++++ b/src/unzck.c
+@@ -58,7 +58,7 @@ struct arguments {
+   char *args[1];
+   zck_log_type log_level;
+   bool dict;
+-  bool stdout;
++  bool stdOut;
+   bool exit;
+ };
+ 
+@@ -75,7 +75,7 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state) {
+                 arguments->log_level = ZCK_LOG_DDEBUG;
+             break;
+         case 'c':
+-            arguments->stdout = true;
++            arguments->stdOut = true;
+             break;
+         case 'V':
+             version();
+@@ -138,7 +138,7 @@ int main (int argc, char *argv[]) {
+         snprintf(out_name + strlen(base_name) - 4, 7, ".zdict");
+ 
+     int dst_fd = STDOUT_FILENO;
+-    if(!arguments.stdout) {
++    if(!arguments.stdOut) {
+         dst_fd = open(out_name, O_TRUNC | O_WRONLY | O_CREAT, 0666);
+         if(dst_fd < 0) {
+             dprintf(STDERR_FILENO, "Unable to open %s", out_name);
+-- 
+2.7.4
+

--- a/meta-oe/recipes-support/zchunk/zchunk_1.1.5.bb
+++ b/meta-oe/recipes-support/zchunk/zchunk_1.1.5.bb
@@ -1,0 +1,26 @@
+DESCRIPTION = "A file format designed for highly efficient deltas while maintaining good compression"
+AUTHOR = "Jonathan Dieter"
+
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=cd6e590282010ce90a94ef25dd31410f"
+
+SRC_URI = " \
+	git://github.com/zchunk/zchunk.git;protocol=https \
+	file://0001-zck.h-fix-build-on-musl.patch \
+	file://0002-unzck-fix-build-with-musl-libc.patch \
+	"
+
+SRCREV = "c01bf12feede792982f165f52f4a6c573e3a8c17"
+S = "${WORKDIR}/git"
+
+DEPENDS = "\
+    curl \
+    zstd \
+    "
+
+DEPENDS_append_libc-musl = " argp-standalone"
+LDFLAGS_append_libc-musl = " -largp"
+
+inherit meson
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
zchunk is a compressed file format that splits the file into independent chunks.
This allows you to only download changed chunks when downloading a new version of
the file, and also makes zchunk files efficient over rsync.

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>