### PR TITLE
Add Python recipes: transitions, dill, and cerberus

### DIFF
--- a/meta-python/recipes-core/packagegroups/packagegroup-meta-python.bb
+++ b/meta-python/recipes-core/packagegroups/packagegroup-meta-python.bb
@@ -427,6 +427,7 @@ RDEPENDS_packagegroup-meta-python3 = "\
     python3-jsonref \
     python3-transitions \
     python3-dill \
+    python3-cerberus \
 "
 
 RDEPENDS_packagegroup-meta-python3-extended = "\

--- a/meta-python/recipes-core/packagegroups/packagegroup-meta-python.bb
+++ b/meta-python/recipes-core/packagegroups/packagegroup-meta-python.bb
@@ -425,6 +425,7 @@ RDEPENDS_packagegroup-meta-python3 = "\
     python3-pycurl \
     gyp \
     python3-jsonref \
+    python3-transitions \
 "
 
 RDEPENDS_packagegroup-meta-python3-extended = "\

--- a/meta-python/recipes-core/packagegroups/packagegroup-meta-python.bb
+++ b/meta-python/recipes-core/packagegroups/packagegroup-meta-python.bb
@@ -426,6 +426,7 @@ RDEPENDS_packagegroup-meta-python3 = "\
     gyp \
     python3-jsonref \
     python3-transitions \
+    python3-dill \
 "
 
 RDEPENDS_packagegroup-meta-python3-extended = "\

--- a/meta-python/recipes-devtools/python/python3-cerberus_1.3.2.bb
+++ b/meta-python/recipes-devtools/python/python3-cerberus_1.3.2.bb
@@ -1,0 +1,11 @@
+# The PyPI package uses a capital letter so we have to specify this explicitly
+PYPI_PACKAGE = "Cerberus"
+
+inherit pypi setuptools3
+
+SUMMARY = "Lightweight, extensible schema and data validation tool for Python dictionaries."
+LICENSE = "ISC"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=48f8e9432d0dac5e0e7a18211a0bacdb"
+
+SRC_URI[md5sum] = "6e648b38b468617a06745d1e8a96c848"
+SRC_URI[sha256sum] = "302e6694f206dd85cb63f13fd5025b31ab6d38c99c50c6d769f8fa0b0f299589"

--- a/meta-python/recipes-devtools/python/python3-dill_0.3.2.bb
+++ b/meta-python/recipes-devtools/python/python3-dill_0.3.2.bb
@@ -1,0 +1,9 @@
+inherit pypi setuptools3
+
+SUMMARY = "Serialize all of python"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=90fee9f98d11d59df3f8aa813ff9a3de"
+
+SRC_URI = "https://files.pythonhosted.org/packages/e2/96/518a8ea959a734b70d2e95fef98bcbfdc7adad1c1e5f5dd9148c835205a5/dill-${PV}.zip"
+SRC_URI[md5sum] = "543607e0a419f154dca65265e87e4812"
+SRC_URI[sha256sum] = "6e12da0d8e49c220e8d6e97ee8882002e624f1160289ce85ec2cc0a5246b3a2e"

--- a/meta-python/recipes-devtools/python/python3-transitions_0.8.4.bb
+++ b/meta-python/recipes-devtools/python/python3-transitions_0.8.4.bb
@@ -1,0 +1,11 @@
+inherit pypi setuptools3
+
+SUMMARY = "A lightweight, object-oriented Python state machine implementation with many extensions."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=de0a0876a688a4483bfafa764773ab39"
+
+SRC_URI = "https://files.pythonhosted.org/packages/32/32/305845f95f98b505e641aa3fc135b0a9747befcff06223a541d2aa388d47/transitions-${PV}.tar.gz"
+SRC_URI[md5sum] = "ef07ea90015a296653a4b095837b0354"
+SRC_URI[sha256sum] = "9a2841b24789dfd345267cb92e26b79da75fd03f6021d1a5222c71b5c9ae3c16"
+
+RDEPENDS_${PN} += "python3-six"


### PR DESCRIPTION
* [transitions](https://pypi.org/project/transitions/): A lightweight, object-oriented Python state machine implementation with many extensions
* [dill](https://pypi.org/project/dill/): Serialization package
* [cerberus](https://pypi.org/project/Cerberus/): Lightweight, extensible schema and data validation tool for Python dictionaries

---

Hi all,

I added these three libraries (among others) to my custom layer as our applications depend on them but they are not yet present in meta-openembedded.