### PR TITLE
Suppress eol in functionfs setup scripts (#147)

### DIFF
--- a/meta-oe/recipes-devtools/android-tools/android-tools-conf-configfs/android-gadget-cleanup
+++ b/meta-oe/recipes-devtools/android-tools/android-tools-conf-configfs/android-gadget-cleanup
@@ -6,7 +6,7 @@ cd /sys/kernel/config/usb_gadget
 
 cd adb
 
-echo "" > UDC || true
+echo -n "" > UDC || true
 
 killall adbd || true
 

--- a/meta-oe/recipes-devtools/android-tools/android-tools-conf-configfs/android-gadget-setup
+++ b/meta-oe/recipes-devtools/android-tools/android-tools-conf-configfs/android-gadget-setup
@@ -23,8 +23,8 @@ mkdir configs/c.1
 mkdir functions/ffs.usb0
 mkdir strings/0x409
 mkdir configs/c.1/strings/0x409
-echo 0x18d1 > idVendor
-echo 0xd002 > idProduct
+echo -n 0x18d1 > idVendor
+echo -n 0xd002 > idProduct
 echo "$serial" > strings/0x409/serialnumber
 echo "$manufacturer" > strings/0x409/manufacturer
 echo "$model" > strings/0x409/product

--- a/meta-oe/recipes-devtools/android-tools/android-tools-conf-configfs/android-gadget-start
+++ b/meta-oe/recipes-devtools/android-tools/android-tools-conf-configfs/android-gadget-start
@@ -4,4 +4,4 @@ set -e
 
 sleep 3
 
-ls /sys/class/udc/ > /sys/kernel/config/usb_gadget/adb/UDC
+ls /sys/class/udc/ | xargs echo -n > /sys/kernel/config/usb_gadget/adb/UDC


### PR DESCRIPTION
Stray newline character causes errors in functionfs setup scripts used by android-tools-adbd.service, when using musl libc and/or toybox.