### PR TITLE
python-periphery: Add python-mmap to RDEPENDS

### DIFF
--- a/meta-python/recipes-devtools/python/python-periphery.inc
+++ b/meta-python/recipes-devtools/python/python-periphery.inc
@@ -5,3 +5,5 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://PKG-INFO;md5=1ecf5c2354c22fb5bfd53eefb8f9e65b"
 
 PYPI_PACKAGE = "python-periphery"
+
+RDEPENDS_${PN} += "${PYTHON_PN}-mmap"


### PR DESCRIPTION
Fixes #233