### PR TITLE
python3-license-expression: add ptest artifacts

### DIFF
--- a/meta-python/recipes-devtools/python/python3-license-expression_21.6.14.bb
+++ b/meta-python/recipes-devtools/python/python3-license-expression_21.6.14.bb
@@ -28,6 +28,8 @@ RDEPENDS:${PN}-ptest += " \
 "
 
 do_install_ptest() {
-	install -d ${D}${PTEST_PATH}/tests
-	cp -rf ${S}/tests/* ${D}${PTEST_PATH}/tests/
+    install -d ${D}${PTEST_PATH}/tests
+    install -d ${D}${PTEST_PATH}/src
+    cp -rf ${S}/tests/* ${D}${PTEST_PATH}/tests/
+    cp -rf ${S}/src/* ${D}${PTEST_PATH}/src/
 }


### PR DESCRIPTION
The python3-license-expression ptest is failing because it requires the
contents of the src/ directory from the repo/tarball. Copy this content
to the image when installing the ptest so that it has what it needs.

Signed-off-by: Trevor Gamblin <trevor.gamblin@windriver.com>
Signed-off-by: Khem Raj <raj.khem@gmail.com>
Signed-off-by: Trevor Gamblin <trevor.gamblin@windriver.com>