### PR TITLE
python3-paramiko: fixing runtime dependencies

### DIFF
--- a/meta-python/recipes-devtools/python/python3-paramiko_2.7.2.bb
+++ b/meta-python/recipes-devtools/python/python3-paramiko_2.7.2.bb
@@ -12,3 +12,8 @@ inherit pypi setuptools3
 
 CLEANBROKEN = "1"
 
+RDEPENDS_${PN} += "\
+    ${PYTHON_PN}-bcrypt \
+    ${PYTHON_PN}-cryptography \
+    ${PYTHON_PN}-pynacl \
+"


### PR DESCRIPTION
added rdepends to bcrypt, cryptography, pynacl as required by the
actual python package

Signed-off-by: Siming Yuan <siyuan@cisco.com>