### PR TITLE
mbedtls: upgrade 2.16.3 -> 2.16.5

### DIFF
--- a/meta-networking/recipes-connectivity/mbedtls/mbedtls_2.16.5.bb
+++ b/meta-networking/recipes-connectivity/mbedtls/mbedtls_2.16.5.bb
@@ -23,8 +23,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=302d50a6369f5f22efdb674db908167a"
 SECTION = "libs"
 
 SRC_URI = "https://tls.mbed.org/download/mbedtls-${PV}-apache.tgz"
-SRC_URI[md5sum] = "90ce7c7a001d2514410280706b3ab1a7"
-SRC_URI[sha256sum] = "ec1bee6d82090ed6ea2690784ea4b294ab576a65d428da9fe8750f932d2da661"
+SRC_URI[md5sum] = "339f0505323b29851ef3128a53d2de20"
+SRC_URI[sha256sum] = "65b4c6cec83e048fd1c675e9a29a394ea30ad0371d37b5742453f74084e7b04d"
 
 inherit cmake
 


### PR DESCRIPTION
Mbed TLS 2.16.5 is a maintenance release of the Mbed TLS 2.16 branch, and
provides security fixes and bug fixes, see:

https://tls.mbed.org/tech-updates/releases/mbedtls-2.16.5-and-2.7.14-released

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>