### PR TITLE
fbgrab: upgrade 1.3 -> 1.3.1

### DIFF
--- a/meta-oe/recipes-graphics/fbgrab/fbgrab_1.3.1.bb
+++ b/meta-oe/recipes-graphics/fbgrab/fbgrab_1.3.1.bb
@@ -1,15 +1,15 @@
 SUMMARY = "FBGrab is a framebuffer screenshot program"
-HOMEPAGE = "http://fbgrab.monells.se/"
+HOMEPAGE = "https://github.com/GunnarMonell/fbgrab"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=ea5bed2f60d357618ca161ad539f7c0a"
 SECTION = "console/utils"
 DEPENDS = "libpng zlib"
-SRC_URI = "http://fbgrab.monells.se/${BP}.tar.gz"
+SRC_URI = "git://github.com/GunnarMonell/fbgrab.git;protocol=https"
+
+SRCREV = "d3a8b6b42b6b74228e92758a0b015d8b8c1e6fa0"
+S = "${WORKDIR}/git"
 
 inherit autotools-brokensep
-
-SRC_URI[md5sum] = "7d8c24081c681dfbba21f2934c1ac656"
-SRC_URI[sha256sum] = "5fab478cbf8731fbacefaa76236a8f8b38ccff920c53b3a8253bc35509fba8ed"
 
 do_configure_prepend() {
     sed -i 's|$(DESTDIR)/usr/man/|$(DESTDIR)${mandir}/|g' ${S}/Makefile


### PR DESCRIPTION
Switch SRC_URI to github because 'http://fbgrab.monells.se' is no more reachable
it redirects to a github page.

See full changelog https://github.com/GunnarMonell/fbgrab/releases

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>