### PR TITLE
[Dunfell] lvgl: Add recipe for Lightweight Graphics Library

### DIFF
--- a/meta-oe/recipes-core/packagegroups/packagegroup-meta-oe.bb
+++ b/meta-oe/recipes-core/packagegroups/packagegroup-meta-oe.bb
@@ -191,6 +191,7 @@ RDEPENDS_packagegroup-meta-oe-graphics ="\
     fbgrab fbida fontforge fvwm glm gphoto2 libgphoto2 \
     gtkperf jasper leptonica libmng libsdl2-image libsdl2-mixer libsdl2-net \
     libsdl-gfx libsdl-image libsdl-mixer libsdl-net libsdl-ttf \
+    ${@bb.utils.contains("DISTRO_FEATURES", "wayland", "lv-drivers lvgl", "", d)} \
     libvncserver libyui libyui-ncurses lxdm numlockx openbox openjpeg \
     packagegroup-fonts-truetype pangomm qrencode takao-fonts terminus-font \
     tesseract tesseract-lang tigervnc tslib source-han-sans-cn-fonts \

--- a/meta-oe/recipes-graphics/lvgl/lv-drivers_7.11.0.bb
+++ b/meta-oe/recipes-graphics/lvgl/lv-drivers_7.11.0.bb
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Huawei Inc.
+# SPDX-License-Identifier: MIT
+
+# TODO: Pin upstream release (current v7.11.0-80-g419a757)
+src_org = "lvgl"
+SRC_URI = "gitsm://github.com/${src_org}/lv_drivers;destsuffix=${S};protocol=https;nobranch=1"
+SRCREV = "419a757c23aaa67c676fe3a2196d64808fcf2254"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=d6fc0df890c5270ef045981b516bb8f2"
+
+HOMEPAGE = "https://docs.lvgl.io/latest/en/html/porting/index.html"
+SUMMARY = "LVGL's Display and Touch pad drivers"
+DESCRIPTION = "Collection of drivers: SDL, framebuffer, wayland and more..."
+
+DEPENDS += "libxkbcommon"
+DEPENDS += "lvgl"
+DEPENDS += "wayland"
+
+REQUIRED_DISTRO_FEATURES = "wayland"
+
+inherit cmake
+inherit features_check
+
+S = "${WORKDIR}/${PN}-${PV}"
+
+EXTRA_OECMAKE += "-Dinstall:BOOL=ON"
+
+TARGET_CFLAGS += "-DLV_CONF_INCLUDE_SIMPLE=1"
+TARGET_CFLAGS += "-I${RECIPE_SYSROOT}/${includedir}/lvgl"
+
+
+do_configure:append() {
+    [ -r "${S}/lv_drv_conf.h" ] \
+        || sed -e "s|#if 0 .*Set it to \"1\" to enable the content.*|#if 1 // Enabled by ${PN}|g" \
+               -e "s|#  define USE_WAYLAND       0|#  define USE_WAYLAND       1|g" \
+          < "${S}/lv_drv_conf_template.h" > "${S}/lv_drv_conf.h"
+}
+
+
+FILES:${PN}-dev = "\
+    ${includedir}/lvgl/lv_drivers/ \
+    "
+
+FILES:${PN}-staticdev = "${libdir}/"

--- a/meta-oe/recipes-graphics/lvgl/lvgl_8.0.3.bb
+++ b/meta-oe/recipes-graphics/lvgl/lvgl_8.0.3.bb
@@ -1,0 +1,40 @@
+# -*- mode: bitbake; c-basic-offset: 4; indent-tabs-mode: nil -*-
+
+# SPDX-FileCopyrightText: Huawei Inc.
+# SPDX-License-Identifier: MIT
+
+# TODO: Pin upstream release (current is v8.0.3-dev-239-g7b7bed37d)
+src_org = "lvgl"
+SRC_URI = "gitsm://github.com/${src_org}/lvgl;destsuffix=${S};protocol=https;nobranch=1"
+SRCREV = "7b7bed37d3e937c59ec99fccba58774fbf9f1930"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENCE.txt;md5=bf1198c89ae87f043108cea62460b03a"
+
+HOMEPAGE = "https://lvgl.io/"
+SUMMARY = "Light and Versatile Graphics Library"
+DESCRIPTION = "LVGL is an open-source graphics library providing everything you need to create embedded GUI with easy-to-use graphical elements, beautiful visual effects and low memory footprint."
+
+REQUIRED_DISTRO_FEATURES = "wayland"
+
+inherit cmake
+inherit features_check
+
+S = "${WORKDIR}/${PN}-${PV}"
+
+EXTRA_OECMAKE += "-Dinstall:BOOL=ON"
+
+
+do_configure:prepend() {
+    [ -r "${S}/lv_conf.h" ] \
+        || sed -e "s|#if 0 /*Set it to \"1\" to enable the content*/|#if 1 // Enabled by ${PN}|g" \
+            < "${S}/lv_conf_template.h" > "${S}/lv_conf.h"
+}
+
+
+FILES:${PN}-dev = "\
+    ${includedir}/${PN}/ \
+    ${includedir}/${PN}/lvgl/ \
+    "
+
+FILES:${PN}-staticdev = "${libdir}/"


### PR DESCRIPTION
Note, this requires lv-drivers for wayland rendering.

Change-Id: I920679891d0c7b5079537af77ff4d21094178cce
Forwarded: https://github.com/openembedded/meta-openembedded/pull/447
Relate-to: https://github.com/lvgl/lvgl/issues/2534
Origin: https://git.ostc-eu.org/OSTC/planning/core-os/-/issues/233
Signed-off-by: Philippe Coval <philippe.coval@huawei.com>