### PR TITLE
libbpf: remove kernel configuration dependency

### DIFF
--- a/meta-oe/recipes-kernel/libbpf/libbpf_0.4.bb
+++ b/meta-oe/recipes-kernel/libbpf/libbpf_0.4.bb
@@ -8,8 +8,6 @@ LIC_FILES_CHKSUM = "file://../LICENSE.LGPL-2.1;md5=b370887980db5dd40659b50909238
 
 DEPENDS = "zlib elfutils"
 
-do_compile[depends] += "virtual/kernel:do_shared_workdir"
-
 SRC_URI = "git://github.com/libbpf/libbpf.git;protocol=https"
 SRCREV = "db9614b6bd69746809d506c2786f914b0f812c37"
 
@@ -23,19 +21,9 @@ EXTRA_OEMAKE += "DESTDIR=${D} LIBDIR=${libdir} INCLUDEDIR=${includedir}"
 inherit pkgconfig
 
 do_compile() {
-	if grep -q "CONFIG_BPF_SYSCALL=y" ${STAGING_KERNEL_BUILDDIR}/.config
-	then
-		oe_runmake
-	else
-		bbnote "BFP syscall is not enabled"
-	fi
+	oe_runmake
 }
 
 do_install() {
-	if grep -q "CONFIG_BPF_SYSCALL=y" ${STAGING_KERNEL_BUILDDIR}/.config
-	then
-		oe_runmake install
-	else
-		bbnote "no files to install"
-	fi
+	oe_runmake install
 }


### PR DESCRIPTION
This dependency introduces a cycle with pahole:

```
kernel --> pahole --> libbpf
  ^                      /
   \                    /
    `------------------<
```

pahole is a build time dependency of the kernel which is required to
generate BTF symbols. The dependency on the kernel configuration is nice
to have but makes using pahole during kernel compile time impossible.

Furthermore this dependency doesn't make sense when building libbpf
purely to ship it via a SDK.

Signed-off-by: Peter Morrow <pemorrow@linux.microsoft.com>