### PR TITLE
samba: Don't guess dirs for perllocal.pod removing

### DIFF
--- a/meta-networking/recipes-connectivity/samba/samba_4.14.5.bb
+++ b/meta-networking/recipes-connectivity/samba/samba_4.14.5.bb
@@ -209,7 +209,7 @@ do_install_append() {
     fi
 
     oe_runmake -C ${S}/pidl DESTDIR=${D} install_vendor
-    rm -rf ${D}${libdir}/perl5/${PERLVERSION}/${BUILD_SYS}/perllocal.pod
+    find ${D}${libdir}/ -type f -name "perllocal.pod" | xargs rm -f
     rm -rf ${D}${libdir}/perl5/vendor_perl/${PERLVERSION}/${BUILD_SYS}/auto/Parse/Pidl/.packlist
     
 }


### PR DESCRIPTION
We're not living in a perfect world so avoid build failures like:

ERROR: samba-4.14.5-r0 do_package_qa: QA Issue: samba-pidl contains perllocal.pod (/usr/lib/perl5/5.34.0/x86_64-linux/perllocal.pod), should not be installed [perllocalpod]
ERROR: samba-4.14.5-r0 do_package_qa: QA run found fatal errors. Please consider fixing them.