### PR TITLE
nodejs: 12.19.0 -> 12.19.1

### DIFF
--- a/meta-oe/recipes-devtools/nodejs/nodejs_12.19.1.bb
+++ b/meta-oe/recipes-devtools/nodejs/nodejs_12.19.1.bb
@@ -26,7 +26,7 @@ SRC_URI = "http://nodejs.org/dist/v${PV}/node-v${PV}.tar.xz \
 SRC_URI_append_class-target = " \
            file://0002-Using-native-binaries.patch \
            "
-SRC_URI[sha256sum] = "3b671c45c493f96d7e018c15110cdbafa4478e5e5cfc9e6eec83cea9e6b551e1"
+SRC_URI[sha256sum] = "74077e0cc3db000a6f3cc685b220e609807b61adc8e7d8243e8511d478d1b17d"
 
 S = "${WORKDIR}/node-v${PV}"
 


### PR DESCRIPTION
Uprev nodejs in order to fix CVE-2020-8277.
This CVE allows an attacker to trigger a DNS request for a host
of their choice, which could trigger a Denial of Service in
nodejs versions < 12.19.1.

See https://nvd.nist.gov/vuln/detail/CVE-2020-8277 for details.

CVE: CVE-2020-8277
Signed-off-by: Stacy Gaikovaia <Stacy.Gaikovaia@windriver.com>