### PR TITLE
nodejs: ppc64le machine support

### DIFF
--- a/meta-oe/recipes-devtools/nodejs/nodejs_12.21.0.bb
+++ b/meta-oe/recipes-devtools/nodejs/nodejs_12.21.0.bb
@@ -39,7 +39,7 @@ def map_nodejs_arch(a, d):
     if   re.match('i.86$', a): return 'ia32'
     elif re.match('x86_64$', a): return 'x64'
     elif re.match('aarch64$', a): return 'arm64'
-    elif re.match('(powerpc64|powerpc64le)$', a): return 'ppc64'
+    elif re.match('(powerpc64|powerpc64le|ppc64le)$', a): return 'ppc64'
     elif re.match('powerpc$', a): return 'ppc'
     return a
 


### PR DESCRIPTION
Commit 836912ab changed the logic in this recipe to stop looking for
"ppc64le". This caused the ppc64le systems used by me to stop working.
There wasn't much in the commit message on why this change occurred but
ppc64le is definitely still needed.

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>