### PR TITLE
libbpf: use pkg-config

### DIFF
--- a/meta-oe/recipes-kernel/libbpf/libbpf_0.3.bb
+++ b/meta-oe/recipes-kernel/libbpf/libbpf_0.3.bb
@@ -23,6 +23,8 @@ S = "${WORKDIR}/git/src"
 
 EXTRA_OEMAKE += "DESTDIR=${D} LIBDIR=${libdir}"
 
+inherit pkgconfig
+
 do_compile() {
 	if grep -q "CONFIG_BPF_SYSCALL=y" ${STAGING_KERNEL_BUILDDIR}/.config
 	then
@@ -40,5 +42,3 @@ do_install() {
 		bbnote "no files to install"
 	fi
 }
-
-BBCLASSEXTEND = "native"


### PR DESCRIPTION
The libbpf makefile uses pkg-config to get the libelf build flags and
file paths.
Inherit pkgconfig so the install target can copy the binaries in the
sysroot, which are needed by other packages, like bcc.

While at it, remove "native" which is unneeded for this recipe.

Signed-off-by: Matteo Croce <mcroce@microsoft.com>