### PR TITLE
Set monit files in temporary locations

### DIFF
--- a/meta-oe/recipes-support/monit/monit/monitrc
+++ b/meta-oe/recipes-support/monit/monit/monitrc
@@ -21,6 +21,12 @@ set daemon  30              # check services at 30 seconds intervals
 #                           # default Monit check immediately after Monit start)
 #
 #
+
+# set monit files in temporary locations
+set pidfile /var/run/.monit.pid
+set statefile /var/run/.monit.state
+set idfile /var/run/.monit.id
+
 ## Set syslog logging. If you want to log to a standalone log file instead,
 ## specify the full path to the log file
 #


### PR DESCRIPTION
Normally monit create its temporary files in $HOME directory.
In case the rootfs is mounted as read-only, monit will not operate.
This patch sets monit configuration to store those files in /var/run

Signed-off-by: Shlomi Vaknin <shlomi.39sd@gmail.com>