### PR TITLE
python3-m2crypto: restore m2crypto-0.26.4-gcc_macros.patch

### DIFF
--- a/meta-python/recipes-devtools/python/python3-m2crypto/0001-import-gcc_macros.h.patch
+++ b/meta-python/recipes-devtools/python/python3-m2crypto/0001-import-gcc_macros.h.patch
@@ -1,0 +1,59 @@
+From 1364722439a0a36e3f57119dd45de666d213888c Mon Sep 17 00:00:00 2001
+From: Martin Jansa <Martin.Jansa@gmail.com>
+Date: Wed, 5 May 2021 21:34:35 +0000
+Subject: [PATCH] import gcc_macros.h
+
+* it was dropped as unnecessary in the upgrade to 0.37.1 but for
+  aarch64 it still seems to be needed at least in some setups
+  otherwise swig fails with:
+  http://errors.yoctoproject.org/Errors/Details/580206/
+  swig -python -py3 -ITOPDIR/tmp-glibc/work/cortexa57-oe-linux/python3-m2crypto/0.37.1-r0/recipe-sysroot-native/usr/bin/aarch64-oe-linux/../../lib/aarch64-oe-linux/gcc/aarch64-oe-linux/11.1.0/include -ITOPDIR/tmp-glibc/work/cortexa57-oe-linux/python3-m2crypto/0.37.1-r0/recipe-sysroot-native/usr/bin/aarch64-oe-linux/../../lib/aarch64-oe-linux/gcc/aarch64-oe-linux/11.1.0/include-fixed -ITOPDIR/tmp-glibc/work/cortexa57-oe-linux/python3-m2crypto/0.37.1-r0/recipe-sysroot/usr/lib/aarch64-oe-linux/11.1.0/include -ITOPDIR/tmp-glibc/work/cortexa57-oe-linux/python3-m2crypto/0.37.1-r0/recipe-sysroot/usr/include -ITOPDIR/tmp-glibc/work/cortexa57-oe-linux/python3-m2crypto/0.37.1-r0/recipe-sysroot/usr/include -ITOPDIR/tmp-glibc/work/cortexa57-oe-linux/python3-m2crypto/0.37.1-r0/recipe-sysroot/usr/include/python3.9 -I/usr/include/openssl -includeall -modern -builtin -outdir TOPDIR/tmp-glibc/work/cortexa57-oe-linux/python3-m2crypto/0.37.1-r0/M2Crypto-0.37.1/M2Crypto -o SWIG/_m2crypto_wrap.c SWIG/_m2crypto.i
+  TOPDIR/tmp-glibc/work/cortexa57-oe-linux/python3-m2crypto/0.37.1-r0/recipe-sysroot/usr/include/openssl/opensslconf.h:23: Error: Unable to find 'openssl/opensslconf-32.h'
+
+* if I drop the -includeall from swig call I get a bit more reasonable error message:
+  Preprocessing...
+  /OE/build/oe-core/tmp-glibc/work/cortexa57-oe-linux/python3-m2crypto/0.37.1-r0/recipe-sysroot/usr/include/openssl/opensslconf.h:29: Error: CPP #error ""Unknown __WORDSIZE detected"". Use the -cpperraswarn option to continue swig processing.
+
+* maybe we need newer swig, the regenerated m2crypto.py shows
+  that it was generated with 4.0.2 before while meta-oe has 3.0.12
+
+Upstream-Status: Pending
+
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+---
+ SWIG/_m2crypto.i  |  10 +-
+ 2 files changed, 737 insertions(+), 5 deletions(-)
+ create mode 100644 SWIG/gcc_macros.h
+
+diff --git a/SWIG/_m2crypto.i b/SWIG/_m2crypto.i
+index e300a10..3d51c22 100644
+--- a/SWIG/_m2crypto.i
++++ b/SWIG/_m2crypto.i
+@@ -8,6 +8,11 @@
+  *
+  */
+ 
++%import "gcc_macros.h"
++
++%ignore WCHAR_MAX;
++%ignore WCHAR_MIN;
++
+ %module(threads=1) m2crypto
+ /* We really don't need threadblock (PyGILState_Ensure() etc.) anywhere.
+    Disable threadallow as well, only enable it for operations likely to
+@@ -15,10 +20,6 @@
+ %nothreadblock;
+ %nothreadallow;
+ 
+-#if SWIG_VERSION >= 0x030000
+-#define __WCHAR_MAX__ __WCHAR_MAX
+-#define __WCHAR_MIN__ __WCHAR_MIN
+-#endif
+ /* https://gitlab.com/m2crypto/m2crypto/issues/246 */
+ %ignore WCHAR_MAX;
+ %ignore WCHAR_MIN;
+@@ -103,4 +104,3 @@ static PyObject *x509_store_verify_cb_func;
+ %constant int encrypt = 1;
+ %constant int decrypt = 0;
+ #endif
+-  

--- a/meta-python/recipes-devtools/python/python3-m2crypto_0.37.1.bb
+++ b/meta-python/recipes-devtools/python/python3-m2crypto_0.37.1.bb
@@ -10,6 +10,7 @@ SRC_URI += "file://0001-setup.py-link-in-sysroot-not-in-host-directories.patch \
             file://cross-compile-platform.patch \
             file://0001-Allow-verify_cb_-to-be-called-with-ok-True.patch \
             file://0001-Use-of-RSA_SSLV23_PADDING-has-been-deprecated.patch \
+            file://0001-import-gcc_macros.h.patch \
            "
 SRC_URI[sha256sum] = "e4e42f068b78ccbf113e5d0a72ae5f480f6c3ace4940b91e4fff5598cfff6fb3"
 


### PR DESCRIPTION
* m2crypto-0.26.4-gcc_macros.patch was dropped as unnecessary
  in the upgrade to 0.37.1 but for aarch64 it still seems to
  be needed at least in some setups otherwise swig fails with:
  http://errors.yoctoproject.org/Errors/Details/580206/
  swig -python -py3 -ITOPDIR/tmp-glibc/work/cortexa57-oe-linux/python3-m2crypto/0.37.1-r0/recipe-sysroot-native/usr/bin/aarch64-oe-linux/../../lib/aarch64-oe-linux/gcc/aarch64-oe-linux/11.1.0/include -ITOPDIR/tmp-glibc/work/cortexa57-oe-linux/python3-m2crypto/0.37.1-r0/recipe-sysroot-native/usr/bin/aarch64-oe-linux/../../lib/aarch64-oe-linux/gcc/aarch64-oe-linux/11.1.0/include-fixed -ITOPDIR/tmp-glibc/work/cortexa57-oe-linux/python3-m2crypto/0.37.1-r0/recipe-sysroot/usr/lib/aarch64-oe-linux/11.1.0/include -ITOPDIR/tmp-glibc/work/cortexa57-oe-linux/python3-m2crypto/0.37.1-r0/recipe-sysroot/usr/include -ITOPDIR/tmp-glibc/work/cortexa57-oe-linux/python3-m2crypto/0.37.1-r0/recipe-sysroot/usr/include -ITOPDIR/tmp-glibc/work/cortexa57-oe-linux/python3-m2crypto/0.37.1-r0/recipe-sysroot/usr/include/python3.9 -I/usr/include/openssl -includeall -modern -builtin -outdir TOPDIR/tmp-glibc/work/cortexa57-oe-linux/python3-m2crypto/0.37.1-r0/M2Crypto-0.37.1/M2Crypto -o SWIG/_m2crypto_wrap.c SWIG/_m2crypto.i
  TOPDIR/tmp-glibc/work/cortexa57-oe-linux/python3-m2crypto/0.37.1-r0/recipe-sysroot/usr/include/openssl/opensslconf.h:23: Error: Unable to find 'openssl/opensslconf-32.h'

* if I drop the -includeall from swig call I get a bit more reasonable error message:
  Preprocessing...
  /OE/build/oe-core/tmp-glibc/work/cortexa57-oe-linux/python3-m2crypto/0.37.1-r0/recipe-sysroot/usr/include/openssl/opensslconf.h:29: Error: CPP #error ""Unknown __WORDSIZE detected"". Use the -cpperraswarn option to continue swig processing.

* gcc_macros.h is generated by do_configure_prepend, if
  this patch really isn't needed, then the do_configure_prepend
  should probably be dropped as well

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
Signed-off-by: Khem Raj <raj.khem@gmail.com>
Signed-off-by: Trevor Gamblin <trevor.gamblin@windriver.com>