### PR TITLE
linuxptp: improvements

### DIFF
--- a/meta-oe/recipes-connectivity/linuxptp/linuxptp_3.1.bb
+++ b/meta-oe/recipes-connectivity/linuxptp/linuxptp_3.1.bb
@@ -1,4 +1,5 @@
 DESCRIPTION = "Precision Time Protocol (PTP) according to IEEE standard 1588 for Linux"
+HOMEPAGE = "http://linuxptp.sourceforge.net/"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 

--- a/meta-oe/recipes-connectivity/linuxptp/linuxptp_3.1.bb
+++ b/meta-oe/recipes-connectivity/linuxptp/linuxptp_3.1.bb
@@ -10,14 +10,12 @@ SRC_URI = "http://sourceforge.net/projects/linuxptp/files/v${PV}/linuxptp-${PV}.
 SRC_URI[md5sum] = "2264cb69c9af947028835c12c89a7572"
 SRC_URI[sha256sum] = "f58f5b11cf14dc7c4f7c9efdfb27190e43d02cf20c3525f6639edac10528ce7d"
 
-EXTRA_OEMAKE = "ARCH=${TARGET_ARCH} EXTRA_CFLAGS='${CFLAGS}'"
+EXTRA_OEMAKE = "ARCH=${TARGET_ARCH} EXTRA_CFLAGS='${CFLAGS}' mandir=${mandir}"
 
 export KBUILD_OUTPUT="${RECIPE_SYSROOT}"
 
-do_install () {
-    install -d ${D}/${bindir}
-    install -p ${S}/ptp4l  ${D}/${bindir}
-    install -p ${S}/pmc  ${D}/${bindir}
-    install -p ${S}/phc2sys  ${D}/${bindir}
-    install -p ${S}/hwstamp_ctl  ${D}/${bindir}
+do_install() {
+    oe_runmake install DESTDIR=${D} prefix=${prefix}
 }
+
+FILES_${PN}-doc = "${mandir}"

--- a/meta-oe/recipes-connectivity/linuxptp/linuxptp_3.1.bb
+++ b/meta-oe/recipes-connectivity/linuxptp/linuxptp_3.1.bb
@@ -17,6 +17,13 @@ export KBUILD_OUTPUT="${RECIPE_SYSROOT}"
 
 do_install() {
     oe_runmake install DESTDIR=${D} prefix=${prefix}
+
+    # Install example configs from source tree
+    install -d ${D}${docdir}/${PN}
+    cp -R --no-dereference --preserve=mode,links ${S}/configs ${D}${docdir}/${PN}
 }
 
+PACKAGES =+ "${PN}-configs"
+
+FILES_${PN}-configs = "${docdir}"
 FILES_${PN}-doc = "${mandir}"


### PR DESCRIPTION
A couple of improvements to the linuxptp recipe. We use the install function from the makefile in order to install all produced binaries and manual pages. Also ship and package example configurations in a separate package. Inspiration is taken from how debian package linuxptp.