### PR TITLE
rsyslog: fix sbindir variable substitution

### DIFF
--- a/meta-oe/recipes-extended/rsyslog/rsyslog_8.2102.0.bb
+++ b/meta-oe/recipes-extended/rsyslog/rsyslog_8.2102.0.bb
@@ -151,7 +151,7 @@ do_install_append() {
     if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
         install -d ${D}${systemd_system_unitdir}
         install -m 644 ${WORKDIR}/rsyslog.service ${D}${systemd_system_unitdir}
-        sed -i -e "s,@sbindir\@,$(sbindir),g" ${D}${systemd_system_unitdir}/rsyslog.service
+        sed -i -e "s,@sbindir@,${sbindir},g" ${D}${systemd_system_unitdir}/rsyslog.service
     fi
 }
 


### PR DESCRIPTION
Noticed that when we pulled the latest commits into OpenBMC that this
issue hit:
systemd[228]: rsyslog.service: Failed to locate executable /rsyslogd: No such file or directory

Looking at the service file you can see the issue with the ExecStart
line:
cat /lib/systemd/system/rsyslog.service
[Unit]
Description=System Logging Service
Requires=syslog.socket
Wants=network.target network-online.target
After=network.target network-online.target
Documentation=man:rsyslogd(8)
Documentation=http://www.rsyslog.com/doc/

[Service]
Type=notify
ExecStart=/rsyslogd -n -iNONE

The issue appears to be with the sed statement in situations where the
systemd feature is enabled. I'm not a sed expert but verified that this
PR does fix the issue being seen. The following stackoverflow was where
I found some info on this:
https://stackoverflow.com/questions/584894/environment-variable-substitution-in-sed

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>