### PR TITLE
python3-fasteners: replace colon by underscore

### DIFF
--- a/meta-python/recipes-devtools/python/python3-fasteners_0.16.3.bb
+++ b/meta-python/recipes-devtools/python/python3-fasteners_0.16.3.bb
@@ -8,7 +8,7 @@ SRC_URI[sha256sum] = "b1ab4e5adfbc28681ce44b3024421c4f567e705cc3963c732bf1cba334
 
 inherit pypi setuptools3
 
-RDEPENDS:${PN} += "\
+RDEPENDS_${PN} += "\
     ${PYTHON_PN}-logging \
     ${PYTHON_PN}-fcntl \
 "


### PR DESCRIPTION
The dunfell branch can't yet handle the colon notation, which results in an
error while bitbake is parsing recipes files:

  unparsed line: 'RDEPENDS:${PN} += "    ${PYTHON_PN}-logging     ${PYTHON_PN}-fcntl "'

Replacing it by an underscore solves that error.