### PR TITLE
[hardknott-next] libiio: fix installing libiio when python3 bindings are enabled

### DIFF
--- a/meta-oe/recipes-support/libiio/files/0001-python-Do-not-verify-whether-libiio-is-installed-whe.patch
+++ b/meta-oe/recipes-support/libiio/files/0001-python-Do-not-verify-whether-libiio-is-installed-whe.patch
@@ -1,0 +1,37 @@
+From 3a26f0536706fa7c241c9de986799ae440c68c8a Mon Sep 17 00:00:00 2001
+From: Julien Malik <julien.malik@unseenlabs.fr>
+Date: Mon, 27 Jul 2020 14:34:44 +0200
+Subject: [PATCH] python: Do not verify whether libiio is installed when
+ cross-compiling
+
+This should fix #561
+
+Upstream-Status: Backport
+
+Signed-off-by: Julien Malik <julien.malik@paraiso.me>
+Signed-off-by: Sam Van Den Berge <sam.van.den.berge@gmail.com>
+---
+ bindings/python/setup.py.cmakein | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/bindings/python/setup.py.cmakein b/bindings/python/setup.py.cmakein
+index cd14e2e..96d58a8 100644
+--- a/bindings/python/setup.py.cmakein
++++ b/bindings/python/setup.py.cmakein
+@@ -54,6 +54,13 @@ class InstallWrapper(install):
+         install.run(self)
+ 
+     def _check_libiio_installed(self):
++        cross_compiling = ("${CMAKE_CROSSCOMPILING}" == "TRUE")
++        if cross_compiling:
++            # When cross-compiling, we generally cannot dlopen
++            # the libiio shared lib from the build platform.
++            # Simply skip this check in that case.
++            return
++
+         from platform import system as _system
+         from ctypes import CDLL as _cdll
+         from ctypes.util import find_library
+-- 
+2.25.1
+

--- a/meta-oe/recipes-support/libiio/libiio_git.bb
+++ b/meta-oe/recipes-support/libiio/libiio_git.bb
@@ -7,7 +7,9 @@ LIC_FILES_CHKSUM = "file://COPYING.txt;md5=7c13b3376cea0ce68d2d2da0a1b3a72c"
 SRCREV = "565bf68eccfdbbf22cf5cb6d792e23de564665c7"
 PV = "0.21+git${SRCPV}"
 
-SRC_URI = "git://github.com/analogdevicesinc/libiio.git;protocol=https"
+SRC_URI = "git://github.com/analogdevicesinc/libiio.git;protocol=https \
+           file://0001-python-Do-not-verify-whether-libiio-is-installed-whe.patch \
+"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>\d+(\.\d+)+)"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This patch fixes the following error when libiio is installed when
python3 bindings are enabled:

ERROR: Execution of '.../libiio/0.21+gitAUTOINC+565bf68ecc-r0/temp/run.do_install.2349473' failed with exit code 1:
running build
running build_py
running install
Traceback (most recent call last):
  File ".../libiio/0.21+gitAUTOINC+565bf68ecc-r0/build/bindings/python/setup.py", line 77, in _check_libiio_installed
    raise OSError
OSError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File ".../libiio/0.21+gitAUTOINC+565bf68ecc-r0/build/bindings/python/setup.py", line 106, in <module>
    setup(**config)
  File ".../libiio/0.21+gitAUTOINC+565bf68ecc-r0/recipe-sysroot-native/usr/lib/python3.9/site-packages/setuptools/__init__.py", line 153, in setup
    return distutils.core.setup(**attrs)
  File ".../libiio/0.21+gitAUTOINC+565bf68ecc-r0/recipe-sysroot-native/usr/lib/python3.9/distutils/core.py", line 148, in setup
    dist.run_commands()
  File ".../libiio/0.21+gitAUTOINC+565bf68ecc-r0/recipe-sysroot-native/usr/lib/python3.9/distutils/dist.py", line 966, in run_commands
    self.run_command(cmd)
  File ".../libiio/0.21+gitAUTOINC+565bf68ecc-r0/recipe-sysroot-native/usr/lib/python3.9/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File ".../libiio/0.21+gitAUTOINC+565bf68ecc-r0/build/bindings/python/setup.py", line 52, in run
    self._check_libiio_installed()
  File "/libiio/0.21+gitAUTOINC+565bf68ecc-r0/build/bindings/python/setup.py", line 83, in _check_libiio_installed
    raise Exception(msg)
Exception: The libiio library could not be found.
            libiio needs to be installed first before the python bindings.
            The latest release can be found on GitHub:
            https://github.com/analogdevicesinc/libiio/releases

Some time ago a fix for this issue was already discussed here [1].
However in the same discussion also a second issue was being handled.

A fix for the second issue was merged in 51f98865da0. The first issue
didn't pop up anymore and so a fix was never applied.

Recently however after switching from build machine, I started seeing
the first issue. I suspect due to build caching the first issue didn't
pop up anymore before up until now. With this patch, fixes are now
available for both issues handled in [1].

[1]: https://github.com/openembedded/meta-openembedded/issues/248
