### PR TITLE
bdwgc: upgrade 8.0.4 -> 8.0.6

### DIFF
--- a/meta-oe/recipes-support/bdwgc/bdwgc_8.0.6.bb
+++ b/meta-oe/recipes-support/bdwgc/bdwgc_8.0.6.bb
@@ -19,11 +19,11 @@ DESCRIPTION = "The Boehm-Demers-Weiser conservative garbage collector can be\
 HOMEPAGE = "http://www.hboehm.info/gc/"
 SECTION = "devel"
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://README.QUICK;md5=81b447d779e278628c843aef92f088fa"
+LIC_FILES_CHKSUM = "file://README.QUICK;md5=e3d68fff6b0c661d949d8df559fdc78f"
 
 DEPENDS = "libatomic-ops"
 
-SRCREV = "d3dede3ce4462cd82a15f161af797ca51654546a"
+SRCREV = "3e1477b72ef4329a196d67b74da4cbe274d04eff"
 SRC_URI = "git://github.com/ivmai/bdwgc.git;branch=release-8_0"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Highlights of this upgrade:
* Fix 'undefined reference to __data_start' linker error on risc-v
* Fix data race in generic_malloc_many
* Fix handling of areas smaller than page size in GC_scratch_recycle
* Fix misaligned tlfs passed to AO_load on m68k
* Fix overflow of scratch_free_ptr value
* Limit number of unmapped regions (to avoid exceeding of vm.max_map_count)

See the following for detailed changes:
* https://github.com/ivmai/bdwgc/releases/tag/v8.0.6

The LIC_FILES_CHKSUM has changed because of update of copyright
year (in README.QUICK).

Signed-off-by: Ivan Maidanski <ivmai@mail.ru>