### PR TITLE
nng: Upgrade 1.2.5 -> 1.4.0

### DIFF
--- a/meta-networking/recipes-connectivity/nanomsg/nng_1.4.0.bb
+++ b/meta-networking/recipes-connectivity/nanomsg/nng_1.4.0.bb
@@ -2,20 +2,23 @@ SUMMARY = "nanomsg-next-generation -- light-weight brokerless messaging"
 DESCRIPTION = "NNG, like its predecessors nanomsg (and to some extent ZeroMQ), is a lightweight, broker-less library, offering a simple API to solve common recurring messaging problems, such as publish/subscribe, RPC-style request/reply, or service discovery."
 HOMEPAGE = "https://github.com/nanomsg/nng"
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=a19b15be6e844b39a54de2ef665bd6de"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=a41e579bb4326c21c774f8e51e41d8a3"
 
 SECTION = "libs/networking"
 
-SRCREV = "53ae1a5ab37fdfc9ad5c236df3eaf4dd63f0fee9"
+SRCREV = "d020adda8f0348d094790618703b8341a26007a3"
 
-SRC_URI = "git://github.com/nanomsg/nng.git;branch=v1.2.x"
+SRC_URI = "git://github.com/nanomsg/nng.git"
 
 S = "${WORKDIR}/git"
 
 inherit cmake pkgconfig
 
-EXTRA_OECMAKE = "-DBUILD_SHARED_LIBS=ON"
+EXTRA_OECMAKE = "-DBUILD_SHARED_LIBS=ON -DNNG_ENABLE_NNGCAT=ON"
 
 PACKAGECONFIG ??= ""
 
 PACKAGECONFIG[mbedtls] = "-DNNG_ENABLE_TLS=ON,-DNNG_ENABLE_TLS=OFF,mbedtls"
+
+PACKAGES =+ "${PN}-tools"
+FILES_${PN}-tools = "${bindir}/*"


### PR DESCRIPTION
In contrast to 1.2.5, this recipe also builds and packages the nngcat tool.