### PR TITLE
bmon and libconfuse recipes

### DIFF
--- a/meta-networking/recipes-support/bmon/bmon_2.1.0.bb
+++ b/meta-networking/recipes-support/bmon/bmon_2.1.0.bb
@@ -1,0 +1,12 @@
+DESCRIPTION = "Portable Bandwidth Monitor and rate estimator"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+# only works with libnl-0.5.0
+DEPENDS = "libnl libconfuse ncurses"
+
+SRCREV = "1b3f11bde315e221474f7d066ce4efb4ff4d39e3"
+SRC_URI = "git://github.com/tgraf/bmon.git;branch=master"
+
+inherit autotools pkgconfig
+
+S = "${WORKDIR}/git"

--- a/meta-networking/recipes-support/libconfuse/libconfuse_3.3.bb
+++ b/meta-networking/recipes-support/libconfuse/libconfuse_3.3.bb
@@ -1,0 +1,18 @@
+DESCRIPTION = "libConfuse is a configuration file parser library"
+LICENSE = "CUSTOM"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=42fa47330d4051cd219f7d99d023de3a"
+
+DEPENDS = "gettext-native"
+
+SRCREV = "a42aebf13db33afd575da6e63f55163d371f776d"
+SRC_URI = "git://github.com/libconfuse/libconfuse.git;branch=master"
+
+inherit autotools pkgconfig
+
+S = "${WORKDIR}/git"
+B = "${S}"
+
+do_configure_prepend(){
+    cd ${S}
+    ${S}/autogen.sh
+}


### PR DESCRIPTION
This pull request adds the recipe for bmon, a network monitor tool using ncurses. It also adds libconfuse which is a dependency not used elsewhere.
It is a rework of a previous pull request.

By the way I was not confident about submiting a patch using gmail for this. But I see how it can be done, next time.