### PR TITLE
mbedtls: add native and nativesdk to BBCLASSEXTEND

### DIFF
--- a/meta-networking/recipes-connectivity/mbedtls/mbedtls_2.16.3.bb
+++ b/meta-networking/recipes-connectivity/mbedtls/mbedtls_2.16.3.bb
@@ -39,3 +39,5 @@ RPROVIDES_${PN} = "polarssl"
 
 PACKAGES =+ "${PN}-programs"
 FILES_${PN}-programs = "${bindir}/"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Fixes:

ERROR: Nothing PROVIDES 'mbedtls-native'

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>