### PR TITLE
Issue #280: firewalld rdepends on nftables-python but this runtime de…

### DIFF
--- a/meta-networking/recipes-connectivity/firewalld/firewalld_0.9.0.bb
+++ b/meta-networking/recipes-connectivity/firewalld/firewalld_0.9.0.bb
@@ -87,4 +87,5 @@ RDEPENDS_${PN} = "\
     python3-slip-dbus \
     python3-decorator \
     python3-pygobject \
+    nftables-python \
 "


### PR DESCRIPTION
Issue #280: firewalld rdepends on nftables-python but this runtime dependency was missing in firewalld recipe.

This fixes #280.

Signed-off-by: Winfried Dobbe <winfried.dobbe@xmsnet.nl>