### PR TITLE
htop: Add ncurses-terminfo-base to RDEPENDS

### DIFF
--- a/meta-oe/recipes-support/htop/htop_3.0.5.bb
+++ b/meta-oe/recipes-support/htop/htop_3.0.5.bb
@@ -31,3 +31,5 @@ PACKAGECONFIG[delayacct] = "--enable-delayacct,--disable-delayacct,libnl"
 PACKAGECONFIG[sensors] = "--with-sensors,--without-sensors,lmsensors,lmsensors-libsensors"
 
 FILES_${PN} += "${datadir}/icons/hicolor/scalable/apps/htop.svg"
+
+RDEPENDS_${PN} += "ncurses-terminfo-base"


### PR DESCRIPTION
Without it there are no terminal configurations on the target
and htop refuses to run.

Simple patch :)