### PR TITLE
ntp: fix ntpdate to wait for subprocesses

### DIFF
--- a/meta-networking/recipes-support/ntp/ntp/ntpdate
+++ b/meta-networking/recipes-support/ntp/ntp/ntpdate
@@ -52,3 +52,8 @@ if [ -x /usr/bin/lockfile-create ] ; then
 fi
 
 ) &
+
+# wait for all subprocesses to finish
+# this is required when using systemd service as ntpd will start before ntpdate finishes
+# and results in a bind error (port 123)
+wait


### PR DESCRIPTION
When using systemd, ntpdate-sync script will start in background
triggering the start of ntpd without actually exiting.
This results in an bind error in ntpd startup.

Add wait at the end of ntpdate script to ensure that when the ntpdate.service
is marked as finished the oneshot script ntpdate-sync finished and unbind the
ntp port

Fixes #386

Signed-off-by: Adrian Zaharia <Adrian.Zaharia@windriver.com>