### PR TITLE
uftrace: add PV to update the package version

### DIFF
--- a/meta-oe/recipes-devtools/uftrace/uftrace_0.9.4.bb
+++ b/meta-oe/recipes-devtools/uftrace/uftrace_0.9.4.bb
@@ -10,12 +10,11 @@ DEPENDS_append_libc-musl = " argp-standalone"
 
 inherit autotools
 
+PV .= "+git${SRCPV}"
 SRCREV = "d648bbffedef529220896283fb59e35531c13804"
 SRC_URI = "git://github.com/namhyung/${BPN} \
            "
 S = "${WORKDIR}/git"
-
-PR .= "+git${SRCPV}"
 
 LDFLAGS_append_libc-musl = " -largp"
 


### PR DESCRIPTION
uftrace_0.9.4.bb now doesn't actually use exact 0.9.4 version, so it has
to add a PV value to update the package version.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>