### PR TITLE
python3-thrift: support native recipe

### DIFF
--- a/meta-python/recipes-connectivity/python-thrift/python3-thrift_0.13.0.bb
+++ b/meta-python/recipes-connectivity/python-thrift/python3-thrift_0.13.0.bb
@@ -16,3 +16,5 @@ RDEPENDS_${PN} += "\
     ${PYTHON_PN}-stringold \
     ${PYTHON_PN}-threading \
 "
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
This is needed for meta-codechecker to communicate to the server

Signed-off-by: Pascal Bach <pascal.bach@siemens.com>