### PR TITLE
recipes-devtools: add pahole

### DIFF
--- a/meta-oe/recipes-devtools/pahole/files/0001-CMakeList.txt-make-python-optional.patch
+++ b/meta-oe/recipes-devtools/pahole/files/0001-CMakeList.txt-make-python-optional.patch
@@ -1,0 +1,44 @@
+From f6ca8c930d0fbd2491b3cc77169e32806a14e5e9 Mon Sep 17 00:00:00 2001
+From: Matteo Croce <mcroce@microsoft.com>
+Date: Mon, 30 Aug 2021 16:25:56 +0200
+Subject: [PATCH] CMakeList.txt: make python optional
+
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/devel/pahole/pahole.git/commit/?id=88431099950ab3e8bc1645353508d7978a6cad35]
+
+ostra-cg, which requires python, is installed in the destination dir.
+Make it optional for embedded distributions which doesn't have the
+python interpreter available.
+
+Signed-off-by: Matteo Croce <mcroce@microsoft.com>
+---
+ CMakeLists.txt | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4140574..8523bce 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -61,6 +61,7 @@ find_package(DWARF REQUIRED)
+ find_package(ZLIB REQUIRED)
+ find_package(argp REQUIRED)
+ find_package(obstack REQUIRED)
++find_package(Python3 QUIET)
+ 
+ # make sure git submodule(s) are checked out
+ find_package(Git QUIET)
+@@ -185,8 +186,10 @@ install(FILES dwarves.h dwarves_emit.h dwarves_reorganize.h
+ 	      elfcreator.h elf_symtab.h hash.h libctf.h
+ 	DESTINATION ${CMAKE_INSTALL_PREFIX}/include/dwarves/)
+ install(FILES man-pages/pahole.1 DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man/man1/)
+-install(PROGRAMS ostra/ostra-cg DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
++if(Python3_FOUND)
++	install(PROGRAMS ostra/ostra-cg DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
++	install(FILES ostra/python/ostra.py DESTINATION ${CMAKE_INSTALL_PREFIX}/share/dwarves/runtime/python)
++endif()
+ install(PROGRAMS btfdiff fullcircle DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+-install(FILES ostra/python/ostra.py DESTINATION ${CMAKE_INSTALL_PREFIX}/share/dwarves/runtime/python)
+ install(FILES lib/Makefile lib/ctracer_relay.c lib/ctracer_relay.h lib/linux.blacklist.cu
+ 	DESTINATION ${CMAKE_INSTALL_PREFIX}/share/dwarves/runtime)
+-- 
+2.31.1
+

--- a/meta-oe/recipes-devtools/pahole/files/0002-Use-usr-bin-env-python3-instead-of-just-usr-bin-pyth.patch
+++ b/meta-oe/recipes-devtools/pahole/files/0002-Use-usr-bin-env-python3-instead-of-just-usr-bin-pyth.patch
@@ -1,0 +1,35 @@
+From 436163ab845c263312cf3d4717a43727cf5f0747 Mon Sep 17 00:00:00 2001
+From: Matteo Croce <mcroce@microsoft.com>
+Date: Wed, 15 Sep 2021 17:54:01 +0200
+Subject: [PATCH] Use /usr/bin/env python3 instead of just /usr/bin/python3
+
+Upstream-Status: inappropriate [OE specific]
+
+---
+ ostra/ostra-cg        | 2 +-
+ ostra/python/ostra.py | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ostra/ostra-cg b/ostra/ostra-cg
+index 52c902e..8142e67 100755
+--- a/ostra/ostra-cg
++++ b/ostra/ostra-cg
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python3
++#!/usr/bin/env python3
+ # ostra-cg - generate callgraphs from encoded trace
+ #
+ # Arnaldo Carvalho de Melo <acme@redhat.com>
+diff --git a/ostra/python/ostra.py b/ostra/python/ostra.py
+index 86fe079..9bb5ad1 100755
+--- a/ostra/python/ostra.py
++++ b/ostra/python/ostra.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python3
++#!/usr/bin/env python3
+ #
+ # Copyright (C) 2005, 2006, 2007 Arnaldo Carvalho de Melo
+ #
+-- 
+2.31.1
+

--- a/meta-oe/recipes-devtools/pahole/pahole_1.22.bb
+++ b/meta-oe/recipes-devtools/pahole/pahole_1.22.bb
@@ -1,0 +1,31 @@
+SUMMARY = "Shows and manipulates data structure layout"
+
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
+
+DEPENDS = "elfutils zlib libbpf"
+
+COMPATIBLE_HOST = "(x86_64|i.86|aarch64).*-linux"
+
+SRCREV = "f02af2553ea58ae1186226af0d0ec835a248358f"
+SRC_URI = "git://git.kernel.org/pub/scm/devel/pahole/pahole.git \
+           file://0001-CMakeList.txt-make-python-optional.patch \
+           file://0002-Use-usr-bin-env-python3-instead-of-just-usr-bin-pyth.patch"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+PACKAGECONFIG[python3] = ",,python3-core,python3-core"
+
+EXTRA_OECMAKE = "-D__LIB=lib -DCMAKE_BUILD_TYPE=Release -DLIBBPF_EMBEDDED=OFF"
+
+FILES:${PN} =  "${bindir}/pahole \
+		${libdir}/libdwarves.so* \
+		${libdir}/libdwarves_reorganize.so*"
+
+PACKAGES += "${PN}-extra"
+FILES:${PN}-extra = "${datadir} ${bindir} ${libdir}/libdwarves_emit.so*"
+RDEPENDS:${PN}-extra += "bash"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Add the pahole host tool which is needed to generate BTF debugging
symbols from the kernel image.

Signed-off-by: Matteo Croce <mcroce@microsoft.com>