### PR TITLE
python3-sh: remove python3-tests from RDEPENDS

### DIFF
--- a/meta-python/recipes-devtools/python/python3-sh_1.14.1.bb
+++ b/meta-python/recipes-devtools/python/python3-sh_1.14.1.bb
@@ -18,7 +18,6 @@ RDEPENDS_${PN} += " \
     ${PYTHON_PN}-resource \
     ${PYTHON_PN}-shell \
     ${PYTHON_PN}-terminal \
-    ${PYTHON_PN}-tests \
     ${PYTHON_PN}-threading \
     ${PYTHON_PN}-unixadmin \
 "


### PR DESCRIPTION
python3-tests installs the unit tests of python
as well as stuff that no one should care about
in its rootfs. Thus, it is not a runtime dependency
of python3-sh.

Signed-off-by: Shlomi Vaknin <shlomi.39sd@gmail.com>