### PR TITLE
tmate: add recipe version 2.4.0

### DIFF
--- a/meta-oe/recipes-extended/tmate/tmate_2.4.0.bb
+++ b/meta-oe/recipes-extended/tmate/tmate_2.4.0.bb
@@ -1,0 +1,17 @@
+SUMMARY = "Instant terminal sharing"
+DESCRIPTION = "Tmate is a fork of tmux. It provides an instant pairing solution."
+AUTHOR = "Marius Kriegerowski <marius.kriegerowski@gmail.com>"
+HOMEPAGE = "https://tmate.io/"
+LICENSE = "ISC"
+LIC_FILES_CHKSUM = "file://COPYING;md5=f7d9aab84ec6567139a4755c48d147fb"
+
+DEPENDS_append = " libevent libssh msgpack-c ncurses"
+SRC_URI = "\
+    git://github.com/tmate-io/tmate.git;protocol=https \
+"
+
+SRCREV = "5e00bfa5e137e76c81888727712ced2b3fd99f5b"
+
+S = "${WORKDIR}/git"
+
+inherit pkgconfig autotools


### PR DESCRIPTION
Add a recipe for tmate, a fork of tmux that provides remote terminal
sharing.

Signed-off-by: Marius Kriegerowski <marius.kriegerowski@gmail.com>