### PR TITLE
spdlog_1.3.1 allow empty for header only libs

### DIFF
--- a/meta-oe/recipes-support/spdlog/spdlog_1.3.1.bb
+++ b/meta-oe/recipes-support/spdlog/spdlog_1.3.1.bb
@@ -17,3 +17,5 @@ inherit cmake
 # Header-only library
 RDEPENDS_${PN}-dev = ""
 RRECOMMENDS_${PN}-dbg = "${PN}-dev (= ${EXTENDPKGV})"
+
+ALLOW_EMPTY_${PN} = "1"


### PR DESCRIPTION
By default, BitBake does not produce empty packages.
- opkg_prepare_url_for_install: Couldn't find anything to satisfy 'spdlog'