### PR TITLE
[hardknott] curlpp, ldns: fix override syntax

### DIFF
--- a/meta-networking/recipes-support/curlpp/curlpp_0.8.1.bb
+++ b/meta-networking/recipes-support/curlpp/curlpp_0.8.1.bb
@@ -17,7 +17,7 @@ inherit cmake pkgconfig binconfig
 
 BBCLASSEXTEND = "native nativesdk"
 
-do_install:append() {
+do_install_append() {
     sed -e 's@[^ ]*-ffile-prefix-map=[^ "]*@@g' \
         -e 's@[^ ]*-fdebug-prefix-map=[^ "]*@@g' \
         -e 's@[^ ]*-fmacro-prefix-map=[^ "]*@@g' \

--- a/meta-oe/recipes-devtools/ldns/ldns_1.7.1.bb
+++ b/meta-oe/recipes-devtools/ldns/ldns_1.7.1.bb
@@ -17,7 +17,7 @@ PACKAGECONFIG[drill] = "--with-drill,--without-drill"
 EXTRA_OECONF = "--with-ssl=${STAGING_EXECPREFIXDIR} \
                 libtool=${TARGET_PREFIX}libtool"
 
-do_install:append() {
+do_install_append() {
     sed -e 's@[^ ]*-ffile-prefix-map=[^ "]*@@g' \
         -e 's@[^ ]*-fdebug-prefix-map=[^ "]*@@g' \
         -e 's@[^ ]*-fmacro-prefix-map=[^ "]*@@g' \


### PR DESCRIPTION
Commits bca3bbbf203086794e5b and 2e794f33a43d71bb9861 cherry-picked a fix from master, which used the new override syntax, which was introduced in [poky commit 2abf8a699edd513405be](http://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/?id=2abf8a699edd513405be). However, this change was merged after 3.4_M2 and is not part of hardknott, so bitbake complains about the new syntax:

``` 
ERROR: ParseError at …/meta-openembedded/meta-oe/recipes-devtools/ldns/ldns_1.7.1.bb:20: unparsed line: 'do_install:append() {'
ERROR: ParseError at …/meta-openembedded/meta-networking/recipes-support/curlpp/curlpp_0.8.1.bb:20: unparsed line: 'do_install:append() {' 
``` 
    
Revert to the old override syntax on the hardknott branch for now.