### PR TITLE
bump makedumpfile for kernel 5.10 support

### DIFF
--- a/meta-oe/recipes-kernel/makedumpfile/makedumpfile_1.6.8.bb
+++ b/meta-oe/recipes-kernel/makedumpfile/makedumpfile_1.6.8.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
 LICENSE = "GPLv2.0"
 
 SRCBRANCH ?= "master"
-SRCREV = "18e0cdba48feeccea2429b3b0b2691f4314d1062"
+SRCREV = "a8250642a4ff50a2559446f4e915a1f59ac7adf7"
 
 DEPENDS = "bzip2 zlib elfutils xz"
 RDEPENDS_${PN}-tools = "perl ${PN}"


### PR DESCRIPTION
This patch bumps makedumpfile for kernel 5.10, prior to 1.6.9 release.
This is makedumpfile 1.6.8 plus all the commits to date.
