### PR TITLE
mycroft: Install more tools needed by scripts

### DIFF
--- a/meta-multimedia/recipes-multimedia/mycroft/mycroft_19.8.1.bb
+++ b/meta-multimedia/recipes-multimedia/mycroft/mycroft_19.8.1.bb
@@ -87,4 +87,7 @@ RDEPENDS:${PN} += "mimic"
 # pgrep is used by stop-mycroft.sh
 RDEPENDS:${PN} += "procps"
 
+# More tools needed by scripts
+RDEPENDS:${PN} += "bash jq libnotify"
+
 SYSTEMD_SERVICE:${PN} = "mycroft-setup.service mycroft.service"


### PR DESCRIPTION
Bash dependency maybe droped once scripts
are simplified to support busybox.

Relate-to: https://github.com/MycroftAI/mycroft-core/pull/2686
Change-Id: Ibbb6c2e72f56f35ce475c045e52b4d4e56275348
Signed-off-by: Philippe Coval <rzr@users.sf.net>