### PR TITLE
remove PNBLACKLIST for can-isotp module

### DIFF
--- a/meta-oe/recipes-extended/socketcan/can-isotp_git.bb
+++ b/meta-oe/recipes-extended/socketcan/can-isotp_git.bb
@@ -1,13 +1,12 @@
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=72d977d697c3c05830fdff00a7448931"
-SRCREV = "d50a2001ec994031233ad9c0cc1647fad41835f3"
+SRCREV = "b31bce98d65f894aad6427bcf6f3f7822e261a59"
 PV = "1.0+git${SRCPV}"
 
-SRC_URI = "git://github.com/hartkopp/can-isotp.git;branch=4.17+;protocol=https"
+SRC_URI = "git://github.com/hartkopp/can-isotp.git;protocol=https"
 
 S = "${WORKDIR}/git"
 
 inherit module
 
 EXTRA_OEMAKE += "KERNELDIR=${STAGING_KERNEL_DIR}"
-

--- a/meta-oe/recipes-extended/socketcan/can-isotp_git.bb
+++ b/meta-oe/recipes-extended/socketcan/can-isotp_git.bb
@@ -1,9 +1,9 @@
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=72d977d697c3c05830fdff00a7448931"
-SRCREV = "b31bce98d65f894aad6427bcf6f3f7822e261a59"
+SRCREV = "d50a2001ec994031233ad9c0cc1647fad41835f3"
 PV = "1.0+git${SRCPV}"
 
-SRC_URI = "git://github.com/hartkopp/can-isotp.git;protocol=https"
+SRC_URI = "git://github.com/hartkopp/can-isotp.git;branch=4.17+;protocol=https"
 
 S = "${WORKDIR}/git"
 
@@ -11,4 +11,3 @@ inherit module
 
 EXTRA_OEMAKE += "KERNELDIR=${STAGING_KERNEL_DIR}"
 
-PNBLACKLIST[can-isotp] = "Kernel module Needs forward porting to kernel 5.2+"


### PR DESCRIPTION
Like I described in Issue for dunfell,

1. Remove PNBLACKLIST for can-isotp module
2. Move git branch to 4.17+ in can-isotp git repo
3. Revert commit id to 41835f3 to avoid another conflict with kernel 5.10+