### PR TITLE
libssh: upgrade 0.8.4 -> 0.8.8

### DIFF
--- a/meta-oe/recipes-support/libssh/libssh_0.8.8.bb
+++ b/meta-oe/recipes-support/libssh/libssh_0.8.8.bb
@@ -2,12 +2,12 @@ SUMMARY = "Multiplatform C library implementing the SSHv2 and SSHv1 protocol"
 HOMEPAGE = "http://www.libssh.org"
 SECTION = "libs"
 LICENSE = "LGPLv2.1"
-LIC_FILES_CHKSUM = "file://COPYING;md5=388a4fb1dea8ceae0be78ba9b01fc139"
+LIC_FILES_CHKSUM = "file://COPYING;md5=dabb4958b830e5df11d2b0ed8ea255a0"
 
 DEPENDS = "zlib openssl libgcrypt"
 
 SRC_URI = "git://git.libssh.org/projects/libssh.git;branch=stable-0.8"
-SRCREV = "789df0b7d0c7abd6b85db9fc5247e146e3d4ddba"
+SRCREV = "7850307210590a9a1b03ab0273d29b3926a974c5"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
License-Update: Reformat COPYING file

0.8.8 is a security release to especially address CVE-2019-14889.
Thins includes the following changes from the 0.8.4 version:

7850307 Bump version to 0.8.8
30c0f0c cpack: Ignore patch files and other stuff
b0edec4 CVE-2019-14889: scp: Quote location to be used on shell
391c78d CVE-2019-14889: scp: Don't allow file path longer than 32kb
2ba1dea CVE-2019-14889: misc: Add function to quote file names
82c375b CVE-2019-14889: scp: Log SCP warnings received from the server
4aea835 CVE-2019-14889: scp: Reformat scp.c
2fbeb2a gitlab-ci: Mips is dead
e981113 doc: Add a note about OpenSSL linking
3736a03 libcrypto: Add missing includes for modes.h
be73335 sftp: Document how to free memory retruned by sftp_canonicalize_path()
5298611 Bump version to 0.8.7
7a49ee5 cmake: Bump API version to 4.7.4
c842bc2 Remove SHA384 HMAC
8892577 Use constant time comparison function for HMAC comparison
ac7c64a pki_gcrypt: Include missing stdbool.h
47014eb pki: Fix size type for len in privatekey_string_to_buffer()
2223106 connect: Fix size type for i an j in ssh_select()
4af7736 connector: Fallback on the socket output callback
f4a0fcc connector: Don't NULL connector (in|out) channels on event remove
fa150ef options: Removed outdated param annotations of ssh_options_set()
810dbd3 config: Avoid buffer overflow
fa6aa12 tests/pkd: repro rsa-sha2-{256,512} negotiation bug
a4948f6 kex: honor client preference for rsa-sha2-{256,512} host key algorithms
e05e4ae pki_crypto: plug pki_signature_from_blob leaks
b6d2755 pki: NULL check pki_signature_from_rsa_blob result
e69fb89 pki_container_openssh: Add padding to be compatible with OpenSSH
f9beb3c gitlab-ci: Disable debian cross mips runner
bfc39d5 kex: List also the SHA2 extension when ordering hostkey algorithms
0acfd81 server: Correctly handle extensions
d028b24 dh: Make sure we do not access uninitialized memory
68fc17c Bump version to 0.8.6
d327712 Bump SO version to 4.7.3
fded1fb channels: Don't call ssh_channel_close() twice
a6e055c packet: Allow SSH2_MSG_EXT_INFO when authenticated
32221ea channels: Send close if we received a remote close
917ba07 channels: Reformat ssh_channel_free()
bcdbc11 channel: Add SSH_CHANNEL_FLAG_CLOSED_LOCAL
79289dc channel: Reformat ssh_channel_close()
45172a7 sftp: Do not overwrite errors set by channel functions
7b0c80b tests: Test calling ssh_init() after ssh_finalize()
d5bc9a1 libcrypto: Fix access violation in ssh_init()
80d3e10 tests: Verify that signatures are sane and can not be verified by non-matching key
455d495 pki: Sanitize input to verification
b1bae1d pki: Return default RSA key type for DIGEST_AUTO
ad4f1db pki: Verify the provided public key has expected type
5ffe695 pki: Sanity-check signature matches base key type
230a437 tests: Do not require base RSA type for SHA2 extension whitelist
1df272c packet_cb: Properly verify the signature type
c3a57fe pki: Separate signature extraction and verification
a238df2 pki: Set correct type for imported signatures
f5e8fa5 pki: Use self-explanatory variable names
0a07266 The largest ECDSA key has 521 bits
953eae8 pki_gcrypt: Do not abort on bad signature
1d5215a server: Do not send SSH_MSG_EXT_INFO after rekey
2d06a83 kex: Do not negotiate extensions during rekey
fd844ca tests: Verify setting NULL knownhosts does not crash
a106a00 options: Do not crash when setting knownhosts to NULL (T108)
d8372c3 gcrypt: Bugfix for very slow ecdh
9462105 socket: Add missing braces
fe0331c socket: Remove redundant code
709c48e socket: Fix potential buffer overrun
3d56bda pki: Fix typos in documentation
8b4de1c packet: Fix timeout on hostkey type mismatch instead of proper error
906f63b packets: Fix ssh_send_keepalive()
26ea4f0 COPYING: Reformat the last paragraph
3b46198 tests: Fix chroot_wrapper location
3de3494 tests: Ensure the ssh session fd is read-/writeable in torture_proxycommand
69cb3c5 knownhosts: Take StrictHostKeyChecking option into account
5102b16 crypto: Fix compilation for OpenSSL without deprecated APIs
dc071dc cmake: Refresh the CMake Config files
a8d4fba tests: Improve error reporting in auth test
56b7d2d tests: Typo -- the flags should be checked according to the comment
a4b99ee knownhosts: Make sure we have both knownhosts files ready
8a8498b client: Reformat comment
44b32e9 tests/pkd: Properly clean up memory
0590795 session: Drop unused structure member (SSHv1)
f11be32 misc: Properly check for errors returned from getpwuid_r()
a9be4ab misc: Reformat ssh_get_user_home_dir and ssh_file_readaccess_ok
273fb4c Bump version to 0.8.5
56f7c27 Bump SO version to 4.7.2
1285b37 doc: fix up various typos and trailing whitespace
b7de358 libcrypto: Fix memory leak in evp_final()
bea6393 gssapi: Set correct state after sending GSSAPI_RESPONSE (select mechanism OID)
9158cc5 socket: Undouble socket fds
8ba10ef client: Send KEX as soon as banners are exchanged
2ff8a09 tests: Verify we can authenticate using ed25519 key
d52fa9a tests: Global known_hosts are used for host key verification
ec3fdb4 knownhosts: Consult also the global known hosts file
d877969 options: Set the global known_hosts file
b1a7bd2 tests: Verify the hostkey ordering for negotiation is correct
0831b85 tests: Generate valid known_hosts file, fixing the current test
34d1f5e tests: Verify the ecdsa key types are handled correctly
fcf2cd0 kex: Use all supported hostkey algorithms for negotiation
4a4ca44 kex: Honor more host key algorithms than the first one (ssh-ed25519)
17a6c3f knownhosts: Use the correct name for ECDSA keys for host key negotiation
e24bb93 tests: Do not trace sshd
5c2d444 tests: Add option tests for global and user specific known_hosts
9763563 options: Add support for getting the known_hosts locations
5f9d9f4 examples: Explicitly track auth state in samplesshd-kbdint
e8f3207 messages: Check that the requested service is 'ssh-connection'
e5cee20 server: Set correct state after sending INFO_REQUEST (Kbd Interactive)
63056d1 priv: Add ssize_t if not available with MSVC
09e4f3d packet: Add missing break in ssh_packet_incoming_filter()
4b886ac src: Fix typos

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>