### PR TITLE
libuv: upgrade 1.34.0 -> 1.34.2

### DIFF
--- a/meta-oe/recipes-connectivity/libuv/libuv_1.34.2.bb
+++ b/meta-oe/recipes-connectivity/libuv/libuv_1.34.2.bb
@@ -4,7 +4,7 @@ BUGTRACKER = "https://github.com/libuv/libuv/issues"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=a68902a430e32200263d182d44924d47"
 
-SRCREV = "15ae750151ac9341e5945eb38f8982d59fb99201"
+SRCREV = "f868c9ab0c307525a16fff99fd21e32a6ebc3837"
 SRC_URI = "git://github.com/libuv/libuv;branch=v1.x"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
See full changelog https://github.com/libuv/libuv/releases/tag/v1.34.2

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>