### PR TITLE
[master][dunfell] openct: cleanup and allow building as native package

### DIFF
--- a/meta-oe/recipes-support/openct/openct_0.6.20.bb
+++ b/meta-oe/recipes-support/openct/openct_0.6.20.bb
@@ -46,7 +46,6 @@ FILES_${PN} += " \
     ${nonarch_base_libdir}/udev \
     ${libdir}/openct-ifd.so \
     ${libdir}/pcsc \
-    /run/openct/status \
 "
 
 FILES_${PN}-dbg += " \
@@ -79,10 +78,4 @@ do_install () {
     so=$(find ${D} -name \*.so | sed "s|^${D}||")
     sed -i -e 's|\\(LIBPATH\\s*\\).*|\\1$so|' etc/reader.conf
     install -Dpm 644 etc/reader.conf ${D}/etc/reader.conf.d/openct.conf
-
-    install -dm 755 ${D}${localstatedir}/run/openct
-    touch ${D}${localstatedir}/run/openct/status
-    chmod 644 ${D}${localstatedir}/run/openct/status
-
-    rm -r ${D}/${localstatedir}/run
 }

--- a/meta-oe/recipes-support/openct/openct_0.6.20.bb
+++ b/meta-oe/recipes-support/openct/openct_0.6.20.bb
@@ -35,7 +35,7 @@ EXTRA_OECONF=" \
     --enable-pcsc \
     --enable-doc \
     --enable-api-doc \
-    --with-udev=${nonarch_base_libdir}/udev \
+    --with-udev=${nonarch_libdir}/udev \
     --with-bundle=${libdir}/pcsc/drivers \
 "
 
@@ -43,7 +43,7 @@ inherit autotools pkgconfig
 
 FILES_${PN} += " \
     ${libdir}/ctapi \
-    ${nonarch_base_libdir}/udev \
+    ${nonarch_libdir}/udev \
     ${libdir}/openct-ifd.so \
     ${libdir}/pcsc \
 "
@@ -55,10 +55,10 @@ FILES_${PN}-dbg += " \
 
 INSANE_SKIP_${PN} += "dev-deps"
 
+do_install[cleandirs] += "${D}"
+
 do_install () {
-    rm -rf ${D}
-    install -d ${D}/etc
-    install -dm 755 ${D}${nonarch_base_libdir}/udev
+    install -d ${D}${sysconfdir}
     # fix up hardcoded paths
     sed -i -e 's,/etc/,${sysconfdir}/,' -e 's,/usr/sbin/,${sbindir}/,' \
         ${WORKDIR}/openct.service ${WORKDIR}/openct.init
@@ -66,16 +66,16 @@ do_install () {
     oe_runmake install DESTDIR=${D}
     install -dm 755 ${D}${libdir}/ctapi/
     mv ${D}${libdir}/libopenctapi.so ${D}${libdir}/ctapi/
-    install -Dpm 644 etc/openct.udev ${D}/etc/udev/rules.d/60-openct.rules
-    install -pm 644 etc/openct.conf ${D}/etc/openct.conf
+    install -Dpm 644 etc/openct.udev ${D}${nonarch_libdir}/udev/rules.d/60-openct.rules
+    install -pm 644 etc/openct.conf ${D}${sysconfdir}/openct.conf
 
-    install -Dpm 755 ${WORKDIR}/openct.init ${D}/etc/init.d/openct
-    install -Dpm 644 ${WORKDIR}/openct.sysconfig ${D}/etc/sysconfig/openct
+    install -Dpm 755 ${WORKDIR}/openct.init ${D}${sysconfdir}/init.d/openct
+    install -Dpm 644 ${WORKDIR}/openct.sysconfig ${D}${sysconfdir}/sysconfig/openct
 
-    install -d ${D}/${systemd_unitdir}/system
-    install -m 644 ${WORKDIR}/openct.service ${D}/${systemd_unitdir}/system
+    install -d ${D}${systemd_unitdir}/system
+    install -m 644 ${WORKDIR}/openct.service ${D}${systemd_unitdir}/system
 
     so=$(find ${D} -name \*.so | sed "s|^${D}||")
     sed -i -e 's|\\(LIBPATH\\s*\\).*|\\1$so|' etc/reader.conf
-    install -Dpm 644 etc/reader.conf ${D}/etc/reader.conf.d/openct.conf
+    install -Dpm 644 etc/reader.conf ${D}${sysconfdir}/reader.conf.d/openct.conf
 }

--- a/meta-oe/recipes-support/openct/openct_0.6.20.bb
+++ b/meta-oe/recipes-support/openct/openct_0.6.20.bb
@@ -79,3 +79,5 @@ do_install () {
     sed -i -e 's|\\(LIBPATH\\s*\\).*|\\1$so|' etc/reader.conf
     install -Dpm 644 etc/reader.conf ${D}${sysconfdir}/reader.conf.d/openct.conf
 }
+
+BBCLASSEXTEND="native"


### PR DESCRIPTION
* Allow building openct as native package
* Clean up `do_install`:
  - Use `sysconfdir` and `nonarch_libdir` instead of hard-coded paths, and be
    consistent with the slashes after `${D}`
  - Install udev rules into `/usr/lib/udev` instead of `/etc/udev` so they can
    be overwritten in `/etc`, which has higher priority. Also use `/usr/lib`
    instead of `/lib`, latter of which isn't searched by udev (see
    [manpage][1]).
  - Don't create `/usr/lib/udev`, it is already created by `install -D` later
    with the default umask, which is fine.
  - Make use of `do_install[cleandirs]`.
* Remove lines that first created `/var/run/openct` and then removed it again

This is for master, but applies to dunfell as well.