### PR TITLE
libiio: upgrade 0.18 -> 0.19

### DIFF
--- a/meta-oe/recipes-support/libiio/libiio_git.bb
+++ b/meta-oe/recipes-support/libiio/libiio_git.bb
@@ -4,9 +4,8 @@ SECTION = "libs"
 LICENSE = "LGPLv2.1+"
 LIC_FILES_CHKSUM = "file://COPYING.txt;md5=7c13b3376cea0ce68d2d2da0a1b3a72c"
 
-# v0.18 + a single commit fixing the build
-SRCREV = "5090603d01779bb1717fb0c50953330e8770550f"
-PV = "0.18+git${SRCPV}"
+SRCREV = "5f5af2e417129ad8f4e05fc5c1b730f0694dca12"
+PV = "0.19+git${SRCPV}"
 
 SRC_URI = "git://github.com/analogdevicesinc/libiio.git;protocol=https"
 


### PR DESCRIPTION
See full changelog https://github.com/analogdevicesinc/libiio/releases/tag/v0.19

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>