### PR TITLE
libcamera: Added the meta multimedia packagegroup in libcamera image

### DIFF
--- a/meta-multimedia/recipes-multimedia/images/multimedia-libcamera-image.bb
+++ b/meta-multimedia/recipes-multimedia/images/multimedia-libcamera-image.bb
@@ -4,7 +4,7 @@
 DESCRIPTION = "libcamera image"
 LICENSE = "MIT"
 
-require  meta-multimedia-image-base.bb
+require  meta-multimedia-image.bb
 
 IMAGE_INSTALL += " \
         kernel-modules \


### PR DESCRIPTION
Added the packagegroup of meta multimedia in the libcamera core image

After adding the meta multimedia packagegroup, we faced the faad2 componenet
was unknown.

Since faad component has commercial license, we could not able
to build with multimedia image. So we have modified the faad
component to be included when commercial licenese is supported.

Signed-off-by: Madhavan Krishnan <madhavan.krishnan@linaro.org>