### PR TITLE
[dunfell][master] geoclue: select avahi-daemon if nmea enabled

### DIFF
--- a/meta-oe/recipes-navigation/geoclue/geoclue_2.5.3.bb
+++ b/meta-oe/recipes-navigation/geoclue/geoclue_2.5.3.bb
@@ -31,7 +31,7 @@ PACKAGECONFIG ??= "3g modem-gps cdma nmea lib"
 PACKAGECONFIG[3g] = "-D3g-source=true,-D3g-source=false,modemmanager"
 PACKAGECONFIG[modem-gps] = "-Dmodem-gps-source=true,-Dmodem-gps-source=false,modemmanager"
 PACKAGECONFIG[cdma] = "-Dcdma-source=true,-Dcdma-source=false,modemmanager"
-PACKAGECONFIG[nmea] = "-Dnmea-source=true,-Dnmea-source=false,avahi"
+PACKAGECONFIG[nmea] = "-Dnmea-source=true,-Dnmea-source=false,avahi,avahi-daemon"
 PACKAGECONFIG[lib] = "-Dlibgeoclue=true,-Dlibgeoclue=false,gobject-introspection"
 
 GTKDOC_MESON_OPTION = "gtk-doc"


### PR DESCRIPTION
geoclue serivce rely on avahi-daemon, so enable it by default.