### PR TITLE
rapidjson: override hard-coded lib install dir

### DIFF
--- a/meta-oe/recipes-devtools/rapidjson/rapidjson_git.bb
+++ b/meta-oe/recipes-devtools/rapidjson/rapidjson_git.bb
@@ -15,6 +15,9 @@ S = "${WORKDIR}/git"
 inherit cmake
 
 EXTRA_OECMAKE += "-DRAPIDJSON_BUILD_DOC=OFF -DRAPIDJSON_BUILD_TESTS=OFF -DRAPIDJSON_BUILD_EXAMPLES=OFF"
+# the install path for cmake modules etc. is hardcoded as ${prefix}/lib in
+# CMakeLists.txt, which breaks the package split with multilib
+EXTRA_OECMAKE += "-DLIB_INSTALL_DIR=${libdir}"
 
 # RapidJSON is a header-only C++ library, so the main package will be empty.
 


### PR DESCRIPTION
The default value for `LIB_INSTALL_DIR` is set to `${prefix}/lib` in CMakeLists.txt. However, in multilib builds, the package split picks up the files from `${prefix}/lib64` or `${prefix}/lib32`, which leads to QA issues in do_package about left-over files in `/usr/lib/pkgconfig` and `/usr/lib/cmake`.

The fix applies to hardknott too.