### PR TITLE
[gatesgarth-next] libpfm4 4.10.1 : enable arm64 host platform

### DIFF
--- a/meta-oe/recipes-kernel/libpfm/libpfm4_4.10.1.bb
+++ b/meta-oe/recipes-kernel/libpfm/libpfm4_4.10.1.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=0de488f3bd4424e308e2e399cb99c788"
 
 SECTION = "devel"
 
-COMPATIBLE_HOST = "powerpc64"
+COMPATIBLE_HOST = "powerpc64|aarch64"
 
 SRC_URI = "${SOURCEFORGE_MIRROR}/perfmon2/${BPN}/libpfm-${PV}.tar.gz \
            file://0001-Include-poll.h-instead-of-sys-poll.h.patch \
@@ -24,6 +24,7 @@ EXTRA_OEMAKE = "DESTDIR=\"${D}\" PREFIX=\"${prefix}\" LIBDIR=\"${libdir}\" LDCON
 EXTRA_OEMAKE_append_powerpc = " ARCH=\"powerpc\""
 EXTRA_OEMAKE_append_powerpc64 = " ARCH=\"powerpc\" BITMODE=\"64\""
 EXTRA_OEMAKE_append_powerpc64le = " ARCH=\"powerpc\" BITMODE=\"64\""
+EXTRA_OEMAKE_append_aarch64 = " ARCH=\"arm64\""
 
 S = "${WORKDIR}/libpfm-${PV}"
 


### PR DESCRIPTION
libpfm4 is only enabled for powerpc arch as of now.
This enables the lib on Arm 64bit platform as well.

Signed-off-by: Olivier Georget <olivier.georget@gmail.com>