### PR TITLE
pahole: don't download vendored libbpf

### DIFF
--- a/meta-oe/recipes-devtools/pahole/files/0003-CMakeList.txt-don-t-download-libbpf-source-when-syst.patch
+++ b/meta-oe/recipes-devtools/pahole/files/0003-CMakeList.txt-don-t-download-libbpf-source-when-syst.patch
@@ -1,0 +1,34 @@
+From 3d20210d84f61ee2189927e2d9de9ce3e5a0a9c5 Mon Sep 17 00:00:00 2001
+From: Matteo Croce <mcroce@microsoft.com>
+Date: Mon, 20 Sep 2021 18:44:52 +0200
+Subject: [PATCH] CMakeList.txt: Don't download libbpf source when system
+ library is used
+
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/devel/pahole/pahole.git/commit/?id=3d20210d84f61ee2189927e2d9de9ce3e5a0a9c5]
+
+The build system always download the libbpf submodule, regardless if
+we're using the embedded or the system version.
+Download the libbpf source only if we're using the embedded one.
+
+Signed-off-by: Matteo Croce <mcroce@microsoft.com>
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8523bce..2ab66e4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -65,7 +65,7 @@ find_package(Python3 QUIET)
+ 
+ # make sure git submodule(s) are checked out
+ find_package(Git QUIET)
+-if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
++if(LIBBPF_EMBEDDED AND GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+ 	# Update submodules as needed
+ 	option(GIT_SUBMODULE "Check submodules during build" ON)
+ 	if(GIT_SUBMODULE)
+-- 
+2.31.1
+

--- a/meta-oe/recipes-devtools/pahole/pahole_1.22.bb
+++ b/meta-oe/recipes-devtools/pahole/pahole_1.22.bb
@@ -10,7 +10,8 @@ COMPATIBLE_HOST = "(x86_64|i.86|aarch64).*-linux"
 SRCREV = "f02af2553ea58ae1186226af0d0ec835a248358f"
 SRC_URI = "git://git.kernel.org/pub/scm/devel/pahole/pahole.git \
            file://0001-CMakeList.txt-make-python-optional.patch \
-           file://0002-Use-usr-bin-env-python3-instead-of-just-usr-bin-pyth.patch"
+           file://0002-Use-usr-bin-env-python3-instead-of-just-usr-bin-pyth.patch \
+           file://0003-CMakeList.txt-don-t-download-libbpf-source-when-syst.patch"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Just use the system libbpf.

Signed-off-by: Matteo Croce <mcroce@microsoft.com>