### PR TITLE
Cockpit recipe: Added missing dep on udisks2 for package cockpit-storaged

### DIFF
--- a/meta-webserver/recipes-webadmin/cockpit/cockpit_218.bb
+++ b/meta-webserver/recipes-webadmin/cockpit/cockpit_218.bb
@@ -85,6 +85,8 @@ FILES_${PN}-storaged = " \
     ${datadir}/cockpit/storaged \
     ${datadir}/metainfo/org.cockpit-project.cockpit-storaged.metainfo.xml \
 "
+RDEPENDS_${PN}-storaged = "udisks2"
+
 FILES_${PN}-networkmanager = "${datadir}/cockpit/networkmanager"
 RDEPENDS_${PN}-networkmanager = "networkmanager"
 


### PR DESCRIPTION

Cockpit uses udisks2 in order to manage storage on the host, without it
cockpit will just display an error when the storage tab is selected.