### PR TITLE
Add flag to enable adbd service (#147)

### DIFF
--- a/meta-oe/recipes-devtools/android-tools/android-tools_5.1.1.r37.bb
+++ b/meta-oe/recipes-devtools/android-tools/android-tools_5.1.1.r37.bb
@@ -180,3 +180,9 @@ FILES:${PN}-fstools = "\
 "
 
 BBCLASSEXTEND = "native"
+
+android_tools_enable_devmode() {
+    touch ${IMAGE_ROOTFS}/var/usb-debugging-enabled
+}
+
+ROOTFS_POSTPROCESS_COMMAND_${PN}-adbd += "${@bb.utils.contains("USB_DEBUGGING_ENABLED", "1", "android_tools_enable_devmode;", "", d)}"


### PR DESCRIPTION
android-tools-adbd service can be enabled in the image using
USB_DEBUGGING_ENABLED = "1" in local.conf.

Signed-off-by: Devendra Tewari <devendra.tewari@gmail.com>