### PR TITLE
[master] pcsc-lite: provide pcsc-lite-lib-native explicitly for native build

### DIFF
--- a/meta-oe/recipes-support/pcsc-lite/pcsc-lite_1.9.0.bb
+++ b/meta-oe/recipes-support/pcsc-lite/pcsc-lite_1.9.0.bb
@@ -36,6 +36,7 @@ PACKAGES = "${PN} ${PN}-dbg ${PN}-dev ${PN}-lib ${PN}-doc ${PN}-spy ${PN}-spy-de
 
 RRECOMMENDS_${PN} = "ccid"
 RRECOMMENDS_${PN}_class-native = ""
+RPROVIDES_${PN}_class-native += "pcsc-lite-lib-native"
 
 FILES_${PN} = "${sbindir}/pcscd"
 FILES_${PN}-lib = "${libdir}/libpcsclite*${SOLIBS}"


### PR DESCRIPTION
Commits e2180b00b3b8fcf776c3 and 8edd760e66b48e411d2a added support for native builds for the opensc and pcsc-lite recipes, but building opensc-native fails after commit 40b3a5123120da0e4586:

    ERROR: Required build target 'opensc-native' has no buildable providers.
    Missing or unbuildable dependency chain was: ['opensc-native', 'pcsc-lite-lib-native']

The commit in question is correct for target builds, but native builds don't have packages. The -lib part is also provided along with pcsc-lite-native, and there is no pcsc-lite-lib-native package.

Ideally we would fix this in the opensc recipe. However, using syntax like "PACKAGECONFIG_class-native[pcsc]" in the opensc recipe is apparently not possible to overwrite the dependency for a native build, and using RDEPENDS_remove has no effect either – apparently dependencies from PACKAGECONFIG are added after RDEPENDS_remove is evaluated. Therefore let pcsc-lite provide the missing package name for native builds, even if fixing this unrelated package is not the most elegant solution.

This is for master, dunfell is in #294.