### PR TITLE
[gatesgarth-next] gpsd: backport d-bus message time patch from upstream

### DIFF
--- a/meta-oe/recipes-navigation/gpsd/gpsd/0001-gpsd-dbusexport.c-Fix-broken-d-bus-message-time.patch
+++ b/meta-oe/recipes-navigation/gpsd/gpsd/0001-gpsd-dbusexport.c-Fix-broken-d-bus-message-time.patch
@@ -1,0 +1,36 @@
+From c9cec2a888d4fea8534be78a0f46d920155ceae6 Mon Sep 17 00:00:00 2001
+From: Paul Fertser <fercerpav@gmail.com>
+Date: Wed, 4 Nov 2020 12:40:50 -0800
+Subject: [PATCH] gpsd/dbusexport.c: Fix broken d-bus message time.
+
+Change-Id: I4b9990ce4517a8feb29fc9e090c62f5a0c56ddd5
+---
+ dbusexport.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/dbusexport.c b/dbusexport.c
+index 40b35739e..5d08a8702 100644
+--- a/dbusexport.c
++++ b/dbusexport.c
+@@ -38,6 +38,7 @@ void send_dbus_fix(struct gps_device_t *channel)
+     /*DBusMessageIter   iter; */
+     dbus_uint32_t serial;	/* collected, but not used */
+     char *gpsd_devname;
++    double dtime;               // time as a double, loss of precision!
+ 
+     /* if the connection is non existent, return without doing anything */
+     if (connection == NULL)
+@@ -51,8 +52,9 @@ void send_dbus_fix(struct gps_device_t *channel)
+     /* the dbus/locationd doc fails to specify altitude as WGS84 or MSL.
+      * assume altMSL */
+     message = dbus_message_new_signal("/org/gpsd", "org.gpsd", "fix");
++    dtime = TSTONS(&gpsfix->time);
+     dbus_message_append_args(message,
+-			     DBUS_TYPE_DOUBLE, &(gpsfix->time),
++			     DBUS_TYPE_DOUBLE, &dtime,
+ 			     DBUS_TYPE_INT32, &(gpsfix->mode),
+ 			     DBUS_TYPE_DOUBLE, &(gpsfix->ept),
+ 			     DBUS_TYPE_DOUBLE, &(gpsfix->latitude),
+-- 
+2.20.1
+

--- a/meta-oe/recipes-navigation/gpsd/gpsd_3.20.bb
+++ b/meta-oe/recipes-navigation/gpsd/gpsd_3.20.bb
@@ -8,6 +8,7 @@ PROVIDES = "virtual/gpsd"
 SRC_URI = "${SAVANNAH_GNU_MIRROR}/${BPN}/${BP}.tar.gz \
     file://0001-SConstruct-prefix-includepy-with-sysroot-and-drop-sy.patch \
     file://0001-Revert-SConstruct-Add-test-for-sizeof-time_t-result-.patch \
+    file://0001-gpsd-dbusexport.c-Fix-broken-d-bus-message-time.patch \
     file://gpsd.init \
 "
 SRC_URI[md5sum] = "cf7fdec7ce7221d20bee1a7246362b05"


### PR DESCRIPTION
This patch is backport from 821c149d486c0e67c1bd35d7c044ede9348aeb8d of
upstream to fix the broken d-bus message time