### PR TITLE
[meta-oe] devtools/php: remove the failing ${D}/${TMPDIR} code

### DIFF
--- a/meta-oe/recipes-devtools/php/php_7.4.9.bb
+++ b/meta-oe/recipes-devtools/php/php_7.4.9.bb
@@ -155,7 +155,6 @@ do_install_prepend_class-target() {
 # fixme
 do_install_append_class-target() {
     install -d ${D}${sysconfdir}/
-    rm -rf ${D}/${TMPDIR}
     rm -rf ${D}/.registry
     rm -rf ${D}/.channels
     rm -rf ${D}/.[a-z]*
@@ -178,14 +177,6 @@ do_install_append_class-target() {
             -e 's,@LOCALSTATEDIR@,${localstatedir},g' \
             ${D}${systemd_unitdir}/system/php-fpm.service
     fi
-
-    TMP=`dirname ${D}/${TMPDIR}`
-    while test ${TMP} != ${D}; do
-        if [ -d ${TMP} ]; then
-            rmdir ${TMP}
-        fi
-        TMP=`dirname ${TMP}`;
-    done
 
     if ${@bb.utils.contains('PACKAGECONFIG', 'apache2', 'true', 'false', d)}; then
         install -d ${D}${sysconfdir}/apache2/modules.d


### PR DESCRIPTION
Appending ${TMPDIR} to ${D} doesn't make any sense, because both are
absolute paths.  And additionally, the code fails:

 rmdir: failed to remove '/usr/src/oe/tmp-musl/work/core2-64-oe-linux-musl/php/7.1.9-r0/image//usr': Directory not empty

Signed-off-by: Max Kellermann <max.kellermann@gmail.com>

(This is the successor of #66 which I cannot update because I had deleted my fork long ago. @kraj)