### PR TITLE
nlohmann-json: backport gcc10 fix

### DIFF
--- a/meta-oe/recipes-devtools/nlohmann-json/nlohmann-json/0001-Templatize-basic_json-ctor-from-json_ref.patch
+++ b/meta-oe/recipes-devtools/nlohmann-json/nlohmann-json/0001-Templatize-basic_json-ctor-from-json_ref.patch
@@ -1,0 +1,99 @@
+From ec955f08b47ab7cb81f6e4a4c3e7b331ddf50f71 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Art=C3=B6m=20Bakri=20Al-Sarmini?= <3sz3tt+git@gmail.com>
+Date: Sun, 12 Apr 2020 22:32:39 +0300
+Subject: [PATCH] Templatize basic_json ctor from json_ref
+
+Upstream-Status: Backport [https://github.com/nlohmann/json/commit/ec955f08b47ab7cb81f6e4a4c3e7b331ddf50f71]
+Signed-off-by: Andrew Geissler <geissonator@gmail.com>
+
+---
+ include/nlohmann/detail/meta/type_traits.hpp | 13 ++++++++++++
+ include/nlohmann/json.hpp                    |  8 ++++----
+ single_include/nlohmann/json.hpp             | 21 ++++++++++++++++----
+ 3 files changed, 34 insertions(+), 8 deletions(-)
+
+diff --git a/include/nlohmann/detail/meta/type_traits.hpp b/include/nlohmann/detail/meta/type_traits.hpp
+index 280f6953..dd0b3084 100644
+--- a/include/nlohmann/detail/meta/type_traits.hpp
++++ b/include/nlohmann/detail/meta/type_traits.hpp
+@@ -41,6 +41,19 @@ template<typename> struct is_basic_json : std::false_type {};
+ NLOHMANN_BASIC_JSON_TPL_DECLARATION
+ struct is_basic_json<NLOHMANN_BASIC_JSON_TPL> : std::true_type {};
+
++//////////////////////
++// jspn_ref helpers //
++//////////////////////
++
++template <typename>
++class json_ref;
++
++template<typename>
++struct is_json_ref : std::false_type {};
++
++template <typename T>
++struct is_json_ref<json_ref<T>> : std::true_type {};
++
+ //////////////////////////
+ // aliases for detected //
+ //////////////////////////
+diff --git a/include/nlohmann/json.hpp b/include/nlohmann/json.hpp
+index 336d69fe..0598efc8 100644
+--- a/include/nlohmann/json.hpp
++++ b/include/nlohmann/json.hpp
+@@ -1773,10 +1773,10 @@ class basic_json
+     // other constructors and destructor //
+     ///////////////////////////////////////
+
+-    /// @private
+-    basic_json(const detail::json_ref<basic_json>& ref)
+-        : basic_json(ref.moved_or_copied())
+-    {}
++    template <typename JsonRef,
++              detail::enable_if_t<detail::conjunction<detail::is_json_ref<JsonRef>,
++                                  std::is_same<typename JsonRef::value_type, basic_json>>::value, int> = 0 >
++    basic_json(const JsonRef& ref) : basic_json(ref.moved_or_copied()) {}
+
+     /*!
+     @brief copy constructor
+diff --git a/single_include/nlohmann/json.hpp b/single_include/nlohmann/json.hpp
+index 09464f3b..8927180e 100644
+--- a/single_include/nlohmann/json.hpp
++++ b/single_include/nlohmann/json.hpp
+@@ -2794,6 +2794,19 @@ template<typename> struct is_basic_json : std::false_type {};
+ NLOHMANN_BASIC_JSON_TPL_DECLARATION
+ struct is_basic_json<NLOHMANN_BASIC_JSON_TPL> : std::true_type {};
+
++//////////////////////
++// jspn_ref helpers //
++//////////////////////
++
++template <typename>
++class json_ref;
++
++template<typename>
++struct is_json_ref : std::false_type {};
++
++template <typename T>
++struct is_json_ref<json_ref<T>> : std::true_type {};
++
+ //////////////////////////
+ // aliases for detected //
+ //////////////////////////
+@@ -16632,10 +16645,10 @@ class basic_json
+     // other constructors and destructor //
+     ///////////////////////////////////////
+
+-    /// @private
+-    basic_json(const detail::json_ref<basic_json>& ref)
+-        : basic_json(ref.moved_or_copied())
+-    {}
++    template <typename JsonRef,
++              detail::enable_if_t<detail::conjunction<detail::is_json_ref<JsonRef>,
++                                  std::is_same<typename JsonRef::value_type, basic_json>>::value, int> = 0 >
++    basic_json(const JsonRef& ref) : basic_json(ref.moved_or_copied()) {}
+
+     /*!
+     @brief copy constructor
+--
+2.21.0 (Apple Git-122)
+

--- a/meta-oe/recipes-devtools/nlohmann-json/nlohmann-json/0001-typo-fix.patch
+++ b/meta-oe/recipes-devtools/nlohmann-json/nlohmann-json/0001-typo-fix.patch
@@ -1,0 +1,43 @@
+From 70be9751cd60e622ce6463f41d47c02fc2d83cbc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Art=C3=B6m=20Bakri=20Al-Sarmini?= <3sz3tt+git@gmail.com>
+Date: Sun, 12 Apr 2020 23:42:26 +0300
+Subject: [PATCH] typo fix
+
+Upstream-Status: Backport [https://github.com/nlohmann/json/commit/70be9751cd60e622ce6463f41d47c02fc2d83cbc]
+
+Signed-off-by: Andrew Geissler <geissonator@gmail.com>
+
+---
+ include/nlohmann/detail/meta/type_traits.hpp | 2 +-
+ single_include/nlohmann/json.hpp             | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/nlohmann/detail/meta/type_traits.hpp b/include/nlohmann/detail/meta/type_traits.hpp
+index dd0b3084..13e92cb4 100644
+--- a/include/nlohmann/detail/meta/type_traits.hpp
++++ b/include/nlohmann/detail/meta/type_traits.hpp
+@@ -42,7 +42,7 @@ NLOHMANN_BASIC_JSON_TPL_DECLARATION
+ struct is_basic_json<NLOHMANN_BASIC_JSON_TPL> : std::true_type {};
+
+ //////////////////////
+-// jspn_ref helpers //
++// json_ref helpers //
+ //////////////////////
+
+ template <typename>
+diff --git a/single_include/nlohmann/json.hpp b/single_include/nlohmann/json.hpp
+index 8927180e..294e7509 100644
+--- a/single_include/nlohmann/json.hpp
++++ b/single_include/nlohmann/json.hpp
+@@ -2795,7 +2795,7 @@ NLOHMANN_BASIC_JSON_TPL_DECLARATION
+ struct is_basic_json<NLOHMANN_BASIC_JSON_TPL> : std::true_type {};
+
+ //////////////////////
+-// jspn_ref helpers //
++// json_ref helpers //
+ //////////////////////
+
+ template <typename>
+--
+2.21.0 (Apple Git-122)
+

--- a/meta-oe/recipes-devtools/nlohmann-json/nlohmann-json_3.7.3.bb
+++ b/meta-oe/recipes-devtools/nlohmann-json/nlohmann-json_3.7.3.bb
@@ -4,7 +4,10 @@ SECTION = "libs"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.MIT;md5=f5f7c71504da070bcf4f090205ce1080"
 
-SRC_URI = "git://github.com/nlohmann/json.git;nobranch=1"
+SRC_URI = "git://github.com/nlohmann/json.git;nobranch=1 \
+           file://0001-Templatize-basic_json-ctor-from-json_ref.patch \
+           file://0001-typo-fix.patch \
+           "
 
 SRCREV = "e7b3b40b5a95bc74b9a7f662830a27c49ffc01b4"
 


### PR DESCRIPTION
The following issue and PR describe an issue with nlohmann-json and
GCC10.

https://github.com/nlohmann/json/issues/1920
https://github.com/nlohmann/json/pull/2034

Confirmed that this fixed the issue seen in OpenBMC when pulling in the
latest upstream meta-openembedded.