### PR TITLE
uftrace: update commit hash to more robust version

### DIFF
--- a/meta-oe/recipes-devtools/uftrace/uftrace_0.9.4.bb
+++ b/meta-oe/recipes-devtools/uftrace/uftrace_0.9.4.bb
@@ -11,7 +11,7 @@ DEPENDS_append_libc-musl = " argp-standalone"
 inherit autotools
 
 # v0.9.4
-SRCREV = "5e422c0ec87b41d14e9ce8527983406718ef64e0"
+SRCREV = "d648bbffedef529220896283fb59e35531c13804"
 SRC_URI = "git://github.com/namhyung/${BPN} \
            "
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Since uftrace-0.9.4 was released, there has been some important bug
fixes.  It would be better to include such bug fix commits so this patch
updates the commit hash to more stable one.

The bug fix patches are as follows:

[1] https://github.com/namhyung/uftrace/commit/a0fbee404b2d23aab6b544075628eb38e837d738
[2] https://github.com/namhyung/uftrace/commit/251ba74a7283664b330649c239dfea20dd8f9dae
[3] https://github.com/namhyung/uftrace/commit/19e6f0d4b382821e3b779012137c38fcc271e7e2
[4] https://github.com/namhyung/uftrace/commit/d648bbffedef529220896283fb59e35531c13804

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>