### PR TITLE
Working 5.2 to 5.10 kernel

### DIFF
--- a/meta-oe/recipes-extended/socketcan/can-isotp_git.bb
+++ b/meta-oe/recipes-extended/socketcan/can-isotp_git.bb
@@ -1,21 +1,17 @@
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=72d977d697c3c05830fdff00a7448931"
-SRCREV = "${AUTOREV}"
-inherit module
-
+SRCREV = "beb4650660179963a8ed5b5cbf2085cc1b34f608"
 PV = "1.0+git${SRCPV}"
+
 SRC_URI = "git://github.com/hartkopp/can-isotp.git;protocol=https"
+
 
 S = "${WORKDIR}/git"
 
+inherit module
 
 EXTRA_OEMAKE += "KERNELDIR=${STAGING_KERNEL_DIR}"
 
-inherit module
-
-#/linux/can/isotp.h is the include used in most examples, feel free to change 
-
 do_install_append() {
-    install -d ${D}${includedir}/linux/can/
-    install -m 644 ${S}/include/uapi/linux/can/isotp.h ${D}${includedir}/linux/can/isotp.h
+    install -Dm 644 ${S}/include/uapi/linux/can/isotp.h ${D}${includedir}/linux/can/isotp.h
 }

--- a/meta-oe/recipes-extended/socketcan/can-isotp_git.bb
+++ b/meta-oe/recipes-extended/socketcan/can-isotp_git.bb
@@ -1,14 +1,21 @@
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=72d977d697c3c05830fdff00a7448931"
-SRCREV = "b31bce98d65f894aad6427bcf6f3f7822e261a59"
-PV = "1.0+git${SRCPV}"
+SRCREV = "${AUTOREV}"
+inherit module
 
+PV = "1.0+git${SRCPV}"
 SRC_URI = "git://github.com/hartkopp/can-isotp.git;protocol=https"
 
 S = "${WORKDIR}/git"
 
-inherit module
 
 EXTRA_OEMAKE += "KERNELDIR=${STAGING_KERNEL_DIR}"
 
-PNBLACKLIST[can-isotp] ?= "Kernel module Needs forward porting to kernel 5.2+"
+inherit module
+
+#/linux/can/isotp.h is the include used in most examples, feel free to change 
+
+do_install_append() {
+    install -d ${D}${includedir}/linux/can/
+    install -m 644 ${S}/include/uapi/linux/can/isotp.h ${D}${includedir}/linux/can/isotp.h
+}


### PR DESCRIPTION
Can-isotp is now upstream from kernel 5.10 onwards. Use kernel config file instead.  This is only provided for legacy kernels.