### PR TITLE
libbpf: remove stale comment

### DIFF
--- a/meta-oe/recipes-kernel/libbpf/libbpf_0.4.bb
+++ b/meta-oe/recipes-kernel/libbpf/libbpf_0.4.bb
@@ -4,8 +4,6 @@ HOMEPAGE = "https://github.com/libbpf/libbpf"
 SECTION = "libs"
 LICENSE = "LGPLv2.1+"
 
-# There is a typo in the filename, LPGL should really be LGPL.
-# Keep this until the correct name is set upstream.
 LIC_FILES_CHKSUM = "file://../LICENSE.LGPL-2.1;md5=b370887980db5dd40659b50909238dbd"
 
 DEPENDS = "zlib elfutils"


### PR DESCRIPTION
The license typo (LPGL --> LGPL) was fixed in libbpf 0.4.

Signed-off-by: Peter Morrow <pemorrow@linux.microsoft.com>