### PR TITLE
Add recipe for dbus-cxx

### DIFF
--- a/meta-oe/recipes-core/dbus-cxx/dbus-cxx_0.12.bb
+++ b/meta-oe/recipes-core/dbus-cxx/dbus-cxx_0.12.bb
@@ -1,0 +1,24 @@
+SUMMARY = "D-Bus wrapper in C++ for dbus"
+HOMEPAGE = "https://dbus-cxx.github.io/"
+SECTION = "base"
+LICENSE = "GPLv3"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4cf0188f02184e1e84b9586ac53c3f83"
+
+SRC_URI = "git://github.com/dbus-cxx/dbus-cxx.git;branch=master"
+SRCREV = "ea7f8e361d11dc7d41d9ae2c4128aed2cdadd84e"
+
+DEPENDS = "\
+	dbus \
+	libsigc++-2.0 \
+"
+
+RDEPENDS_${PN} = "\
+	dbus \
+	libsigc++-2.0 \
+"
+
+S = "${WORKDIR}/git/"
+
+inherit pkgconfig cmake
+
+OECMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "BOTH"

--- a/meta-oe/recipes-core/dbus-cxx/dbus-cxx_0.12.bb
+++ b/meta-oe/recipes-core/dbus-cxx/dbus-cxx_0.12.bb
@@ -4,7 +4,9 @@ SECTION = "base"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4cf0188f02184e1e84b9586ac53c3f83"
 
+FILEEXTRAPATHS_prepend = "${THISDIR}/files"
 SRC_URI = "git://github.com/dbus-cxx/dbus-cxx.git;branch=master"
+SRC_URI += "file://fix_build_musl.patch"
 SRCREV = "ea7f8e361d11dc7d41d9ae2c4128aed2cdadd84e"
 
 DEPENDS = "\

--- a/meta-oe/recipes-core/dbus-cxx/files/fix_build_musl.patch
+++ b/meta-oe/recipes-core/dbus-cxx/files/fix_build_musl.patch
@@ -1,0 +1,26 @@
+diff --git a/dbus-cxx/timeout.cpp b/dbus-cxx/timeout.cpp
+index 16e9f7e..aa0b99f 100644
+--- a/dbus-cxx/timeout.cpp
++++ b/dbus-cxx/timeout.cpp
+@@ -132,7 +132,7 @@ namespace DBus
+     return m_cobj;
+   }
+ 
+-  void Timeout::timer_callback_proxy( sigval_t sv ) {
++  void Timeout::timer_callback_proxy( union sigval sv ) {
+     SIMPLELOGGER_DEBUG( "dbus.Timeout","Timeout::timer_callback_proxy" );
+     Timeout* t;
+     t = ( Timeout* ) sv.sival_ptr;
+diff --git a/dbus-cxx/timeout.h b/dbus-cxx/timeout.h
+index 1e469b5..5b69fbb 100644
+--- a/dbus-cxx/timeout.h
++++ b/dbus-cxx/timeout.h
+@@ -83,7 +83,7 @@ namespace DBus
+ 
+       std::mutex m_arming_mutex;
+ 
+-      static void timer_callback_proxy( sigval_t sv );
++      static void timer_callback_proxy( union sigval sv );
+ 
+   };
+ 

--- a/meta-oe/recipes-core/packagegroups/packagegroup-meta-oe.bb
+++ b/meta-oe/recipes-core/packagegroups/packagegroup-meta-oe.bb
@@ -179,6 +179,7 @@ RDEPENDS_packagegroup-meta-oe-core = "\
     sdbus-c++ \
     toybox \
     usleep \
+    dbus-cxx \
 "
 RDEPENDS_packagegroup-meta-oe-core_append_libc-glibc = " glfw"
 RDEPENDS_packagegroup-meta-oe-core_remove_riscv64 = "safec"


### PR DESCRIPTION
The library dbus-cxx is a C++ wrapper for dbus.

For more information check: https://dbus-cxx.github.io/