### PR TITLE
recipes: Update SRC_URI branch and protocols

### DIFF
--- a/meta-filesystems/recipes-filesystems/logfsprogs/logfsprogs_git.bb
+++ b/meta-filesystems/recipes-filesystems/logfsprogs/logfsprogs_git.bb
@@ -11,7 +11,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://fsck.c;md5=3859dc73da97909ff1d0125e88a27e02"
 DEPENDS = "zlib"
 
-SRC_URI = "git://github.com/prasad-joshi/logfsprogs.git \
+SRC_URI = "git://github.com/prasad-joshi/logfsprogs.git;branch=master;protocol=https \
            file://0001-Add-LDFLAGS-to-linker-cmdline.patch \
            file://0001-btree-Avoid-conflicts-with-libc-namespace-about-setk.patch \
            file://0001-include-sys-sysmacros.h-for-major-minor-definition.patch \

--- a/meta-filesystems/recipes-filesystems/owfs/owfs_3.2p3.bb
+++ b/meta-filesystems/recipes-filesystems/owfs/owfs_3.2p3.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=628b867016631792781a8735a04760e5 \
 DEPENDS = "fuse virtual/libusb0"
 # v3.2p3
 SRCREV = "3744375dfaa350e31c9b360eb1e1a517bbeb5c47"
-SRC_URI = "git://github.com/owfs/owfs \
+SRC_URI = "git://github.com/owfs/owfs;branch=master;protocol=https \
            file://0001-Add-build-rule-for-README.patch \
            file://0001-Fix-compilation-with-GCC10.patch \
            file://owhttpd \

--- a/meta-filesystems/recipes-filesystems/sshfs-fuse/sshfs-fuse_3.7.1.bb
+++ b/meta-filesystems/recipes-filesystems/sshfs-fuse/sshfs-fuse_3.7.1.bb
@@ -6,7 +6,7 @@ LICENSE = "GPLv2"
 DEPENDS = "glib-2.0 fuse3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/libfuse/sshfs"
+SRC_URI = "git://github.com/libfuse/sshfs;branch=master;protocol=https"
 SRCREV = "8059e2ce630dd2b984f7a6c44a2b5291b0fe2abc"
 S = "${WORKDIR}/git"
 

--- a/meta-filesystems/recipes-filesystems/unionfs-fuse/unionfs-fuse_2.1.bb
+++ b/meta-filesystems/recipes-filesystems/unionfs-fuse/unionfs-fuse_2.1.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://src/unionfs.c;beginline=3;endline=8;md5=30fa8de70fd8a
                     file://LICENSE;md5=7e5a37fce17307066eec6b23546da3b3 \
 "
 
-SRC_URI = "git://github.com/rpodgorny/${BPN}.git;branch=master \
+SRC_URI = "git://github.com/rpodgorny/${BPN}.git;branch=master;protocol=https \
            file://0001-support-cross-compiling.patch \
            "
 SRCREV = "8d732962423c3ca5be1f14b7ec139ff464e10a51"

--- a/meta-filesystems/recipes-utils/f2fs-tools/f2fs-tools_1.14.0.bb
+++ b/meta-filesystems/recipes-utils/f2fs-tools/f2fs-tools_1.14.0.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=362b4b2594cd362b874a97718faa51d3"
 DEPENDS = "util-linux"
 
 SRCREV = "d41dcbdf46dc3841cd0a0507e6573e38cb6c55bb"
-SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git \
+SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git;branch=master \
            "
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>\d+(\.\d+)+)"
 

--- a/meta-filesystems/recipes-utils/fatcat/fatcat_1.1.0.bb
+++ b/meta-filesystems/recipes-utils/fatcat/fatcat_1.1.0.bb
@@ -7,7 +7,7 @@ HOMEPAGE = "https://github.com/Gregwar/fatcat"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=57fbbfebd0dd1d6ff21b8cecb552a03f"
 
-SRC_URI = "git://github.com/Gregwar/fatcat.git \
+SRC_URI = "git://github.com/Gregwar/fatcat.git;branch=master;protocol=https \
            file://0001-Use-unistd.h-not-argp.h-for-all-POSIX-systems.patch \
            "
 

--- a/meta-filesystems/recipes-utils/fatresize/fatresize_1.0.2.bb
+++ b/meta-filesystems/recipes-utils/fatresize/fatresize_1.0.2.bb
@@ -3,7 +3,7 @@ SECTION = "console/tools"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 
-SRC_URI = "git://salsa.debian.org/parted-team/fatresize.git;protocol=https"
+SRC_URI = "git://salsa.debian.org/parted-team/fatresize.git;protocol=https;branch=master"
 SRCREV = "3f80afc76ad82d4a1b852a6c8dea24cd9f5e7a24"
 
 PV = "1.0.2-11"

--- a/meta-filesystems/recipes-utils/ufs-utils/ufs-utils_1.9.bb
+++ b/meta-filesystems/recipes-utils/ufs-utils/ufs-utils_1.9.bb
@@ -6,7 +6,7 @@ BRANCH ?= "dev"
 
 SRCREV = "517c0b01e47d4441cc45be351509fb4c96843d5a"
 
-SRC_URI = "git://github.com/westerndigitalcorporation/ufs-utils.git;protocol=git;branch=${BRANCH} \
+SRC_URI = "git://github.com/westerndigitalcorporation/ufs-utils.git;protocol=https;branch=${BRANCH} \
            file://0001-Use-asm-type.h-for-kernel-types.patch \
 "
 

--- a/meta-gnome/recipes-gnome/libchamplain/libchamplain_0.12.20.bb
+++ b/meta-gnome/recipes-gnome/libchamplain/libchamplain_0.12.20.bb
@@ -6,7 +6,7 @@ DEPENDS = "glib-2.0 gtk+3 gdk-pixbuf clutter-1.0 clutter-gtk-1.0 libsoup-2.4"
 inherit meson gobject-introspection
 
 SRCREV = "145e417f32e507b63c21ad4e915b808a6174099e"
-SRC_URI = "git://github.com/gnome/libchamplain.git"
+SRC_URI = "git://github.com/gnome/libchamplain.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-gnome/recipes-support/ibus/ibus.inc
+++ b/meta-gnome/recipes-support/ibus/ibus.inc
@@ -10,7 +10,7 @@ PV = "1.5.23+git${SRCPV}"
 DEPENDS = "unicode-ucd"
 
 SRC_URI = " \
-    git://github.com/ibus/ibus.git \
+    git://github.com/ibus/ibus.git;branch=master;protocol=https \
     file://0001-Do-not-try-to-start-dbus-we-do-not-have-dbus-lauch.patch \
 "
 SRCREV = "dd4cc5b028c35f9bb8fa9d3bdc8f26bcdfc43d40"

--- a/meta-gnome/recipes-support/keybinder/keybinder_3.0.bb
+++ b/meta-gnome/recipes-support/keybinder/keybinder_3.0.bb
@@ -13,7 +13,7 @@ B = "${S}"
 
 SRCREV = "736ccef40d39603b8111c8a3a0bca0319bbafdc0"
 PV = "3.0+git${SRCPV}"
-SRC_URI = "git://github.com/engla/keybinder.git;branch=keybinder-3.0 \
+SRC_URI = "git://github.com/engla/keybinder.git;branch=keybinder-3.0;protocol=https \
 "
 
 RDEPENDS_${PN} = "gtk+"

--- a/meta-gnome/recipes-support/libstemmer/libstemmer_git.bb
+++ b/meta-gnome/recipes-support/libstemmer/libstemmer_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=2750797da77c1d784e7626b3f7d7ff3e"
 DEPENDS_class-target = "${BPN}-native"
 
 SRC_URI = "\
-    git://github.com/snowballstem/snowball.git \
+    git://github.com/snowballstem/snowball.git;branch=master;protocol=https \
     file://0001-Build-so-lib.patch \
     file://0002-snowball-stemwords-do-link-with-LDFLAGS-set-by-build.patch \
 "

--- a/meta-gnome/recipes-support/libwacom/libwacom_0.33.bb
+++ b/meta-gnome/recipes-support/libwacom/libwacom_0.33.bb
@@ -9,6 +9,6 @@ DEPENDS = " \
 
 inherit autotools pkgconfig
 
-SRC_URI = "git://github.com/linuxwacom/libwacom.git"
+SRC_URI = "git://github.com/linuxwacom/libwacom.git;branch=master;protocol=https"
 SRCREV = "87cc710e21a6220e267dd08936bbec2932aa3658"
 S = "${WORKDIR}/git"

--- a/meta-initramfs/recipes-bsp/kexecboot/kexecboot_git.bb
+++ b/meta-initramfs/recipes-bsp/kexecboot/kexecboot_git.bb
@@ -5,7 +5,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 PV = "0.6+git${SRCPV}"
 S = "${WORKDIR}/git"
-SRC_URI = "git://github.com/kexecboot/kexecboot.git"
+SRC_URI = "git://github.com/kexecboot/kexecboot.git;branch=master;protocol=https"
 SRC_URI_append_libc-klibc = "\
     file://0001-kexecboot-Use-new-reboot-API-with-klibc.patch \
     file://0001-make-Add-compiler-includes-in-cflags.patch \

--- a/meta-initramfs/recipes-devtools/dracut/dracut_git.bb
+++ b/meta-initramfs/recipes-devtools/dracut/dracut_git.bb
@@ -9,7 +9,7 @@ PE = "1"
 PV = "051"
 
 SRCREV = "e473057ae1de303340dec297c786c4a701cc61bd"
-SRC_URI = "git://git.kernel.org/pub/scm/boot/dracut/dracut.git;protocol=http \
+SRC_URI = "git://git.kernel.org/pub/scm/boot/dracut/dracut.git;protocol=http;branch=master \
            file://0001-util.h-include-sys-reg.h-when-libc-glibc.patch \
            "
 

--- a/meta-initramfs/recipes-devtools/grubby/grubby_8.40.bb
+++ b/meta-initramfs/recipes-devtools/grubby/grubby_8.40.bb
@@ -14,7 +14,7 @@ DEPENDS_append_libc-musl = " libexecinfo"
 
 S = "${WORKDIR}/git"
 SRCREV = "79c5cfa02c567efdc5bb18cdd584789e2e35aa23"
-SRC_URI = "git://github.com/rhboot/grubby.git;protocol=https; \
+SRC_URI = "git://github.com/rhboot/grubby.git;protocol=https;branch=master \
            file://grubby-rename-grub2-editenv-to-grub-editenv.patch \
            file://run-ptest \
            file://0001-Add-another-variable-LIBS-to-provides-libraries-from.patch \

--- a/meta-initramfs/recipes-devtools/grubby/grubby_git.bb
+++ b/meta-initramfs/recipes-devtools/grubby/grubby_git.bb
@@ -14,7 +14,7 @@ DEPENDS_append_libc-musl = " libexecinfo"
 
 S = "${WORKDIR}/git"
 SRCREV = "a1d2ae93408c3408e672d7eba4550fdf27fb0201"
-SRC_URI = "git://github.com/rhboot/grubby.git;protocol=https; \
+SRC_URI = "git://github.com/rhboot/grubby.git;protocol=https;branch=master \
            file://grubby-rename-grub2-editenv-to-grub-editenv.patch \
            file://run-ptest \
            file://0001-Add-another-variable-LIBS-to-provides-libraries-from.patch \

--- a/meta-initramfs/recipes-devtools/mtd/ubi-utils-klibc_2.0.2.bb
+++ b/meta-initramfs/recipes-devtools/mtd/ubi-utils-klibc_2.0.2.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=0636e73ff0215e8d672dc4c32c317bb3 \
 inherit autotools pkgconfig klibc
 
 SRCREV = "64f61a9dc71b158c7084006cbce4ea23886f0b47"
-SRC_URI = "git://git.infradead.org/mtd-utils.git \
+SRC_URI = "git://git.infradead.org/mtd-utils.git;branch=master \
              file://0001-libmissing.h-fix-klibc-build-when-using-glibc-toolch.patch \
              file://0002-Instead-of-doing-preprocessor-magic-just-output-off_.patch \
              file://0003-Makefile.am-only-build-ubi-utils.patch \

--- a/meta-initramfs/recipes-kernel/kexec/kexec-tools-klibc_git.bb
+++ b/meta-initramfs/recipes-kernel/kexec/kexec-tools-klibc_git.bb
@@ -12,7 +12,7 @@ DEPENDS = "zlib xz"
 
 inherit klibc autotools siteinfo
 
-SRC_URI = "git://git.kernel.org/pub/scm/utils/kernel/kexec/kexec-tools.git"
+SRC_URI = "git://git.kernel.org/pub/scm/utils/kernel/kexec/kexec-tools.git;branch=master"
 SRCREV = "5750980cdbbc33ef75bfba6660295b932376ce15"
 
 BUILD_PATCHES = "file://0001-force-static-build.patch \

--- a/meta-multimedia/recipes-connectivity/libupnp/libupnp_1.14.0.bb
+++ b/meta-multimedia/recipes-connectivity/libupnp/libupnp_1.14.0.bb
@@ -9,7 +9,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=394a0f17b97f33426275571e15920434"
 
 SRCREV = "a6c3616530490ca67db41131572ec18f00d95eb0"
-SRC_URI = "git://github.com/mrjimenez/pupnp.git;protocol=https"
+SRC_URI = "git://github.com/mrjimenez/pupnp.git;protocol=https;branch=master"
 
 S="${WORKDIR}/git"
 

--- a/meta-multimedia/recipes-dvb/tvheadend/tvheadend_git.bb
+++ b/meta-multimedia/recipes-dvb/tvheadend/tvheadend_git.bb
@@ -8,7 +8,7 @@ DEPENDS = "avahi cmake-native dvb-apps libdvbcsa libpcre2 openssl uriparser zlib
 LICENSE = "GPLv3+"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=9cae5acac2e9ee2fc3aec01ac88ce5db"
 
-SRC_URI = "git://github.com/tvheadend/tvheadend.git \
+SRC_URI = "git://github.com/tvheadend/tvheadend.git;branch=master;protocol=https \
            file://0001-adjust-for-64bit-time_t.patch \
            "
 

--- a/meta-multimedia/recipes-multimedia/aom/aom_3.0.0.bb
+++ b/meta-multimedia/recipes-multimedia/aom/aom_3.0.0.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=6ea91368c1bbdf877159435572b931f5 \
                     file://PATENTS;md5=e69ad12202bd20da3c76a5d3648cfa83 \
                    "
 
-SRC_URI = "git://aomedia.googlesource.com/aom;protocol=https"
+SRC_URI = "git://aomedia.googlesource.com/aom;protocol=https;branch=master"
 
 SRCREV = "307ce06ed82d93885ee8ed53e152c9268ac0d98d"
 

--- a/meta-multimedia/recipes-multimedia/dca/dcadec_0.2.0.bb
+++ b/meta-multimedia/recipes-multimedia/dca/dcadec_0.2.0.bb
@@ -4,7 +4,7 @@ LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING.LGPLv2.1;md5=4fbd65380cdd255951079008b364516c"
 
 SRCREV = "b93deed1a231dd6dd7e39b9fe7d2abe05aa00158"
-SRC_URI = "git://github.com/foo86/dcadec.git;protocol=https \
+SRC_URI = "git://github.com/foo86/dcadec.git;protocol=https;branch=master \
            file://0001-define-BASELIB-make-variable.patch \
           "
 

--- a/meta-multimedia/recipes-multimedia/dleyna/dleyna-connector-dbus_0.3.0.bb
+++ b/meta-multimedia/recipes-multimedia/dleyna/dleyna-connector-dbus_0.3.0.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c \
 
 DEPENDS = "glib-2.0 dbus dleyna-core"
 
-SRC_URI = "git://github.com/01org/${BPN}.git"
+SRC_URI = "git://github.com/01org/${BPN}.git;branch=master;protocol=https"
 SRCREV = "de913c35e5c936e2d40ddbd276ee902cd802bd3a"
 S = "${WORKDIR}/git"
 

--- a/meta-multimedia/recipes-multimedia/dleyna/dleyna-core_0.6.0.bb
+++ b/meta-multimedia/recipes-multimedia/dleyna/dleyna-core_0.6.0.bb
@@ -13,7 +13,7 @@ DEPENDS = "glib-2.0 gupnp"
 
 PV .= "+git${SRCPV}"
 
-SRC_URI = "git://github.com/01org/${BPN}.git"
+SRC_URI = "git://github.com/01org/${BPN}.git;branch=master;protocol=https"
 SRCREV = "1c6853f5bc697dc0a8774fd70dbc915c4dbe7c5b"
 S = "${WORKDIR}/git"
 

--- a/meta-multimedia/recipes-multimedia/dleyna/dleyna-renderer_0.6.0.bb
+++ b/meta-multimedia/recipes-multimedia/dleyna/dleyna-renderer_0.6.0.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c \
 DEPENDS = "glib-2.0 gssdp gupnp gupnp-av gupnp-dlna libsoup-2.4 dleyna-core"
 RDEPENDS_${PN} = "dleyna-connector-dbus"
 
-SRC_URI = "git://github.com/01org/${BPN}.git \
+SRC_URI = "git://github.com/01org/${BPN}.git;branch=master;protocol=https \
            file://0001-add-gupnp-1.2-API-support.patch \
           "
 SRCREV = "50fd1ec9d51328e7dea98874129dc8d6fe3ea1dd"

--- a/meta-multimedia/recipes-multimedia/dleyna/dleyna-server_0.6.0.bb
+++ b/meta-multimedia/recipes-multimedia/dleyna/dleyna-server_0.6.0.bb
@@ -12,7 +12,7 @@ DEPENDS = "glib-2.0 gssdp gupnp gupnp-av gupnp-dlna libsoup-2.4 libxml2 dleyna-c
 RDEPENDS_${PN} = "dleyna-connector-dbus"
 
 PV .= "+git${SRCPV}"
-SRC_URI = "git://github.com/01org/${BPN}.git"
+SRC_URI = "git://github.com/01org/${BPN}.git;branch=master;protocol=https"
 SRCREV = "eb895ae82715e9889a948ffa810c0f828b4f4c76"
 S = "${WORKDIR}/git"
 

--- a/meta-multimedia/recipes-multimedia/fdk-aac/fdk-aac_2.0.1.bb
+++ b/meta-multimedia/recipes-multimedia/fdk-aac/fdk-aac_2.0.1.bb
@@ -11,7 +11,7 @@ LICENSE = "Fraunhofer_FDK_AAC_Codec_Library_for_Android"
 LICENSE_FLAGS = "commercial"
 LIC_FILES_CHKSUM = "file://NOTICE;md5=5985e1e12f4afa710d64ed7bfd291875"
 
-SRC_URI = "git://github.com/mstorsjo/fdk-aac.git;protocol=git;branch=master"
+SRC_URI = "git://github.com/mstorsjo/fdk-aac.git;protocol=https;branch=master"
 SRCREV = "d387d3b6ed79ff9a82c60440bdd86e6e5e324bec"
 
 S = "${WORKDIR}/git"

--- a/meta-multimedia/recipes-multimedia/fluidsynth/fluidsynth.inc
+++ b/meta-multimedia/recipes-multimedia/fluidsynth/fluidsynth.inc
@@ -4,7 +4,7 @@ SECTION = "libs/multimedia"
 LICENSE = "LGPL-2.1"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=fc178bcd425090939a8b634d1d6a9594"
 
-SRC_URI = "git://github.com/FluidSynth/fluidsynth.git"
+SRC_URI = "git://github.com/FluidSynth/fluidsynth.git;branch=master;protocol=https"
 SRCREV = "8413c35aca641567baf13e9b16e9839019ebf99d"
 S = "${WORKDIR}/git"
 PV = "2.2.0"

--- a/meta-multimedia/recipes-multimedia/gerbera/gerbera_1.7.0.bb
+++ b/meta-multimedia/recipes-multimedia/gerbera/gerbera_1.7.0.bb
@@ -3,7 +3,7 @@ Description = "Gerbera - An UPnP media server"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=25cdec9afe3f1f26212ead6bd2f7fac8"
 
-SRC_URI = "git://github.com/v00d00/gerbera.git;protocol=https \
+SRC_URI = "git://github.com/v00d00/gerbera.git;protocol=https;branch=master \
            file://0001-include-optional-header.patch \
           "
 

--- a/meta-multimedia/recipes-multimedia/gstreamer-1.0/gst-shark_git.bb
+++ b/meta-multimedia/recipes-multimedia/gstreamer-1.0/gst-shark_git.bb
@@ -17,7 +17,7 @@ SRCREV_common = "88e512ca7197a45c4114f7fa993108f23245bf50"
 SRCREV_FORMAT = "base_common"
 SRC_URI = " \
     git://github.com/RidgeRun/gst-shark.git;protocol=https;branch=${SRCBRANCH};name=base \
-    git://gitlab.freedesktop.org/gstreamer/common.git;protocol=https;destsuffix=git/common;name=common; \
+    git://gitlab.freedesktop.org/gstreamer/common.git;protocol=https;destsuffix=git/common;name=common;branch=master \
     "
 
 S = "${WORKDIR}/git"

--- a/meta-multimedia/recipes-multimedia/libcamera/libcamera.bb
+++ b/meta-multimedia/recipes-multimedia/libcamera/libcamera.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "\
 "
 
 SRC_URI = " \
-        git://linuxtv.org/libcamera.git;protocol=git \
+        git://linuxtv.org/libcamera.git;protocol=git;branch=master \
         file://0001-uvcvideo-Use-auto-variable-to-avoid-range-loop-warni.patch \
 "
 

--- a/meta-multimedia/recipes-multimedia/libdvbcsa/libdvbcsa_1.1.0.bb
+++ b/meta-multimedia/recipes-multimedia/libdvbcsa/libdvbcsa_1.1.0.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 
 SRCREV = "bc6c0b164a87ce05e9925785cc6fb3f54c02b026"
 
-SRC_URI = "git://code.videolan.org/videolan/libdvbcsa.git;protocol=https \
+SRC_URI = "git://code.videolan.org/videolan/libdvbcsa.git;protocol=https;branch=master \
            file://libdvbcsa.pc \
 "
 

--- a/meta-multimedia/recipes-multimedia/libsquish/libsquish_git.bb
+++ b/meta-multimedia/recipes-multimedia/libsquish/libsquish_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://alpha.cpp;beginline=3;endline=22;md5=6665e479f71feb92
 PV = "1.10+git${SRCPV}"
 
 SRCREV = "52e7d93c5947f72380521116c05d97c528863ba8"
-SRC_URI = "git://github.com/OpenELEC/libsquish.git;protocol=https"
+SRC_URI = "git://github.com/OpenELEC/libsquish.git;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"
 

--- a/meta-multimedia/recipes-multimedia/libuvc/libuvc.bb
+++ b/meta-multimedia/recipes-multimedia/libuvc/libuvc.bb
@@ -5,7 +5,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2f1963e0bb88c93463af750daf9ba0c2"
 DEPENDS = "libusb jpeg"
 
-SRC_URI = "git://github.com/libuvc/libuvc.git"
+SRC_URI = "git://github.com/libuvc/libuvc.git;branch=master;protocol=https"
 SRCREV = "ad6c72a4e390367f0d2be81aac00cfc0b6680d74"
 PV = "v0.0.6+git${SRCPV}"
 

--- a/meta-multimedia/recipes-multimedia/mimic/mimic_1.3.0.1.bb
+++ b/meta-multimedia/recipes-multimedia/mimic/mimic_1.3.0.1.bb
@@ -20,7 +20,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=a2c2c7371b58b9cdeae0dc68846fe9f1"
 DEPENDS = "curl-native libpcre2"
 
 SRCREV = "adf655da0399530ac1b586590257847eb61be232"
-SRC_URI = "git://github.com/MycroftAI/mimic1.git \
+SRC_URI = "git://github.com/MycroftAI/mimic1.git;branch=master;protocol=https \
            file://0001-Fix-musl-compatibility.patch \
            file://0001-cmu_indic_lang-Make-cst_rx_not_indic-as-extern-decla.patch \
           "

--- a/meta-multimedia/recipes-multimedia/musicbrainz/libmusicbrainz_git.bb
+++ b/meta-multimedia/recipes-multimedia/musicbrainz/libmusicbrainz_git.bb
@@ -8,7 +8,7 @@ DEPENDS = "expat libxml2 libxml2-native neon neon-native"
 PV = "5.1.0+git${SRCPV}"
 
 SRCREV = "44c05779dd996035758f5ec426766aeedce29cc3"
-SRC_URI = "git://github.com/metabrainz/libmusicbrainz.git \
+SRC_URI = "git://github.com/metabrainz/libmusicbrainz.git;branch=master;protocol=https \
            file://allow-libdir-override.patch "
 
 S = "${WORKDIR}/git"

--- a/meta-multimedia/recipes-multimedia/musicpd/libmpdclient_2.19.bb
+++ b/meta-multimedia/recipes-multimedia/musicpd/libmpdclient_2.19.bb
@@ -6,7 +6,7 @@ HOMEPAGE = "https://www.musicpd.org/libs/libmpdclient/"
 inherit meson
 
 SRC_URI = " \
-    git://github.com/MusicPlayerDaemon/libmpdclient \
+    git://github.com/MusicPlayerDaemon/libmpdclient;branch=master;protocol=https \
 "
 SRCREV = "27767959442ef390aabb16790494ba93fed962ef"
 S = "${WORKDIR}/git"

--- a/meta-multimedia/recipes-multimedia/musicpd/mpc_0.33.bb
+++ b/meta-multimedia/recipes-multimedia/musicpd/mpc_0.33.bb
@@ -7,7 +7,7 @@ inherit meson
 
 DEPENDS += "libmpdclient"
 
-SRC_URI = "git://github.com/MusicPlayerDaemon/mpc"
+SRC_URI = "git://github.com/MusicPlayerDaemon/mpc;branch=master;protocol=https"
 SRCREV = "ef16b280052ef0320cb80f79d74c8ce0324005ed"
 
 S = "${WORKDIR}/git"

--- a/meta-multimedia/recipes-multimedia/musicpd/mpd_0.22.6.bb
+++ b/meta-multimedia/recipes-multimedia/musicpd/mpd_0.22.6.bb
@@ -18,7 +18,7 @@ DEPENDS += " \
 "
 
 SRC_URI = " \
-    git://github.com/MusicPlayerDaemon/MPD;branch=v0.22.x \
+    git://github.com/MusicPlayerDaemon/MPD;branch=v0.22.x;protocol=https \
     file://mpd.conf.in \
 "
 SRCREV = "938728820b11d4544a071994fe3c63c6ab710e8e"

--- a/meta-multimedia/recipes-multimedia/musicpd/ncmpc_0.45.bb
+++ b/meta-multimedia/recipes-multimedia/musicpd/ncmpc_0.45.bb
@@ -33,7 +33,7 @@ PACKAGECONFIG[outputs_screen] = "-Doutputs_screen=true,-Doutputs_screen=false"
 PACKAGECONFIG[chat_screen] = "-Dchat_screen=true,-Dchat_screen=false"
 
 SRC_URI = " \
-    git://github.com/MusicPlayerDaemon/ncmpc \
+    git://github.com/MusicPlayerDaemon/ncmpc;branch=master;protocol=https \
 "
 SRCREV = "6780ec072f1d314f44ed77efdc58d03c6fbcc96b"
 S = "${WORKDIR}/git"

--- a/meta-multimedia/recipes-multimedia/mycroft/mycroft_19.8.1.bb
+++ b/meta-multimedia/recipes-multimedia/mycroft/mycroft_19.8.1.bb
@@ -7,7 +7,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=79aa497b11564d1d419ee889e7b498f6"
 
 SRCREV = "913f29d3d550637934f9abf43a097eb2c30d76fc"
-SRC_URI = "git://github.com/MycroftAI/mycroft-core.git;branch=master \
+SRC_URI = "git://github.com/MycroftAI/mycroft-core.git;branch=master;protocol=https \
            file://0001-Remove-python-venv.patch \
            file://0002-dev_setup.sh-Remove-the-git-dependency.patch \
            file://0003-dev_setup.sh-Remove-the-TERM-dependency.patch \

--- a/meta-multimedia/recipes-multimedia/openal/openal-soft_1.20.1.bb
+++ b/meta-multimedia/recipes-multimedia/openal/openal-soft_1.20.1.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=0f159f19f9377e1895fbb477d5a7953e"
 inherit cmake pkgconfig
 
 SRCREV = "f5e0eef34db3a3ab94b61a2f99f84f078ba947e7"
-SRC_URI = "git://github.com/kcat/openal-soft \
+SRC_URI = "git://github.com/kcat/openal-soft;branch=master;protocol=https \
            file://0001-Use-BUILD_CC-to-compile-native-tools.patch \
            file://0002-makehrtf-Disable-Wstringop-truncation.patch \
            "

--- a/meta-multimedia/recipes-multimedia/pipewire/pipewire-0.2_git.bb
+++ b/meta-multimedia/recipes-multimedia/pipewire/pipewire-0.2_git.bb
@@ -11,7 +11,7 @@ DEPENDS = "alsa-lib dbus udev"
 SRCREV = "14c11c0fe4d366bad4cfecdee97b6652ff9ed63d"
 PV = "0.2.7"
 
-SRC_URI = "git://github.com/PipeWire/pipewire"
+SRC_URI = "git://github.com/PipeWire/pipewire;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-multimedia/recipes-multimedia/rtmpdump/rtmpdump_2.4.bb
+++ b/meta-multimedia/recipes-multimedia/rtmpdump/rtmpdump_2.4.bb
@@ -9,7 +9,7 @@ DEPENDS = "gnutls zlib"
 
 SRCREV = "fa8646daeb19dfd12c181f7d19de708d623704c0"
 SRC_URI = " \
-    git://git.ffmpeg.org/rtmpdump \
+    git://git.ffmpeg.org/rtmpdump;branch=master \
     file://fix-racing-build-issue.patch"
 
 S = "${WORKDIR}/git"

--- a/meta-multimedia/recipes-multimedia/tinyalsa/tinyalsa.bb
+++ b/meta-multimedia/recipes-multimedia/tinyalsa/tinyalsa.bb
@@ -7,7 +7,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://NOTICE;md5=dbdefe400d894b510a9de14813181d0b"
 
 SRCREV = "8449529c7e50f432091539ba7b438e79b04059b5"
-SRC_URI = "git://github.com/tinyalsa/tinyalsa \
+SRC_URI = "git://github.com/tinyalsa/tinyalsa;branch=master;protocol=https \
            file://0001-Use-CMAKE_INSTALL_-path-instead-of-hardcoding-bin-li.patch \
           "
 PV = "1.1.1+git${SRCPV}"

--- a/meta-multimedia/recipes-multimedia/tremor/tremor_20180319.bb
+++ b/meta-multimedia/recipes-multimedia/tremor/tremor_20180319.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=db1b7a668b2a6f47b2af88fb008ad555 \
                     file://os.h;beginline=3;endline=14;md5=5c0af5e1bedef3ce8178c89f48cd6f1f"
 DEPENDS = "libogg"
 
-SRC_URI = "git://gitlab.xiph.org/xiph/tremor.git;protocol=https \
+SRC_URI = "git://gitlab.xiph.org/xiph/tremor.git;protocol=https;branch=master \
            file://obsolete_automake_macros.patch;striplevel=0 \
            file://tremor-arm-thumb2.patch \
 "

--- a/meta-multimedia/recipes-support/crossguid/crossguid_0.2.2.bb
+++ b/meta-multimedia/recipes-support/crossguid/crossguid_0.2.2.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1373274bc8d8001edc54933919f36f68"
 DEPENDS += "util-linux"
 
 SRCREV = "5b45cdd9a56ca9da35ee0f8845cb4e2603d245dc"
-SRC_URI = "git://github.com/graeme-hill/crossguid;protocol=https"
+SRC_URI = "git://github.com/graeme-hill/crossguid;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"
 

--- a/meta-multimedia/recipes-support/gst-instruments/gst-instruments_git.bb
+++ b/meta-multimedia/recipes-support/gst-instruments/gst-instruments_git.bb
@@ -9,7 +9,7 @@ DEPENDS = "gstreamer1.0"
 
 S = "${WORKDIR}/git"
 SRCREV = "3b862e52e5c53ad1023dc6808effa4cb75572c4b"
-SRC_URI = "git://github.com/kirushyk/gst-instruments.git;protocol=https;"
+SRC_URI = "git://github.com/kirushyk/gst-instruments.git;protocol=https;;branch=master"
 
 FILES_${PN}-staticdev += "${libdir}/gstreamer-1.0/*a"
 FILES_${PN} += "${libdir}/*"

--- a/meta-multimedia/recipes-support/libsrtp/libsrtp_2.3.0.bb
+++ b/meta-multimedia/recipes-support/libsrtp/libsrtp_2.3.0.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=2909fcf6f09ffff8430463d91c08c4e1"
 
 S = "${WORKDIR}/git"
 SRCREV = "d02d21111e379c297e93a9033d7b653135f732ee"
-SRC_URI = "git://github.com/cisco/libsrtp.git"
+SRC_URI = "git://github.com/cisco/libsrtp.git;branch=master;protocol=https"
 
 inherit autotools pkgconfig
 

--- a/meta-multimedia/recipes-support/srt/srt_1.4.2.bb
+++ b/meta-multimedia/recipes-support/srt/srt_1.4.2.bb
@@ -7,7 +7,7 @@ LICENSE = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=815ca599c9df247a0c7f619bab123dad"
 
 SRCREV = "50b7af06f3a0a456c172b4cb3aceafa8a5cc0036"
-SRC_URI = "git://github.com/Haivision/srt;protocol=https \
+SRC_URI = "git://github.com/Haivision/srt;protocol=https;branch=master \
            file://0001-don-t-install-srt-ffplay.patch \
            file://0001-core-Fix-build-with-GCC-11.-1806.patch \
            "

--- a/meta-networking/recipes-connectivity/cannelloni/cannelloni_1.0.0.bb
+++ b/meta-networking/recipes-connectivity/cannelloni/cannelloni_1.0.0.bb
@@ -2,7 +2,7 @@ SUMMARY = "a SocketCAN over Ethernet tunnel"
 HOMEPAGE = "https://github.com/mguentner/cannelloni"
 LICENSE = "GPLv2"
 
-SRC_URI = "git://github.com/mguentner/cannelloni.git;protocol=https"
+SRC_URI = "git://github.com/mguentner/cannelloni.git;protocol=https;branch=master"
 SRCREV = "0bd7e27db35bdef361226882ae04205504f7b2f4"
 
 LIC_FILES_CHKSUM = "file://gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"

--- a/meta-networking/recipes-connectivity/civetweb/civetweb_git.bb
+++ b/meta-networking/recipes-connectivity/civetweb/civetweb_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.md;md5=50bd1d7f135b50d7e218996ba28d0d88"
 
 SRCREV = "4b440a339979852d5a51fb11a822952712231c23"
 PV = "1.12+git${SRCPV}"
-SRC_URI = "git://github.com/civetweb/civetweb.git \
+SRC_URI = "git://github.com/civetweb/civetweb.git;branch=master;protocol=https \
            file://0001-Unittest-Link-librt-and-libm-using-l-option.patch \
            "
 

--- a/meta-networking/recipes-connectivity/dibbler/dibbler_git.bb
+++ b/meta-networking/recipes-connectivity/dibbler/dibbler_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=7236695bb6d4461c105d685a8b61c4e3"
 
 SRCREV = "a7c6cf58a88a510cb00841351e75030ce78d36bf"
 
-SRC_URI = "git://github.com/tomaszmrugalski/dibbler \
+SRC_URI = "git://github.com/tomaszmrugalski/dibbler;branch=master;protocol=https \
            file://dibbler_fix_getSize_crash.patch \
            "
 PV = "1.0.1+1.0.2RC1+git${SRCREV}"

--- a/meta-networking/recipes-connectivity/freeradius/freeradius_3.0.21.bb
+++ b/meta-networking/recipes-connectivity/freeradius/freeradius_3.0.21.bb
@@ -13,7 +13,7 @@ LICENSE = "GPLv2 & LGPLv2+"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=eb723b61539feef013de476e68b5c50a"
 DEPENDS = "openssl-native openssl libidn libtool libpcap libtalloc"
 
-SRC_URI = "git://github.com/FreeRADIUS/freeradius-server.git;branch=v3.0.x;lfs=0; \
+SRC_URI = "git://github.com/FreeRADIUS/freeradius-server.git;branch=v3.0.x;lfs=0;protocol=https \
     file://freeradius \
     file://volatiles.58_radiusd \
     file://freeradius-enble-user-in-conf.patch \

--- a/meta-networking/recipes-connectivity/libdnet/libdnet_1.14.bb
+++ b/meta-networking/recipes-connectivity/libdnet/libdnet_1.14.bb
@@ -4,7 +4,7 @@ SECTION = "libs"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=0036c1b155f4e999f3e0a373490b5db9"
 
-SRC_URI = "git://github.com/dugsong/libdnet.git;nobranch=1"
+SRC_URI = "git://github.com/dugsong/libdnet.git;nobranch=1;protocol=https"
 SRCREV = "3e782472d2a58d5e1b94d04eda4a364c2d257600"
 
 UPSTREAM_CHECK_GITTAGREGEX = "libdnet-(?P<pver>\d+(\.\d+)+)"

--- a/meta-networking/recipes-connectivity/libiec61850/libiec61850_1.4.2.1.bb
+++ b/meta-networking/recipes-connectivity/libiec61850/libiec61850_1.4.2.1.bb
@@ -15,7 +15,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 DEPENDS = "swig-native python3"
 SRCREV = "d798814fb463115a835da597535a625b68a39cff"
 
-SRC_URI = "git://github.com/mz-automation/${BPN}.git;branch=v1.4 \
+SRC_URI = "git://github.com/mz-automation/${BPN}.git;branch=v1.4;protocol=https \
            file://0001-use-poll.h-instead-of-sys-poll.h.patch \
            file://0002-serial_port_linux-Add-missing-include-sys-time.h.patch \
            file://0003-pyiec61850-don-t-break-CMAKE_INSTALL_PATH-by-trying-.patch \

--- a/meta-networking/recipes-connectivity/nanomsg/nanomsg_1.1.5.bb
+++ b/meta-networking/recipes-connectivity/nanomsg/nanomsg_1.1.5.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=587b3fd7fd291e418ff4d2b8f3904755"
 
 SECTION = "libs/networking"
 
-SRC_URI = "git://github.com/nanomsg/nanomsg.git;protocol=https"
+SRC_URI = "git://github.com/nanomsg/nanomsg.git;protocol=https;branch=master"
 SRCREV = "1749fd7b039165a91b8d556b4df18e3e632ad830"
 
 S = "${WORKDIR}/git"

--- a/meta-networking/recipes-connectivity/nanomsg/nng_1.2.5.bb
+++ b/meta-networking/recipes-connectivity/nanomsg/nng_1.2.5.bb
@@ -8,7 +8,7 @@ SECTION = "libs/networking"
 
 SRCREV = "53ae1a5ab37fdfc9ad5c236df3eaf4dd63f0fee9"
 
-SRC_URI = "git://github.com/nanomsg/nng.git;branch=v1.2.x"
+SRC_URI = "git://github.com/nanomsg/nng.git;branch=v1.2.x;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-networking/recipes-connectivity/nanomsg/nngpp_git.bb
+++ b/meta-networking/recipes-connectivity/nanomsg/nngpp_git.bb
@@ -7,7 +7,7 @@ DEPENDS = "nng"
 SRCREV = "cc5d2641babab165d8a9943817c46d36c6dc17c2"
 PV = "1.3.0"
 
-SRC_URI = "git://github.com/cwzx/nngpp"
+SRC_URI = "git://github.com/cwzx/nngpp;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-networking/recipes-connectivity/netplan/netplan_0.101.bb
+++ b/meta-networking/recipes-connectivity/netplan/netplan_0.101.bb
@@ -15,7 +15,7 @@ SRCREV = "e445b87b9dff439ec564c245d030b03d61eb0f24"
 PV = "0.101+git${SRCPV}"
 
 SRC_URI = " \
-        git://github.com/CanonicalLtd/netplan.git \
+        git://github.com/CanonicalLtd/netplan.git;branch=master;protocol=https \
         file://0001-dbus-Remove-unused-variabes.patch \
         file://0002-Makefile-Exclude-.h-files-from-target-rule.patch \
 "

--- a/meta-networking/recipes-connectivity/openconnect/openconnect_8.10.bb
+++ b/meta-networking/recipes-connectivity/openconnect/openconnect_8.10.bb
@@ -3,7 +3,7 @@ LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING.LGPL;md5=243b725d71bb5df4a1e5920b344b86ad"
 
 SRC_URI = " \
-    git://git.infradead.org/users/dwmw2/openconnect.git \
+    git://git.infradead.org/users/dwmw2/openconnect.git;branch=master \
 "
 SRCREV = "9d287e40c57233190a51b6434ba7345370e36f38"
 

--- a/meta-networking/recipes-connectivity/relayd/relayd_git.bb
+++ b/meta-networking/recipes-connectivity/relayd/relayd_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://main.c;endline=17;md5=86aad799085683e0a2e1c2684a20bab
 
 DEPENDS = "libubox"
 
-SRC_URI = "git://git.openwrt.org/project/relayd.git \
+SRC_URI = "git://git.openwrt.org/project/relayd.git;branch=master \
            file://0001-rtnl_flush-Error-on-failed-write.patch \
 "
 

--- a/meta-networking/recipes-connectivity/vpnc/vpnc_0.5.3.bb
+++ b/meta-networking/recipes-connectivity/vpnc/vpnc_0.5.3.bb
@@ -9,7 +9,7 @@ DEPENDS += "libgcrypt"
 
 PV .= "r550-2jnpr1"
 SRCREV = "b1243d29e0c00312ead038b04a2cf5e2fa31d740"
-SRC_URI = "git://github.com/ndpgroup/vpnc \
+SRC_URI = "git://github.com/ndpgroup/vpnc;branch=master;protocol=https \
            file://long-help \
            file://default.conf \
            file://0001-search-for-log-help-in-build-dir.patch \

--- a/meta-networking/recipes-connectivity/wolfssl/wolfssl_4.7.1.bb
+++ b/meta-networking/recipes-connectivity/wolfssl/wolfssl_4.7.1.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 PROVIDES += "cyassl"
 RPROVIDES_${PN} = "cyassl"
 
-SRC_URI = "git://github.com/wolfSSL/wolfssl.git;protocol=https \
+SRC_URI = "git://github.com/wolfSSL/wolfssl.git;protocol=https;branch=master \
 "
 SRCREV = "95b91d89133a712a3d0f389442924612c103da24"
 S = "${WORKDIR}/git"

--- a/meta-networking/recipes-daemons/atftp/atftp_0.7.4.bb
+++ b/meta-networking/recipes-daemons/atftp/atftp_0.7.4.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=94d55d512a9ba36caa9b7df079bae19f"
 
 SRCREV = "e56e8845f1070e89a4a6e509396b681688d03793"
 
-SRC_URI = "git://git.code.sf.net/p/atftp/code \
+SRC_URI = "git://git.code.sf.net/p/atftp/code;branch=master \
            file://atftpd.init \
            file://atftpd.service \
 "

--- a/meta-networking/recipes-daemons/cyrus-sasl/cyrus-sasl_2.1.27.bb
+++ b/meta-networking/recipes-daemons/cyrus-sasl/cyrus-sasl_2.1.27.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=3f55e0974e3d6db00ca6f57f2d206396"
 
 SRCREV = "e41cfb986c1b1935770de554872247453fdbb079"
 
-SRC_URI = "git://github.com/cyrusimap/cyrus-sasl;protocol=https \
+SRC_URI = "git://github.com/cyrusimap/cyrus-sasl;protocol=https;branch=master \
            file://avoid-to-call-AC_TRY_RUN.patch \
            file://Fix-hardcoded-libdir.patch \
            file://debian_patches_0014_avoid_pic_overwrite.diff \

--- a/meta-networking/recipes-daemons/iscsi-initiator-utils/iscsi-initiator-utils_2.1.4.bb
+++ b/meta-networking/recipes-daemons/iscsi-initiator-utils/iscsi-initiator-utils_2.1.4.bb
@@ -14,7 +14,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRCREV ?= "095f59ca464220eae285de6b5f2ee31185a6a84c"
 
-SRC_URI = "git://github.com/open-iscsi/open-iscsi \
+SRC_URI = "git://github.com/open-iscsi/open-iscsi;branch=master;protocol=https \
            file://0001-Makefile-Do-not-set-Werror.patch \
            file://initd.debian \
            file://99_iscsi-initiator-utils \

--- a/meta-networking/recipes-daemons/vblade/vblade_25.bb
+++ b/meta-networking/recipes-daemons/vblade/vblade_25.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 UPSTREAM_CHECK_URI = "https://sourceforge.net/projects/aoetools/files/vblade/"
 
 SRCREV = "5f1a0ba8b9815e3f08a3e2635a17f78bbf2a5b10"
-SRC_URI = "git://github.com/OpenAoE/vblade \
+SRC_URI = "git://github.com/OpenAoE/vblade;branch=master;protocol=https \
            file://cross.patch \
            file://makefile-add-ldflags.patch \
            file://${BPN}.conf \

--- a/meta-networking/recipes-filter/arno-iptables-firewall/arno-iptables-firewall_2.1.1.bb
+++ b/meta-networking/recipes-filter/arno-iptables-firewall/arno-iptables-firewall_2.1.1.bb
@@ -5,7 +5,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://gpl_license.txt;md5=11c7b65c4a4acb9d5175f7e9bf99c403"
 
 SRCREV = "a96b81da4a9b619e4045805f5f13a1e982c95663"
-SRC_URI = "git://github.com/arno-iptables-firewall/aif"
+SRC_URI = "git://github.com/arno-iptables-firewall/aif;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-networking/recipes-filter/libnetfilter/libnetfilter-log_1.0.1.bb
+++ b/meta-networking/recipes-filter/libnetfilter/libnetfilter-log_1.0.1.bb
@@ -8,7 +8,7 @@ DEPENDS = "libnfnetlink libmnl"
 SRCREV = "ba196a97e810746e5660fe3f57c87c0ed0f2b324"
 PV .= "+git${SRCPV}"
 
-SRC_URI = "git://git.netfilter.org/libnetfilter_log"
+SRC_URI = "git://git.netfilter.org/libnetfilter_log;branch=master"
 
 S = "${WORKDIR}/git"
 

--- a/meta-networking/recipes-filter/libnetfilter/libnetfilter-queue_1.0.3.bb
+++ b/meta-networking/recipes-filter/libnetfilter/libnetfilter-queue_1.0.3.bb
@@ -8,7 +8,7 @@ DEPENDS = "libnfnetlink libmnl"
 
 SRCREV = "601abd1c71ccdf90753cf294c120ad43fb25dc54"
 
-SRC_URI = "git://git.netfilter.org/libnetfilter_queue \
+SRC_URI = "git://git.netfilter.org/libnetfilter_queue;branch=master \
            file://0001-libnetfilter-queue-Declare-the-define-visivility-attribute-together.patch \
            "
 

--- a/meta-networking/recipes-filter/libnftnl/libnftnl_1.1.9.bb
+++ b/meta-networking/recipes-filter/libnftnl/libnftnl_1.1.9.bb
@@ -5,7 +5,7 @@ SECTION = "libs"
 DEPENDS = "libmnl"
 
 SRCREV = "c3fdda6ac8675aea9b35772458544f03157be415"
-SRC_URI = "git://git.netfilter.org/libnftnl \
+SRC_URI = "git://git.netfilter.org/libnftnl;branch=master \
            file://0001-avoid-naming-local-function-as-one-of-printf-family.patch \
            "
 

--- a/meta-networking/recipes-irc/znc/znc_1.8.2.bb
+++ b/meta-networking/recipes-irc/znc/znc_1.8.2.bb
@@ -5,8 +5,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS = "openssl zlib icu"
 
-SRC_URI = "git://github.com/znc/znc.git;name=znc \
-           git://github.com/jimloco/Csocket.git;destsuffix=git/third_party/Csocket;name=Csocket \
+SRC_URI = "git://github.com/znc/znc.git;name=znc;branch=master;protocol=https \
+           git://github.com/jimloco/Csocket.git;destsuffix=git/third_party/Csocket;name=Csocket;branch=master;protocol=https \
           "
 SRCREV_znc = "bf253640d33d03331310778e001fb6f5aba2989e"
 SRCREV_Csocket = "e8d9e0bb248c521c2c7fa01e1c6a116d929c41b4"

--- a/meta-networking/recipes-kernel/wireguard/wireguard-module_1.0.20210219.bb
+++ b/meta-networking/recipes-kernel/wireguard/wireguard-module_1.0.20210219.bb
@@ -2,7 +2,7 @@ require wireguard.inc
 
 SRCREV = "122f06bfd8fc7b06a0899fa9adc4ce8e06900d98"
 
-SRC_URI = "git://git.zx2c4.com/wireguard-linux-compat"
+SRC_URI = "git://git.zx2c4.com/wireguard-linux-compat;branch=master"
 
 inherit module kernel-module-split
 

--- a/meta-networking/recipes-kernel/wireguard/wireguard-tools_1.0.20210315.bb
+++ b/meta-networking/recipes-kernel/wireguard/wireguard-tools_1.0.20210315.bb
@@ -1,7 +1,7 @@
 require wireguard.inc
 
 SRCREV = "622408872fd6f3a58e98e88d39d30e98968314fa"
-SRC_URI = "git://git.zx2c4.com/wireguard-tools"
+SRC_URI = "git://git.zx2c4.com/wireguard-tools;branch=master"
 
 inherit bash-completion systemd pkgconfig
 

--- a/meta-networking/recipes-protocols/babeld/babeld_1.9.2.bb
+++ b/meta-networking/recipes-protocols/babeld/babeld_1.9.2.bb
@@ -12,7 +12,7 @@ SECTION = "net"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENCE;md5=411a48ac3c2e9e0911b8dd9aed26f754"
 
-SRC_URI = "git://github.com/jech/babeld.git;protocol=git"
+SRC_URI = "git://github.com/jech/babeld.git;protocol=https;branch=master"
 SRCREV = "a1043879225ac205614259b480d7f577025d8bb0"
 
 UPSTREAM_CHECK_GITTAGREGEX = "babeld-(?P<pver>\d+(\.\d+)+)"

--- a/meta-networking/recipes-protocols/openflow/openflow.inc
+++ b/meta-networking/recipes-protocols/openflow/openflow.inc
@@ -11,7 +11,7 @@ LICENSE = "GPLv2"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=e870c934e2c3d6ccf085fd7cf0a1e2e2"
 
-SRC_URI = "git://gitosis.stanford.edu/openflow.git;protocol=git"
+SRC_URI = "git://gitosis.stanford.edu/openflow.git;protocol=git;branch=master"
 
 DEPENDS = "virtual/libc"
 

--- a/meta-networking/recipes-protocols/xl2tpd/xl2tpd_1.3.14.bb
+++ b/meta-networking/recipes-protocols/xl2tpd/xl2tpd_1.3.14.bb
@@ -8,7 +8,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/xelerance/xl2tpd.git"
+SRC_URI = "git://github.com/xelerance/xl2tpd.git;branch=master;protocol=https"
 SRCREV = "ba619c79c4790c78c033df0abde4a9a5de744a08"
 
 S = "${WORKDIR}/git"

--- a/meta-networking/recipes-support/arptables/arptables_git.bb
+++ b/meta-networking/recipes-support/arptables/arptables_git.bb
@@ -6,7 +6,7 @@ SRCREV = "efae8949e31f8b2eb6290f377a28384cecaf105a"
 PV = "0.0.5+git${SRCPV}"
 
 SRC_URI = " \
-    git://git.netfilter.org/arptables \
+    git://git.netfilter.org/arptables;branch=master \
     file://0001-Use-ARPCFLAGS-for-package-specific-compiler-flags.patch \
     file://arptables-arpt-get-target-fix.patch \
     file://arptables.service \

--- a/meta-networking/recipes-support/cifs/cifs-utils_6.13.bb
+++ b/meta-networking/recipes-support/cifs/cifs-utils_6.13.bb
@@ -5,7 +5,7 @@ LICENSE = "GPLv3 & LGPLv3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
 SRCREV = "464a60344a324311a6f5bb326fdf5f422a3c9005"
-SRC_URI = "git://git.samba.org/cifs-utils.git"
+SRC_URI = "git://git.samba.org/cifs-utils.git;branch=master"
 
 S = "${WORKDIR}/git"
 DEPENDS += "libtalloc"

--- a/meta-networking/recipes-support/curlpp/curlpp_0.8.1.bb
+++ b/meta-networking/recipes-support/curlpp/curlpp_0.8.1.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://doc/LICENSE;md5=fd0c9adf285a69aa3b4faf34384e1029"
 DEPENDS = "curl"
 DEPENDS_class-native = "curl-native"
 
-SRC_URI = "git://github.com/jpbarrette/curlpp.git"
+SRC_URI = "git://github.com/jpbarrette/curlpp.git;branch=master;protocol=https"
 
 SRCREV = "592552a165cc569dac7674cb7fc9de3dc829906f"
 

--- a/meta-networking/recipes-support/drbd/drbd-utils_9.13.1.bb
+++ b/meta-networking/recipes-support/drbd/drbd-utils_9.13.1.bb
@@ -8,8 +8,8 @@ SECTION = "admin"
 LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=5574c6965ae5f583e55880e397fbb018"
 
-SRC_URI = "git://github.com/LINBIT/drbd-utils;name=drbd-utils;branch=${PV} \
-           git://github.com/LINBIT/drbd-headers;name=drbd-headers;destsuffix=git/drbd-headers \
+SRC_URI = "git://github.com/LINBIT/drbd-utils;name=drbd-utils;branch=${PV};protocol=https \
+           git://github.com/LINBIT/drbd-headers;name=drbd-headers;destsuffix=git/drbd-headers;branch=master;protocol=https \
            file://0001-v84-Make-setup_options-definitions-as-extern.patch \
            ${@bb.utils.contains('DISTRO_FEATURES','usrmerge','file://0001-drbd-utils-support-usrmerge.patch','',d)} \
           "

--- a/meta-networking/recipes-support/ettercap/ettercap_0.8.3.1.bb
+++ b/meta-networking/recipes-support/ettercap/ettercap_0.8.3.1.bb
@@ -19,7 +19,7 @@ DEPENDS += "ethtool \
 
 RDEPENDS_${PN} += "bash ethtool libgcc"
 
-SRC_URI = "gitsm://github.com/Ettercap/ettercap"
+SRC_URI = "gitsm://github.com/Ettercap/ettercap;branch=master;protocol=https"
 
 SRCREV = "7281fbddb7da7478beb1d21e3cb105fff3778b31"
 

--- a/meta-networking/recipes-support/geoip/geoip-perl_1.51.bb
+++ b/meta-networking/recipes-support/geoip/geoip-perl_1.51.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=e4f3ea6e9b28af88dc0321190a1f8250"
 
 S = "${WORKDIR}/git"
 SRCREV = "4cdfdc38eca237c19c22a8b90490446ce6d970fa"
-SRC_URI = "git://github.com/maxmind/geoip-api-perl.git;branch=main \
+SRC_URI = "git://github.com/maxmind/geoip-api-perl.git;branch=main;protocol=https \
     file://run-ptest \
 "
 

--- a/meta-networking/recipes-support/geoip/geoip_1.6.12.bb
+++ b/meta-networking/recipes-support/geoip/geoip_1.6.12.bb
@@ -10,7 +10,7 @@ SECTION = "libdevel"
 
 GEOIP_DATABASE_VERSION = "20181205"
 
-SRC_URI = "git://github.com/maxmind/geoip-api-c.git;branch=main \
+SRC_URI = "git://github.com/maxmind/geoip-api-c.git;branch=main;protocol=https \
            http://sources.openembedded.org/GeoIP.dat.${GEOIP_DATABASE_VERSION}.gz;apply=no;name=GeoIP-dat; \
            http://sources.openembedded.org/GeoIPv6.dat.${GEOIP_DATABASE_VERSION}.gz;apply=no;name=GeoIPv6-dat; \
            http://sources.openembedded.org/GeoLiteCity.dat.${GEOIP_DATABASE_VERSION}.gz;apply=no;name=GeoLiteCity-dat; \

--- a/meta-networking/recipes-support/ifenslave/ifenslave_2.11.bb
+++ b/meta-networking/recipes-support/ifenslave/ifenslave_2.11.bb
@@ -9,7 +9,7 @@ inherit manpages
 MAN_PKG = "${PN}"
 
 SRCREV = "c26e9310f552e69d0d44eb48746e02c9ae4b4f6f"
-SRC_URI = "git://salsa.debian.org/debian/ifenslave.git;protocol=https"
+SRC_URI = "git://salsa.debian.org/debian/ifenslave.git;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"
 

--- a/meta-networking/recipes-support/ipcalc/ipcalc_0.2.3.bb
+++ b/meta-networking/recipes-support/ipcalc/ipcalc_0.2.3.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 S = "${WORKDIR}/git"
 SRCREV = "c3ee70c878b9c5833a77a1f339f1ca4dc6f225c5"
 SRC_URI = "\
-    git://github.com/nmav/ipcalc.git;protocol=https; \
+    git://github.com/nmav/ipcalc.git;protocol=https;;branch=master \
     file://0001-Makefile-pass-extra-linker-flags.patch \
 "
 

--- a/meta-networking/recipes-support/lksctp-tools/lksctp-tools_1.0.18.bb
+++ b/meta-networking/recipes-support/lksctp-tools/lksctp-tools_1.0.18.bb
@@ -14,7 +14,7 @@ PV .= "+git${SRCPV}"
 LK_REL = "1.0.18"
 
 SRC_URI = " \
-    git://github.com/sctp/lksctp-tools.git \
+    git://github.com/sctp/lksctp-tools.git;branch=master;protocol=https \
     file://0001-m4-sctp.m4-make-conpatible-to-autoconf-2.70.patch \
     file://run-ptest \
     file://v4test.sh \

--- a/meta-networking/recipes-support/lowpan-tools/lowpan-tools_git.bb
+++ b/meta-networking/recipes-support/lowpan-tools/lowpan-tools_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
 DEPENDS = "flex-native bison-native libnl python"
 
 PV = "0.3.1+git${SRCPV}"
-SRC_URI = "git://github.com/linux-wpan/lowpan-tools \
+SRC_URI = "git://github.com/linux-wpan/lowpan-tools;branch=master;protocol=https \
            file://no-help2man.patch \
            file://0001-Fix-build-errors-with-clang.patch \
            file://0001-addrdb-coord-config-parse.y-add-missing-time.h-inclu.patch \

--- a/meta-networking/recipes-support/mtr/mtr_0.94.bb
+++ b/meta-networking/recipes-support/mtr/mtr_0.94.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
                     file://ui/mtr.c;beginline=5;endline=16;md5=00a894a39d53726a27386534d1c4e468"
 
 SRCREV = "2c73cbf4094e4eed343ed11ae5bab2580f3122d1"
-SRC_URI = "git://github.com/traviscross/mtr"
+SRC_URI = "git://github.com/traviscross/mtr;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-networking/recipes-support/nbdkit/nbdkit_1.25.6.bb
+++ b/meta-networking/recipes-support/nbdkit/nbdkit_1.25.6.bb
@@ -9,7 +9,7 @@ HOMEPAGE = "https://github.com/libguestfs/nbdkit"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=f9dcc2d8acdde215fa4bd6ac12bb14f0"
 
-SRC_URI = "git://github.com/libguestfs/nbdkit.git;protocol=https \
+SRC_URI = "git://github.com/libguestfs/nbdkit.git;protocol=https;branch=master \
 "
 
 SRCREV = "023dac3e09a0e39d6f91dea4b7f8efb8f5faae36"

--- a/meta-networking/recipes-support/ndisc6/ndisc6_git.bb
+++ b/meta-networking/recipes-support/ndisc6/ndisc6_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
 
 PV = "1.0.4+git${SRCPV}"
 SRCREV = "4c794b5512d23c649def1f94a684225dcbb6ac3e"
-SRC_URI = "git://git.remlab.net/git/ndisc6.git;protocol=http \
+SRC_URI = "git://git.remlab.net/git/ndisc6.git;protocol=http;branch=master \
            file://0001-replace-VLAIS-with-malloc-free-pair.patch \
            file://0002-Do-not-undef-_GNU_SOURCE.patch \
            file://0001-autogen-Do-not-symlink-gettext.h-from-build-host.patch \

--- a/meta-networking/recipes-support/netcf/netcf_0.2.8.bb
+++ b/meta-networking/recipes-support/netcf/netcf_0.2.8.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=fb919cc88dbe06ec0b0bd50e001ccf1f"
 SRCREV = "2c5d4255857531bc09d91dcd02e86545f29004d4"
 PV .= "+git${SRCPV}"
 
-SRC_URI = "git://pagure.io/netcf.git;protocol=https \
+SRC_URI = "git://pagure.io/netcf.git;protocol=https;branch=master \
 "
 
 UPSTREAM_CHECK_GITTAGREGEX = "release-(?P<pver>(\d+(\.\d+)+))"

--- a/meta-networking/recipes-support/netperf/netperf_git.bb
+++ b/meta-networking/recipes-support/netperf/netperf_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=a0ab17253e7a3f318da85382c7d5d5d6"
 
 PV = "2.7.0+git${SRCPV}"
 
-SRC_URI = "git://github.com/HewlettPackard/netperf.git \
+SRC_URI = "git://github.com/HewlettPackard/netperf.git;branch=master;protocol=https \
            file://cpu_set.patch \
            file://vfork.patch \
            file://init \

--- a/meta-networking/recipes-support/nis/yp-tools_4.2.3.bb
+++ b/meta-networking/recipes-support/nis/yp-tools_4.2.3.bb
@@ -14,7 +14,7 @@ and ypdomainname. \
 # v4.2.3
 SRCREV = "1bfda29c342a81b97cb1995ffd9e8da5de63e7ab"
 
-SRC_URI = "git://github.com/thkukuk/yp-tools \
+SRC_URI = "git://github.com/thkukuk/yp-tools;branch=master;protocol=https \
            file://domainname.service \
            "
 

--- a/meta-networking/recipes-support/ntimed/ntimed_git.bb
+++ b/meta-networking/recipes-support/ntimed/ntimed_git.bb
@@ -8,7 +8,7 @@ SECTION = "net"
 LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://main.c;beginline=2;endline=24;md5=89db8e76f2951f3fad167e7aa9718a44"
 
-SRC_URI = "git://github.com/bsdphk/Ntimed \
+SRC_URI = "git://github.com/bsdphk/Ntimed;branch=master;protocol=https \
            file://use-ldflags.patch"
 
 PV = "0.0+git${SRCPV}"

--- a/meta-networking/recipes-support/ntopng/ndpi_3.4.bb
+++ b/meta-networking/recipes-support/ntopng/ndpi_3.4.bb
@@ -9,7 +9,7 @@ LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b52f2d57d10c4f7ee67a7eb9615d5d24"
 
 SRCREV = "64929a75e0a7a60d864bd25a9fd97fdf9ac892a2"
-SRC_URI = "git://github.com/ntop/nDPI.git;branch=3.4-stable \
+SRC_URI = "git://github.com/ntop/nDPI.git;branch=3.4-stable;protocol=https \
            file://0001-autogen.sh-not-generate-configure.patch \
            file://CVE-2021-36082.patch \
 "

--- a/meta-networking/recipes-support/ntopng/ntopng_4.2.bb
+++ b/meta-networking/recipes-support/ntopng/ntopng_4.2.bb
@@ -12,7 +12,7 @@ LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
 SRCREV = "5e649a2d1130b4a3ab0c5bb673d615172cc0bdbb"
-SRC_URI = "git://github.com/ntop/ntopng.git;protocol=git;branch=4.2-stable \
+SRC_URI = "git://github.com/ntop/ntopng.git;protocol=https;branch=4.2-stable \
            file://0001-configure.seed-fix-configure-error.patch \
            file://0001-configure.seed-fix-host-contamination.patch \
            file://0001-Makefile.in-don-t-use-the-internal-lua.patch \

--- a/meta-networking/recipes-support/open-isns/open-isns_0.101.bb
+++ b/meta-networking/recipes-support/open-isns/open-isns_0.101.bb
@@ -13,7 +13,7 @@ SECTION = "net"
 
 DEPENDS = "openssl"
 
-SRC_URI = "git://github.com/open-iscsi/open-isns \
+SRC_URI = "git://github.com/open-iscsi/open-isns;branch=master;protocol=https \
            file://0001-isnsd.socket-use-run-instead-of-var-run.patch \
            "
 

--- a/meta-networking/recipes-support/open-vm-tools/open-vm-tools_11.2.5.bb
+++ b/meta-networking/recipes-support/open-vm-tools/open-vm-tools_11.2.5.bb
@@ -25,7 +25,7 @@ LICENSE_modules/freebsd/vmxnet = "GPL-2.0"
 LICENSE_modules/linux = "GPL-2.0"
 LICENSE_modules/solaris = "CDDL-1.0"
 
-SRC_URI = "git://github.com/vmware/open-vm-tools.git;protocol=https \
+SRC_URI = "git://github.com/vmware/open-vm-tools.git;protocol=https;branch=master \
     file://tools.conf \
     file://vmtoolsd.service \
     file://vmtoolsd.init \

--- a/meta-networking/recipes-support/phytool/phytool.bb
+++ b/meta-networking/recipes-support/phytool/phytool.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=39bba7d2cf0ba1036f2a6e2be52fe3f0"
 
 PV = "2+git${SRCPV}"
 SRCREV = "8882328c08ba2efb13c049812098f1d0cb8adf0c"
-SRC_URI = "git://github.com/wkz/phytool.git"
+SRC_URI = "git://github.com/wkz/phytool.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-networking/recipes-support/rdma-core/rdma-core_33.0.bb
+++ b/meta-networking/recipes-support/rdma-core/rdma-core_33.0.bb
@@ -5,7 +5,7 @@ SECTION = "libs"
 DEPENDS = "libnl"
 RDEPENDS_${PN} = "bash perl"
 
-SRC_URI = "git://github.com/linux-rdma/rdma-core.git"
+SRC_URI = "git://github.com/linux-rdma/rdma-core.git;branch=master;protocol=https"
 SRCREV = "e66ca0832e58dafac7af7ad9e6799eaef438061a"
 S = "${WORKDIR}/git"
 

--- a/meta-networking/recipes-support/smcroute/smcroute_2.4.4.bb
+++ b/meta-networking/recipes-support/smcroute/smcroute_2.4.4.bb
@@ -6,7 +6,7 @@ LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
 
 SRCREV = "a8e5847e5f7e411be424f9b52a6cdf9d2ed4aeb5"
-SRC_URI = "git://github.com/troglobit/smcroute.git;branch=master;protocol=git"
+SRC_URI = "git://github.com/troglobit/smcroute.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-networking/recipes-support/spice/spice-protocol_git.bb
+++ b/meta-networking/recipes-support/spice/spice-protocol_git.bb
@@ -18,7 +18,7 @@ PV = "0.14.1+git${SRCPV}"
 SRCREV = "e0ec178a72aa33e307ee5ac02b63bf336da921a5"
 
 SRC_URI = " \
-    git://anongit.freedesktop.org/spice/spice-protocol \
+    git://anongit.freedesktop.org/spice/spice-protocol;branch=master \
 "
 
 S = "${WORKDIR}/git"

--- a/meta-networking/recipes-support/spice/spice_git.bb
+++ b/meta-networking/recipes-support/spice/spice_git.bb
@@ -21,8 +21,8 @@ SRCREV_spice-common = "4fc4c2db36c7f07b906e9a326a9d3dc0ae6a2671"
 SRCREV_FORMAT = "spice_spice-common"
 
 SRC_URI = " \
-    git://anongit.freedesktop.org/spice/spice;name=spice \
-    git://anongit.freedesktop.org/spice/spice-common;destsuffix=git/subprojects/spice-common;name=spice-common \
+    git://anongit.freedesktop.org/spice/spice;name=spice;branch=master \
+    git://anongit.freedesktop.org/spice/spice-common;destsuffix=git/subprojects/spice-common;name=spice-common;branch=master \
     file://0001-Convert-pthread_t-to-be-numeric.patch \
     file://0001-Fix-compile-errors-on-Linux-32bit-system.patch \
     file://0001-configure.ac-explicitly-link-to-jpeg-lib.patch \

--- a/meta-networking/recipes-support/spice/usbredir_0.9.0.bb
+++ b/meta-networking/recipes-support/spice/usbredir_0.9.0.bb
@@ -10,7 +10,7 @@ DEPENDS = "libusb1"
 SRCREV = "bca484fc6f206ab9da2f73e8a0118fad45374d4e"
 
 SRC_URI = " \
-    git://anongit.freedesktop.org/spice/usbredir \
+    git://anongit.freedesktop.org/spice/usbredir;branch=master \
 "
 
 S = "${WORKDIR}/git"

--- a/meta-networking/recipes-support/unbound/unbound_1.12.0.bb
+++ b/meta-networking/recipes-support/unbound/unbound_1.12.0.bb
@@ -9,7 +9,7 @@ SECTION = "net"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=5308494bc0590c0cb036afd781d78f06"
 
-SRC_URI = "git://github.com/NLnetLabs/unbound.git;protocol=http;branch=master \
+SRC_URI = "git://github.com/NLnetLabs/unbound.git;protocol=http;branch=master;protocol=https \
 	file://0001-contrib-add-yocto-compatible-init-script.patch \
 "
 SRCREV="52b04806f4236c37acd10179ab465a54adc7e86a"

--- a/meta-networking/recipes-support/wpan-tools/wpan-tools_0.9.bb
+++ b/meta-networking/recipes-support/wpan-tools/wpan-tools_0.9.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4cfd939b1d7e6aba9fcefb7f6e2fd45d"
 
 DEPENDS = "libnl"
 
-SRC_URI = "git://github.com/linux-wpan/wpan-tools"
+SRC_URI = "git://github.com/linux-wpan/wpan-tools;branch=master;protocol=https"
 SRCREV = "a316ca2caa746d60817400e5bf646c2820f09273"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/dynamic-layers/meta-python/recipes-benchmark/speedtest-cli/speedtest-cli_2.1.2.bb
+++ b/meta-oe/dynamic-layers/meta-python/recipes-benchmark/speedtest-cli/speedtest-cli_2.1.2.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 inherit setuptools3
 
-SRC_URI = "git://github.com/sivel/speedtest-cli.git"
+SRC_URI = "git://github.com/sivel/speedtest-cli.git;branch=master;protocol=https"
 SRCREV = "c58ad3367bf27f4b4a4d5b1bca29ebd574731c5d"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/dynamic-layers/meta-python/recipes-bsp/rwmem/rwmem_1.2.bb
+++ b/meta-oe/dynamic-layers/meta-python/recipes-bsp/rwmem/rwmem_1.2.bb
@@ -21,7 +21,7 @@ SRCREV_inih = "4b10c654051a86556dfdb634c891b6c3224c4109"
 SRCREV_FORMAT = "rwmem_inih"
 
 SRC_URI = " \
-    git://github.com/tomba/rwmem.git;protocol=https;name=rwmem \
+    git://github.com/tomba/rwmem.git;protocol=https;name=rwmem;branch=master \
     git://github.com/benhoyt/inih.git;protocol=https;name=inih;nobranch=1;destsuffix=git/ext/inih \
 "
 

--- a/meta-oe/dynamic-layers/meta-python/recipes-dbs/mongodb/mongodb_git.bb
+++ b/meta-oe/dynamic-layers/meta-python/recipes-dbs/mongodb/mongodb_git.bb
@@ -14,7 +14,7 @@ inherit scons dos2unix siteinfo python3native systemd useradd
 PV = "4.4.6"
 #v4.4.6
 SRCREV = "72e66213c2c3eab37d9358d5e78ad7f5c1d0d0d7"
-SRC_URI = "git://github.com/mongodb/mongo.git;branch=v4.4 \
+SRC_URI = "git://github.com/mongodb/mongo.git;branch=v4.4;protocol=https \
            file://0001-Tell-scons-to-use-build-settings-from-environment-va.patch \
            file://0001-Use-long-long-instead-of-int64_t.patch \
            file://0001-Use-__GLIBC__-to-control-use-of-gnu_get_libc_version.patch \

--- a/meta-oe/dynamic-layers/meta-python/recipes-devtools/nanopb/nanopb_0.4.5.bb
+++ b/meta-oe/dynamic-layers/meta-python/recipes-devtools/nanopb/nanopb_0.4.5.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=9db4b73a55a3994384112efcdb37c01f"
 
 DEPENDS = "protobuf-native"
 
-SRC_URI = "git://github.com/nanopb/nanopb.git"
+SRC_URI = "git://github.com/nanopb/nanopb.git;branch=master;protocol=https"
 SRCREV = "c9124132a604047d0ef97a09c0e99cd9bed2c818"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/dynamic-layers/meta-python/recipes-extended/lcdproc/lcdproc_git.bb
+++ b/meta-oe/dynamic-layers/meta-python/recipes-extended/lcdproc/lcdproc_git.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=18810669f13b87348459e611d31ab760 \
 
 PV = "0.5.9+git${SRCPV}"
 SRCREV = "3a3d622d9bb74c44fa67bc20573751a207514134"
-SRC_URI = "git://github.com/lcdproc/lcdproc \
+SRC_URI = "git://github.com/lcdproc/lcdproc;branch=master;protocol=https \
            file://0001-Fix-parallel-build-fix-port-internal-make-dependenci.patch \
            file://0002-Include-limits.h-for-PATH_MAX-definition.patch \
            file://0003-Fix-non-x86-platforms-on-musl.patch \

--- a/meta-oe/dynamic-layers/networking-layer/recipes-devtools/valijson/valijson_0.3.bb
+++ b/meta-oe/dynamic-layers/networking-layer/recipes-devtools/valijson/valijson_0.3.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/tristanpenman/valijson"
 LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=015106c62262b2383f6c72063f0998f2"
 
-SRC_URI = "git://github.com/tristanpenman/valijson.git"
+SRC_URI = "git://github.com/tristanpenman/valijson.git;branch=master;protocol=https"
 SRCREV = "7a52fc88cdffd6678c009ca2fad700151f7363c6"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/dynamic-layers/perl-layer/recipes-support/rasdaemon/rasdaemon_0.6.6.bb
+++ b/meta-oe/dynamic-layers/perl-layer/recipes-support/rasdaemon/rasdaemon_0.6.6.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://git.infradead.org/users/mchehab/rasdaemon.git"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d3070efe0afa3dc41608bd82c00bb0dc"
 
-SRC_URI = "git://github.com/mchehab/rasdaemon.git;branch=master \
+SRC_URI = "git://github.com/mchehab/rasdaemon.git;branch=master;protocol=https \
            file://0001-Fix-system-header-includes.patch \
            file://rasdaemon.service \
            file://init"

--- a/meta-oe/recipes-benchmark/cpuburn/cpuburn-arm_git.bb
+++ b/meta-oe/recipes-benchmark/cpuburn/cpuburn-arm_git.bb
@@ -9,7 +9,7 @@ SRCREV = "ad7e646700d14b81413297bda02fb7fe96613c3f"
 
 PV = "1.0+git${SRCPV}"
 
-SRC_URI = "git://github.com/ssvb/cpuburn-arm.git \
+SRC_URI = "git://github.com/ssvb/cpuburn-arm.git;branch=master;protocol=https \
            file://0001-cpuburn-a8.S-Remove-.func-.endfunc.patch \
            file://0002-burn.S-Add.patch \
            file://0003-burn.S-Remove-.func-.endfunc.patch \

--- a/meta-oe/recipes-benchmark/fio/fio_3.26.bb
+++ b/meta-oe/recipes-benchmark/fio/fio_3.26.bb
@@ -23,7 +23,7 @@ PACKAGECONFIG ??= "${PACKAGECONFIG_NUMA}"
 PACKAGECONFIG[numa] = ",--disable-numa,numactl"
 
 SRCREV = "267b164c372d57145880f365bab8d8a52bf8baa7"
-SRC_URI = "git://git.kernel.dk/fio.git \
+SRC_URI = "git://git.kernel.dk/fio.git;branch=master \
 "
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-benchmark/glmark2/glmark2_git.bb
+++ b/meta-oe/recipes-benchmark/glmark2/glmark2_git.bb
@@ -14,7 +14,7 @@ DEPENDS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland-n
 PV = "2021.02+${SRCPV}"
 
 SRC_URI = " \
-    git://github.com/glmark2/glmark2.git;protocol=https \
+    git://github.com/glmark2/glmark2.git;protocol=https;branch=master \
     file://0001-fix-dispmanx-build.patch \
     file://0002-run-dispmanx-fullscreen.patch \
     "

--- a/meta-oe/recipes-benchmark/iperf3/iperf3_3.9.bb
+++ b/meta-oe/recipes-benchmark/iperf3/iperf3_3.9.bb
@@ -11,7 +11,7 @@ AUTHOR = "ESNET <info@es.net>, Lawrence Berkeley National Laboratory <websupport
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b7fb682e9941a49f1214dcd7441410d7"
 
-SRC_URI = "git://github.com/esnet/iperf.git \
+SRC_URI = "git://github.com/esnet/iperf.git;branch=master;protocol=https \
            file://0002-Remove-pg-from-profile_CFLAGS.patch \
            file://0001-configure.ac-check-for-CPP-prog.patch \
            "

--- a/meta-oe/recipes-benchmark/libc-bench/libc-bench_git.bb
+++ b/meta-oe/recipes-benchmark/libc-bench/libc-bench_git.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=9a825c63897c53f487ef900598c31527"
 SRCREV = "b6b2ce5f9f87a09b14499cb00c600c601f022634"
 PV = "20110206+git${SRCPV}"
 
-SRC_URI = "git://git.musl-libc.org/libc-bench \
+SRC_URI = "git://git.musl-libc.org/libc-bench;branch=master \
            "
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-benchmark/libhugetlbfs/libhugetlbfs_git.bb
+++ b/meta-oe/recipes-benchmark/libhugetlbfs/libhugetlbfs_git.bb
@@ -12,7 +12,7 @@ PE = "1"
 
 SRCREV = "6b126a4d7da9490fa40fe7e1b962edcb939feddc"
 SRC_URI = " \
-    git://github.com/libhugetlbfs/libhugetlbfs.git;protocol=https \
+    git://github.com/libhugetlbfs/libhugetlbfs.git;protocol=https;branch=master \
     file://skip-checking-LIB32-and-LIB64-if-they-point-to-the-s.patch \
     file://libhugetlbfs-avoid-search-host-library-path-for-cros.patch \
     file://tests-Makefile-install-static-4G-edge-testcases.patch \

--- a/meta-oe/recipes-benchmark/stressapptest/stressapptest_1.0.9.bb
+++ b/meta-oe/recipes-benchmark/stressapptest/stressapptest_1.0.9.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=55ea9d559f985fb4834317d8ed6b9e58"
 
 SRCREV = "fb72e5e5f0879231f38e0e826a98a6ca2d1ca38e"
 
-SRC_URI = "git://github.com/stressapptest/stressapptest \
+SRC_URI = "git://github.com/stressapptest/stressapptest;branch=master;protocol=https \
            file://libcplusplus-compat.patch \
            file://read_sysfs_for_cachesize.patch \
           "

--- a/meta-oe/recipes-benchmark/tinymembench/tinymembench_git.bb
+++ b/meta-oe/recipes-benchmark/tinymembench/tinymembench_git.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://main.c;endline=22;md5=879b9bbb60851454885b5fa47eb6b34
 PV = "0.4.9+git${SRCPV}"
 
 SRCREV = "a2cf6d7e382e3aea1eb39173174d9fa28cad15f3"
-SRC_URI = "git://github.com/ssvb/tinymembench.git \
+SRC_URI = "git://github.com/ssvb/tinymembench.git;branch=master;protocol=https \
            file://0001-asm-Delete-.func-.endfunc-directives.patch \
            "
 

--- a/meta-oe/recipes-bsp/con2fbmap/con2fbmap_git.bb
+++ b/meta-oe/recipes-bsp/con2fbmap/con2fbmap_git.bb
@@ -9,7 +9,7 @@ SECTION = "console/utils"
 DEPENDS = ""
 
 SRCREV = "61ed2f28b294b1ebeb767df8cb5fcd391709c8e2"
-SRC_URI = "git://gitlab.com/pibox/con2fbmap.git;protocol=https"
+SRC_URI = "git://gitlab.com/pibox/con2fbmap.git;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-bsp/cpufrequtils/cpufrequtils_008.bb
+++ b/meta-oe/recipes-bsp/cpufrequtils/cpufrequtils_008.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 SRCREV = "a2f0c39d5f21596bb9f5223e895c0ff210b265d0"
 # SRC_URI = "git://git.kernel.org/pub/scm/utils/kernel/cpufreq/cpufrequtils.git
 
-SRC_URI = "git://github.com/emagii/cpufrequtils.git \
+SRC_URI = "git://github.com/emagii/cpufrequtils.git;branch=master;protocol=https \
            file://0001-dont-unset-cflags.patch \
 "
 

--- a/meta-oe/recipes-bsp/edac-utils/edac-utils_git.bb
+++ b/meta-oe/recipes-bsp/edac-utils/edac-utils_git.bb
@@ -11,7 +11,7 @@ PV = "0.18+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 
-SRC_URI = "git://github.com/grondo/edac-utils \
+SRC_URI = "git://github.com/grondo/edac-utils;branch=master;protocol=https \
     file://make-init-script-be-able-to-automatically-load-EDAC-.patch \
     file://add-restart-to-initscript.patch \
     file://edac.service \

--- a/meta-oe/recipes-bsp/firmwared/firmwared_git.bb
+++ b/meta-oe/recipes-bsp/firmwared/firmwared_git.bb
@@ -7,7 +7,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE-APACHE;md5=7b486c2338d225a1405d979ed2c15ce8 \
                     file://COPYING;md5=daa868b8e1ae17d03228a1145b4060da"
 
-SRC_URI = "git://github.com/teg/firmwared.git \
+SRC_URI = "git://github.com/teg/firmwared.git;branch=master;protocol=https \
            file://firmwared.service"
 
 PV = "0+git${SRCPV}"

--- a/meta-oe/recipes-bsp/ledmon/ledmon_git.bb
+++ b/meta-oe/recipes-bsp/ledmon/ledmon_git.bb
@@ -16,7 +16,7 @@ inherit autotools systemd
 SYSTEMD_SERVICE_${PN} = "ledmon.service"
 
 # 0.93
-SRC_URI = "git://github.com/intel/ledmon;branch=master \
+SRC_URI = "git://github.com/intel/ledmon;branch=master;protocol=https \
            file://0002-include-sys-select.h-and-sys-types.h.patch \
            file://0001-Don-t-build-with-Werror-to-fix-compile-error.patch \
           "

--- a/meta-oe/recipes-bsp/lm_sensors/lmsensors_3.6.0.bb
+++ b/meta-oe/recipes-bsp/lm_sensors/lmsensors_3.6.0.bb
@@ -10,7 +10,7 @@ DEPENDS = " \
     virtual/libiconv \
 "
 
-SRC_URI = "git://github.com/lm-sensors/lm-sensors.git;protocol=https \
+SRC_URI = "git://github.com/lm-sensors/lm-sensors.git;protocol=https;branch=master \
            file://fancontrol.init \
            file://sensord.init \
            file://0001-Change-PIDFile-path-from-var-run-to-run.patch \

--- a/meta-oe/recipes-bsp/nvme-cli/nvme-cli_1.13.bb
+++ b/meta-oe/recipes-bsp/nvme-cli/nvme-cli_1.13.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=8264535c0c4e9c6c335635c4026a8022"
 DEPENDS = "util-linux"
 PV .= "+git${SRCPV}"
 
-SRC_URI = "git://github.com/linux-nvme/nvme-cli.git"
+SRC_URI = "git://github.com/linux-nvme/nvme-cli.git;branch=master;protocol=https"
 SRCREV = "f0e9569df9289d6ee55ba2c23615cc7c73a9b088"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-connectivity/gattlib/gattlib_git.bb
+++ b/meta-oe/recipes-connectivity/gattlib/gattlib_git.bb
@@ -9,7 +9,7 @@ DEPENDS += "glib-2.0-native"
 
 PV = "0.2+git${SRCPV}"
 
-SRC_URI = "git://github.com/labapart/gattlib.git \
+SRC_URI = "git://github.com/labapart/gattlib.git;branch=master;protocol=https \
            file://dbus-avoid-strange-chars-from-the-build-dir.patch \
            file://0001-cmake-Use-GNUInstallDirs.patch \
            "

--- a/meta-oe/recipes-connectivity/iwd/iwd_1.12.bb
+++ b/meta-oe/recipes-connectivity/iwd/iwd_1.12.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=fb504b67c50331fc78734fed90fb0e09"
 
 DEPENDS = "ell"
 
-SRC_URI = "git://git.kernel.org/pub/scm/network/wireless/iwd.git \
+SRC_URI = "git://git.kernel.org/pub/scm/network/wireless/iwd.git;branch=master \
           "
 SRCREV = "bde3e0f6e3364e9c884b6b93a944d8138345b8e5"
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-connectivity/libimobiledevice/libimobiledevice_1.3.0.bb
+++ b/meta-oe/recipes-connectivity/libimobiledevice/libimobiledevice_1.3.0.bb
@@ -9,7 +9,7 @@ HOMEPAGE = "http://www.libimobiledevice.org/"
 DEPENDS = "libplist usbmuxd libusbmuxd libtasn1 gnutls libgcrypt"
 
 SRCREV = "15f8652126664e3a4b980e5d1c039b9053ce8566"
-SRC_URI = "git://github.com/libimobiledevice/libimobiledevice;protocol=https"
+SRC_URI = "git://github.com/libimobiledevice/libimobiledevice;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"
 inherit autotools pkgconfig

--- a/meta-oe/recipes-connectivity/libndp/libndp_1.7.bb
+++ b/meta-oe/recipes-connectivity/libndp/libndp_1.7.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://libndp.org/"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "git://github.com/jpirko/libndp \
+SRC_URI = "git://github.com/jpirko/libndp;branch=master;protocol=https \
            "
 # tag for v1.6
 SRCREV = "96674e7d4f4d569c2c961e865cc16152dfab5f09"

--- a/meta-oe/recipes-connectivity/libtorrent/libtorrent_git.bb
+++ b/meta-oe/recipes-connectivity/libtorrent/libtorrent_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=393a5ca445f6965873eca0259a17f833"
 
 DEPENDS = "zlib libsigc++-2.0 openssl cppunit"
 
-SRC_URI = "git://github.com/rakshasa/libtorrent \
+SRC_URI = "git://github.com/rakshasa/libtorrent;branch=master;protocol=https \
            file://don-t-run-code-while-configuring-package.patch \
            "
 SRCREV = "756f70010779927dc0691e1e722ed433d5d295e1"

--- a/meta-oe/recipes-connectivity/paho-mqtt-c/paho-mqtt-c_1.3.8.bb
+++ b/meta-oe/recipes-connectivity/paho-mqtt-c/paho-mqtt-c_1.3.8.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = " \
     file://about.html;md5=e5662cbb5f8fd5c9faac526e4077898e \
 "
 
-SRC_URI = "git://github.com/eclipse/paho.mqtt.c;protocol=http"
+SRC_URI = "git://github.com/eclipse/paho.mqtt.c;protocol=http;branch=master;protocol=https"
 
 SRCREV = "317fb008e1541838d1c29076d2bc5c3e4b6c4f53"
 

--- a/meta-oe/recipes-connectivity/rabbitmq-c/rabbitmq-c_0.11.0.bb
+++ b/meta-oe/recipes-connectivity/rabbitmq-c/rabbitmq-c_0.11.0.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/alanxz/rabbitmq-c"
 LIC_FILES_CHKSUM = "file://LICENSE-MIT;md5=6b7424f9db80cfb11fdd5c980b583f53"
 LICENSE = "MIT"
 
-SRC_URI = "git://github.com/alanxz/rabbitmq-c.git"
+SRC_URI = "git://github.com/alanxz/rabbitmq-c.git;branch=master;protocol=https"
 # v0.11.0-master
 SRCREV = "a64c08c68aff34d49a2ac152f04988cd921084f9"
 

--- a/meta-oe/recipes-connectivity/rtorrent/rtorrent_git.bb
+++ b/meta-oe/recipes-connectivity/rtorrent/rtorrent_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 
 DEPENDS = "libsigc++-2.0 curl cppunit libtorrent ncurses"
 
-SRC_URI = "git://github.com/rakshasa/rtorrent \
+SRC_URI = "git://github.com/rakshasa/rtorrent;branch=master;protocol=https \
     file://don-t-run-code-while-configuring-package.patch \
 "
 # v0.9.8

--- a/meta-oe/recipes-connectivity/transmission/transmission_git.bb
+++ b/meta-oe/recipes-connectivity/transmission/transmission_git.bb
@@ -8,7 +8,7 @@ DEPENDS = "curl libevent gnutls openssl libtool intltool-native glib-2.0-native"
 RDEPENDS_${PN}-web = "${PN}"
 
 SRC_URI = " \
-	gitsm://github.com/transmission/transmission \
+	gitsm://github.com/transmission/transmission;branch=master;protocol=https \
 	file://transmission-daemon \
 "
 

--- a/meta-oe/recipes-connectivity/usbmuxd/usbmuxd_1.1.1.bb
+++ b/meta-oe/recipes-connectivity/usbmuxd/usbmuxd_1.1.1.bb
@@ -11,7 +11,7 @@ inherit autotools pkgconfig gitpkgv systemd
 PKGV = "${GITPKGVTAG}"
 
 SRCREV = "79c8b38d1488a6b07e1e68f39d8caec3f1a45622"
-SRC_URI = "git://github.com/libimobiledevice/usbmuxd;protocol=https"
+SRC_URI = "git://github.com/libimobiledevice/usbmuxd;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-connectivity/wifi-test-suite/wifi-test-suite_git.bb
+++ b/meta-oe/recipes-connectivity/wifi-test-suite/wifi-test-suite_git.bb
@@ -9,7 +9,7 @@ SECTION = "test"
 
 S = "${WORKDIR}/git"
 SRCREV = "2da947374c8324f88a0e2155aeba4cf75464b0d8"
-SRC_URI = "git://github.com/Wi-FiTestSuite/Wi-FiTestSuite-Linux-DUT.git \
+SRC_URI = "git://github.com/Wi-FiTestSuite/Wi-FiTestSuite-Linux-DUT.git;branch=master;protocol=https \
 	file://0001-Use-toolchain-from-environment-variables.patch \
 	file://0002-Add-missing-include-removes-unnedded-stuff-and-add-n.patch \
 	file://0003-fix-path-to-usr-sbin-for-script-and-make-script-for-.patch \

--- a/meta-oe/recipes-connectivity/zeromq/cppzmq_git.bb
+++ b/meta-oe/recipes-connectivity/zeromq/cppzmq_git.bb
@@ -7,7 +7,7 @@ DEPENDS = "zeromq"
 SRCREV = "76bf169fd67b8e99c1b0e6490029d9cd5ef97666"
 PV = "4.7.1"
 
-SRC_URI = "git://github.com/zeromq/cppzmq.git;branch=bugfix-4-7-1"
+SRC_URI = "git://github.com/zeromq/cppzmq.git;branch=bugfix-4-7-1;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-core/dbus-cxx/dbus-cxx_0.12.bb
+++ b/meta-oe/recipes-core/dbus-cxx/dbus-cxx_0.12.bb
@@ -5,7 +5,7 @@ LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4cf0188f02184e1e84b9586ac53c3f83"
 
 FILEEXTRAPATHS_prepend = "${THISDIR}/files"
-SRC_URI = "git://github.com/dbus-cxx/dbus-cxx.git;branch=master"
+SRC_URI = "git://github.com/dbus-cxx/dbus-cxx.git;branch=master;protocol=https"
 SRC_URI += "file://fix_build_musl.patch"
 SRCREV = "ea7f8e361d11dc7d41d9ae2c4128aed2cdadd84e"
 

--- a/meta-oe/recipes-core/dbus/dbus-daemon-proxy_git.bb
+++ b/meta-oe/recipes-core/dbus/dbus-daemon-proxy_git.bb
@@ -6,7 +6,7 @@ SRCREV = "1226a0a1374628ff191f6d8a56000be5e53e7608"
 PV = "0.0.0+gitr${SRCPV}"
 PR = "r1.59"
 
-SRC_URI = "git://github.com/alban/dbus-daemon-proxy \
+SRC_URI = "git://github.com/alban/dbus-daemon-proxy;branch=master;protocol=https \
            file://0001-dbus-daemon-proxy-Return-DBUS_HANDLER_RESULT_NOT_YET.patch \
            "
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-core/emlog/emlog.inc
+++ b/meta-oe/recipes-core/emlog/emlog.inc
@@ -3,7 +3,7 @@ most recent (and only the most recent) output from a process"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 
-SRC_URI = "git://github.com/nicupavel/emlog.git;protocol=http"
+SRC_URI = "git://github.com/nicupavel/emlog.git;protocol=http;branch=master;protocol=https"
 SRCREV = "aee53e8dee862f35291242ba41b0ca88010f6c71"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-core/glfw/glfw_3.3.bb
+++ b/meta-oe/recipes-core/glfw/glfw_3.3.bb
@@ -12,7 +12,7 @@ inherit pkgconfig cmake features_check
 
 PV .= "+git${SRCPV}"
 SRCREV = "781fbbadb0bccc749058177b1385c82da9ace880"
-SRC_URI = "git://github.com/glfw/glfw.git"
+SRC_URI = "git://github.com/glfw/glfw.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-core/libnfc/libnfc_git.bb
+++ b/meta-oe/recipes-core/libnfc/libnfc_git.bb
@@ -11,7 +11,7 @@ PV = "1.8.0+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 SRCREV = "f02ff51449240102c27a97173dc495e8e7789046"
-SRC_URI = "git://github.com/nfc-tools/libnfc.git"
+SRC_URI = "git://github.com/nfc-tools/libnfc.git;branch=master;protocol=https"
 
 CFLAGS_append_libc-musl = " -D_GNU_SOURCE"
 DEPENDS = "libusb"

--- a/meta-oe/recipes-core/mdbus2/mdbus2_git.bb
+++ b/meta-oe/recipes-core/mdbus2/mdbus2_git.bb
@@ -6,7 +6,7 @@ DEPENDS = "readline"
 
 PV = "2.3.3+git${SRCPV}"
 
-SRC_URI = "git://github.com/freesmartphone/mdbus.git;protocol=http \
+SRC_URI = "git://github.com/freesmartphone/mdbus.git;protocol=http;branch=master;protocol=https \
            file://0001-Fix-arguments-in-GLib.DBusSignalCallback-for-Vala-0..patch \
            "
 SRCREV = "28202692d0b441000f4ddb8f347f72d1355021aa"

--- a/meta-oe/recipes-core/musl-rpmatch/musl-rpmatch_git.bb
+++ b/meta-oe/recipes-core/musl-rpmatch/musl-rpmatch_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "Implementation of rpmatch(3) for musl libc."
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=81a81bf31abecc50c20862fc8a716329"
 
-SRC_URI = "gitsm://github.com/pullmoll/musl-rpmatch.git;protocol=https"
+SRC_URI = "gitsm://github.com/pullmoll/musl-rpmatch.git;protocol=https;branch=master"
 
 PV = "1.0+git${SRCPV}"
 SRCREV = "46267b154987d3e1f25d3a75423faa62bb5ee342"

--- a/meta-oe/recipes-core/ndctl/ndctl_v69.bb
+++ b/meta-oe/recipes-core/ndctl/ndctl_v69.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=e66651809cac5da60c8b80e9e4e79e08"
 inherit autotools-brokensep pkgconfig bash-completion systemd
 
 SRCREV = "ea62d6d53bf6f806c4841e97a370201e18446860"
-SRC_URI = "git://github.com/pmem/ndctl.git"
+SRC_URI = "git://github.com/pmem/ndctl.git;branch=master;protocol=https"
 
 DEPENDS = "kmod udev json-c keyutils"
 

--- a/meta-oe/recipes-core/opencl/ocl-icd_2.3.0.bb
+++ b/meta-oe/recipes-core/opencl/ocl-icd_2.3.0.bb
@@ -5,7 +5,7 @@ DESCRIPTION = "Open Source alternative to vendor specific OpenCL ICD loaders."
 LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=1238d5bccbb6bda30654e48dcc0a554b"
 
-SRC_URI = "git://github.com/OCL-dev/ocl-icd.git;protocol=https"
+SRC_URI = "git://github.com/OCL-dev/ocl-icd.git;protocol=https;branch=master"
 
 SRCREV = "59c098b6b1f97a339e3e5308499aee6538ecea40"
 

--- a/meta-oe/recipes-core/opencl/opencl-clhpp_git.bb
+++ b/meta-oe/recipes-core/opencl/opencl-clhpp_git.bb
@@ -1,7 +1,7 @@
 SUMMARY  = "OpenCL API C++ bindings"
 DESCRIPTION = "OpenCL API C++ bindings from Khronos"
 
-SRC_URI = "git://github.com/KhronosGroup/OpenCL-CLHPP.git;protocol=https"
+SRC_URI = "git://github.com/KhronosGroup/OpenCL-CLHPP.git;protocol=https;branch=master"
 
 LICENSE  = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"

--- a/meta-oe/recipes-core/opencl/opencl-headers_git.bb
+++ b/meta-oe/recipes-core/opencl/opencl-headers_git.bb
@@ -7,7 +7,7 @@ SECTION = "base"
 S = "${WORKDIR}/git"
 # v2020.12.18
 SRCREV = "c57ba81c460ee97b6b9d0b8d18faf5ba6883114b"
-SRC_URI = "git://github.com/KhronosGroup/OpenCL-Headers.git"
+SRC_URI = "git://github.com/KhronosGroup/OpenCL-Headers.git;branch=master;protocol=https"
 
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"

--- a/meta-oe/recipes-core/opencl/opencl-icd-loader_git.bb
+++ b/meta-oe/recipes-core/opencl/opencl-icd-loader_git.bb
@@ -11,7 +11,7 @@ inherit pkgconfig cmake
 S = "${WORKDIR}/git"
 PV = "2020.12.18+git${SRCPV}"
 SRCREV = "1d5315c3ed30d026acb79a1aa53a276fc833ffa7"
-SRC_URI = "git://github.com/KhronosGroup/OpenCL-ICD-Loader.git"
+SRC_URI = "git://github.com/KhronosGroup/OpenCL-ICD-Loader.git;branch=master;protocol=https"
 
 do_install () {
 	install -d ${D}${bindir}

--- a/meta-oe/recipes-core/safec/safec_3.5.1.bb
+++ b/meta-oe/recipes-core/safec/safec_3.5.1.bb
@@ -9,7 +9,7 @@ inherit autotools pkgconfig
 S = "${WORKDIR}/git"
 # v08112019
 SRCREV = "ad76c7b1dbd0403b0c9decf54164fcce271c590f"
-SRC_URI = "git://github.com/rurban/safeclib.git \
+SRC_URI = "git://github.com/rurban/safeclib.git;branch=master;protocol=https \
 "
 
 COMPATIBLE_HOST = '(x86_64|i.86|powerpc|powerpc64|arm|aarch64|mips).*-linux'

--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd_243.bb
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd_243.bb
@@ -12,7 +12,7 @@ DEPENDS += "gperf-native gettext-native util-linux libcap"
 
 SRCREV = "efb536d0cbe2e58f80e501d19999928c75e08f6a"
 SRCBRANCH = "v243-stable"
-SRC_URI = "git://github.com/systemd/systemd-stable.git;protocol=git;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/systemd/systemd-stable.git;protocol=https;branch=${SRCBRANCH}"
 
 SRC_URI += "file://static-libsystemd-pkgconfig.patch"
 

--- a/meta-oe/recipes-crypto/fsverity-utils/fsverity-utils_1.3.bb
+++ b/meta-oe/recipes-crypto/fsverity-utils/fsverity-utils_1.3.bb
@@ -10,7 +10,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=bc974d217b525ea216a336adb73e1220"
 
 SRCREV = "a92b1a54b003879322c044adf0ae3ea3e95e7348"
-SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/ebiggers/fsverity-utils.git"
+SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/ebiggers/fsverity-utils.git;branch=master"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-crypto/libkcapi/libkcapi_1.2.1.bb
+++ b/meta-oe/recipes-crypto/libkcapi/libkcapi_1.2.1.bb
@@ -7,7 +7,7 @@ DEPENDS = "libtool"
 
 S = "${WORKDIR}/git"
 SRCREV = "d41284525ec8960e9a828979cfe269012b7df8db"
-SRC_URI = "git://github.com/smuellerDD/libkcapi.git \
+SRC_URI = "git://github.com/smuellerDD/libkcapi.git;branch=master;protocol=https \
            file://0001-Disable-use-of-__NR_io_getevents-when-not-defined.patch \
            "
 

--- a/meta-oe/recipes-crypto/pkcs11-helper/pkcs11-helper_1.27.bb
+++ b/meta-oe/recipes-crypto/pkcs11-helper/pkcs11-helper_1.27.bb
@@ -15,7 +15,7 @@ LIC_FILES_CHKSUM = " \
     file://COPYING.GPL;md5=8a71d0475d08eee76d8b6d0c6dbec543 \
     file://COPYING.BSD;md5=66b7a37c3c10483c1fd86007726104d7 \
 "
-SRC_URI = "git://github.com/OpenSC/${BPN}.git"
+SRC_URI = "git://github.com/OpenSC/${BPN}.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 # v1.27

--- a/meta-oe/recipes-dbs/leveldb/leveldb_1.22.bb
+++ b/meta-oe/recipes-dbs/leveldb/leveldb_1.22.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/google/leveldb"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=92d1b128950b11ba8495b64938fc164d"
 
-SRC_URI = "git://github.com/google/${BPN}.git \
+SRC_URI = "git://github.com/google/${BPN}.git;branch=master;protocol=https \
            file://run-ptest"
 
 SRCREV = "78b39d68c15ba020c0d60a3906fb66dbf1697595"

--- a/meta-oe/recipes-dbs/rocksdb/rocksdb_6.15.5.bb
+++ b/meta-oe/recipes-dbs/rocksdb/rocksdb_6.15.5.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.Apache;md5=3b83ef96387f14655fc854ddc3c6bd57 \
 SRCREV = "abd4b1ff1504ae2a7ed6e60bc9c9797b880c33a5"
 SRCBRANCH = "6.15.fb"
 
-SRC_URI = "git://github.com/facebook/${BPN}.git;branch=${SRCBRANCH} \
+SRC_URI = "git://github.com/facebook/${BPN}.git;branch=${SRCBRANCH};protocol=https \
            file://0001-cmake-Add-check-for-atomic-support.patch \
            file://0001-cmake-Use-exported-target-for-bz2.patch \
            file://0001-folly-Use-SYS_futex-for-syscall.patch \

--- a/meta-oe/recipes-devtools/abseil-cpp/abseil-cpp_git.bb
+++ b/meta-oe/recipes-devtools/abseil-cpp/abseil-cpp_git.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=df52c6edb7adc22e533b2bacc3bd3915"
 PV = "20200923+git${SRCPV}"
 SRCREV = "6f9d96a1f41439ac172ee2ef7ccd8edf0e5d068c"
 BRANCH = "lts_2020_09_23"
-SRC_URI = "git://github.com/abseil/abseil-cpp;branch=${BRANCH}         \
+SRC_URI = "git://github.com/abseil/abseil-cpp;branch=${BRANCH};protocol=https \
            file://0001-absl-always-use-asm-sgidefs.h.patch             \
            file://0002-Remove-maes-option-from-cross-compilation.patch \
            file://abseil-ppc-fixes.patch \

--- a/meta-oe/recipes-devtools/apitrace/apitrace_9.0.bb
+++ b/meta-oe/recipes-devtools/apitrace/apitrace_9.0.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=aeb969185a143c3c25130bc2c3ef9a50 \
                     file://thirdparty/snappy/COPYING;md5=f62f3080324a97b3159a7a7e61812d0c"
 
 SRCREV = "cae55f54c53449fd07f8a917dcd0874db2c15032"
-SRC_URI = "git://github.com/${BPN}/${BPN}.git"
+SRC_URI = "git://github.com/${BPN}/${BPN}.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-devtools/boost-url/boost-url_git.bb
+++ b/meta-oe/recipes-devtools/boost-url/boost-url_git.bb
@@ -4,7 +4,7 @@ SECTION = "libs"
 LICENSE = "BSL-1.0"
 LIC_FILES_CHKSUM = "file://LICENSE_1_0.txt;md5=e4224ccaecb14d942c71d31bef20d78c"
 
-SRC_URI = "git://github.com/CPPAlliance/url.git;branch=develop"
+SRC_URI = "git://github.com/CPPAlliance/url.git;branch=develop;protocol=https"
 
 SRCREV = "2c867fbe284ae532f1329b87a86ad3f8cd382867"
 

--- a/meta-oe/recipes-devtools/bootchart/bootchart_git.bb
+++ b/meta-oe/recipes-devtools/bootchart/bootchart_git.bb
@@ -8,7 +8,7 @@ PV = "1.17"
 PR = "r1"
 PE = "1"
 
-SRC_URI = "git://gitorious.org/meego-developer-tools/bootchart.git;protocol=https \
+SRC_URI = "git://gitorious.org/meego-developer-tools/bootchart.git;protocol=https;branch=master \
            file://0001-svg-add-rudimentary-support-for-ARM-cpuinfo.patch \
            file://0002-svg-open-etc-os-release-and-use-PRETTY_NAME-for-the-.patch \
 "

--- a/meta-oe/recipes-devtools/breakpad/breakpad_git.bb
+++ b/meta-oe/recipes-devtools/breakpad/breakpad_git.bb
@@ -28,11 +28,11 @@ SRCREV_protobuf = "cb6dd4ef5f82e41e06179dcd57d3b1d9246ad6ac"
 SRCREV_lss = "fd00dbbd0c06a309c657d89e9430143b179ff6db"
 SRCREV_gyp = "324dd166b7c0b39d513026fa52d6280ac6d56770"
 
-SRC_URI = "git://github.com/google/breakpad;name=breakpad;branch=main \
-           git://github.com/google/googletest.git;destsuffix=git/src/testing/gtest;name=gtest \
-           git://github.com/protocolbuffers/protobuf.git;destsuffix=git/src/third_party/protobuf/protobuf;name=protobuf \
+SRC_URI = "git://github.com/google/breakpad;name=breakpad;branch=main;protocol=https \
+           git://github.com/google/googletest.git;destsuffix=git/src/testing/gtest;name=gtest;branch=master;protocol=https \
+           git://github.com/protocolbuffers/protobuf.git;destsuffix=git/src/third_party/protobuf/protobuf;name=protobuf;branch=master;protocol=https \
            git://chromium.googlesource.com/linux-syscall-support;protocol=https;branch=main;destsuffix=git/src/third_party/lss;name=lss \
-           git://chromium.googlesource.com/external/gyp;protocol=https;destsuffix=git/src/tools/gyp;name=gyp \
+           git://chromium.googlesource.com/external/gyp;protocol=https;destsuffix=git/src/tools/gyp;name=gyp;branch=master \
            file://0001-include-sys-reg.h-to-get-__WORDSIZE-on-musl-libc.patch \
            file://0003-Fix-conflict-between-musl-libc-dirent.h-and-lss.patch \
            file://0001-Turn-off-sign-compare-for-musl-libc.patch \

--- a/meta-oe/recipes-devtools/capnproto/capnproto_0.8.0.bb
+++ b/meta-oe/recipes-devtools/capnproto/capnproto_0.8.0.bb
@@ -5,7 +5,7 @@ SECTION = "console/tools"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://../LICENSE;md5=a05663ae6cca874123bf667a60dca8c9"
 
-SRC_URI = "git://github.com/sandstorm-io/capnproto.git;branch=release-${PV} \
+SRC_URI = "git://github.com/sandstorm-io/capnproto.git;branch=release-${PV};protocol=https \
            file://0001-mutex-Fix-build-on-32-bit-architectures-using-64-bit.patch;patchdir=../ \
            "
 SRCREV = "57a4ca5af5a7f55b768a9d9d6655250bffb1257f"

--- a/meta-oe/recipes-devtools/cjson/cjson_1.7.15.bb
+++ b/meta-oe/recipes-devtools/cjson/cjson_1.7.15.bb
@@ -5,7 +5,7 @@ SECTION = "libs"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=218947f77e8cb8e2fa02918dc41c50d0"
 
-SRC_URI = "git://github.com/DaveGamble/cJSON.git"
+SRC_URI = "git://github.com/DaveGamble/cJSON.git;branch=master;protocol=https"
 SRCREV = "d348621ca93571343a56862df7de4ff3bc9b5667"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-devtools/concurrencykit/concurrencykit_git.bb
+++ b/meta-oe/recipes-devtools/concurrencykit/concurrencykit_git.bb
@@ -10,7 +10,7 @@ SECTION = "base"
 PV = "0.5.1+git${SRCPV}"
 SRCREV = "f97d3da5c375ac2fc5a9173cdd36cb828915a2e1"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=a0b24c1a8f9ad516a297d055b0294231"
-SRC_URI = "git://github.com/concurrencykit/ck.git \
+SRC_URI = "git://github.com/concurrencykit/ck.git;branch=master;protocol=https \
            file://cross.patch \
 "
 

--- a/meta-oe/recipes-devtools/dnf-plugin-tui/dnf-plugin-tui_git.bb
+++ b/meta-oe/recipes-devtools/dnf-plugin-tui/dnf-plugin-tui_git.bb
@@ -3,7 +3,7 @@ LICENSE = "GPLv2"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/ubinux/dnf-plugin-tui.git;branch=master "
+SRC_URI = "git://github.com/ubinux/dnf-plugin-tui.git;branch=master;protocol=https"
 SRCREV = "6d3fab9b9559b6a483fe668e39c29126cdbb58d8"
 PV = "1.2"
 

--- a/meta-oe/recipes-devtools/exprtk/exprtk_git.bb
+++ b/meta-oe/recipes-devtools/exprtk/exprtk_git.bb
@@ -5,7 +5,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 SRCREV = "281c2ccc65b8f91c012ea3725ebcef406378a225"
 
-SRC_URI = "git://github.com/ArashPartow/exprtk.git"
+SRC_URI = "git://github.com/ArashPartow/exprtk.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-devtools/flatbuffers/flatbuffers_1.12.0.bb
+++ b/meta-oe/recipes-devtools/flatbuffers/flatbuffers_1.12.0.bb
@@ -15,7 +15,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 SRCREV = "6df40a2471737b27271bdd9b900ab5f3aec746c7"
 
-SRC_URI = "git://github.com/google/flatbuffers.git"
+SRC_URI = "git://github.com/google/flatbuffers.git;branch=master;protocol=https"
 
 CVE_CHECK_WHITELIST += "CVE-2020-35864"
 

--- a/meta-oe/recipes-devtools/guider/guider_3.9.8.bb
+++ b/meta-oe/recipes-devtools/guider/guider_3.9.8.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=2c1c00f9d3ed9e24fa69b932b7e7aff2"
 
 PV = "3.9.8+git${SRCPV}"
 
-SRC_URI = "git://github.com/iipeace/${BPN}"
+SRC_URI = "git://github.com/iipeace/${BPN};branch=master;protocol=https"
 SRCREV = "a502cd93b13235b7539557a91328de00b7c51bc3"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-devtools/heaptrack/heaptrack_1.2.0.bb
+++ b/meta-oe/recipes-devtools/heaptrack/heaptrack_1.2.0.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 DEPENDS = "zlib boost libunwind elfutils"
 
-SRC_URI = "git://github.com/KDE/heaptrack.git;protocol=https \
+SRC_URI = "git://github.com/KDE/heaptrack.git;protocol=https;branch=master \
            file://0001-libheaptrack-Replace-__pid_t-with-pid_t.patch \
            file://0002-heaptrack_inject-Include-dlfcn.h-for-dlopen-dlclose.patch \
            file://0003-heaptrack_preload-Make-noexcept-attribute-conditiona.patch \

--- a/meta-oe/recipes-devtools/json-schema-validator/json-schema-validator_2.1.0.bb
+++ b/meta-oe/recipes-devtools/json-schema-validator/json-schema-validator_2.1.0.bb
@@ -2,7 +2,7 @@ SUMMARY = "JSON schema validator for JSON for Modern C++"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c441d022da1b1663c70181a32225d006"
 
-SRC_URI = "git://github.com/pboettch/json-schema-validator"
+SRC_URI = "git://github.com/pboettch/json-schema-validator;branch=master;protocol=https"
 SRCREV = "27fc1d094503623dfe39365ba82581507524545c"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-devtools/jsoncpp/jsoncpp_1.9.4.bb
+++ b/meta-oe/recipes-devtools/jsoncpp/jsoncpp_1.9.4.bb
@@ -14,7 +14,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=fa2a23dd1dc6c139f35105379d76df2b"
 PE = "1"
 
 SRCREV = "9059f5cad030ba11d37818847443a53918c327b1"
-SRC_URI = "git://github.com/open-source-parsers/jsoncpp"
+SRC_URI = "git://github.com/open-source-parsers/jsoncpp;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-devtools/jsonrpc/jsonrpc_1.3.0.bb
+++ b/meta-oe/recipes-devtools/jsonrpc/jsonrpc_1.3.0.bb
@@ -9,7 +9,7 @@ SECTION = "libs"
 
 DEPENDS = "curl jsoncpp libmicrohttpd hiredis"
 
-SRC_URI = "git://github.com/cinemast/libjson-rpc-cpp \
+SRC_URI = "git://github.com/cinemast/libjson-rpc-cpp;branch=master;protocol=https \
 	   file://0001-Fix-build-with-libmicrohttpd.patch \
 "
 

--- a/meta-oe/recipes-devtools/lapack/lapack_3.9.0.bb
+++ b/meta-oe/recipes-devtools/lapack/lapack_3.9.0.bb
@@ -14,7 +14,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=930f8aa500a47c7dab0f8efb5a1c9a40"
 DEPENDS = "libgfortran"
 
 SRCREV = "6acc99d5f39130be7cec00fb835606042101a970"
-SRC_URI = "git://github.com/Reference-LAPACK/lapack.git;protocol=https"
+SRC_URI = "git://github.com/Reference-LAPACK/lapack.git;protocol=https;branch=master"
 S = "${WORKDIR}/git"
 
 EXTRA_OECMAKE = " -DBUILD_SHARED_LIBS=ON "

--- a/meta-oe/recipes-devtools/libsombok3/libsombok3_2.4.0.bb
+++ b/meta-oe/recipes-devtools/libsombok3/libsombok3_2.4.0.bb
@@ -7,7 +7,7 @@ Cluster segmentation described in Annex #29 (UAX #29)."
 LICENSE = "Artistic-1.0 | GPLv1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=5b122a36d0f6dc55279a0ebc69f3c60b"
 
-SRC_URI = "git://github.com/hatukanezumi/sombok.git;protocol=https \
+SRC_URI = "git://github.com/hatukanezumi/sombok.git;protocol=https;branch=master \
            file://0001-configure.ac-fix-cross-compiling-issue.patch \
           "
 

--- a/meta-oe/recipes-devtools/libubox/libubox_git.bb
+++ b/meta-oe/recipes-devtools/libubox/libubox_git.bb
@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = "\
 "
 
 SRC_URI = "\
-    git://git.openwrt.org/project/libubox.git \
+    git://git.openwrt.org/project/libubox.git;branch=master \
     file://0001-version-libraries.patch \
     file://fix-libdir.patch \
     file://0001-blobmsg-fix-array-out-of-bounds-GCC-10-warning.patch \

--- a/meta-oe/recipes-devtools/ltrace/ltrace_git.bb
+++ b/meta-oe/recipes-devtools/ltrace/ltrace_git.bb
@@ -14,7 +14,7 @@ PV = "7.91+git${SRCPV}"
 SRCREV = "c22d359433b333937ee3d803450dc41998115685"
 
 DEPENDS = "elfutils"
-SRC_URI = "git://github.com/sparkleholic/ltrace.git;branch=master;protocol=http \
+SRC_URI = "git://github.com/sparkleholic/ltrace.git;branch=master;protocol=http;protocol=https \
            file://configure-allow-to-disable-selinux-support.patch \
            file://0001-replace-readdir_r-with-readdir.patch \
            file://0001-Use-correct-enum-type.patch \

--- a/meta-oe/recipes-devtools/luaposix/luaposix_33.4.0.bb
+++ b/meta-oe/recipes-devtools/luaposix/luaposix_33.4.0.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=7dd2aad04bb7ca212e69127ba8d58f9f"
 
 DEPENDS += "lua-native lua"
 
-SRC_URI = "git://github.com/luaposix/luaposix.git;branch=release \
+SRC_URI = "git://github.com/luaposix/luaposix.git;branch=release;protocol=https \
            file://0001-fix-avoid-race-condition-between-test-and-mkdir.patch \
 "
 SRCREV = "8e4902ed81c922ed8f76a7ed85be1eaa3fd7e66d"

--- a/meta-oe/recipes-devtools/msgpack/msgpack-c_3.2.1.bb
+++ b/meta-oe/recipes-devtools/msgpack/msgpack-c_3.2.1.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://NOTICE;md5=7a858c074723608e08614061dc044352 \
 
 PV .= "+git${SRCPV}"
 
-SRC_URI = "git://github.com/msgpack/msgpack-c \
+SRC_URI = "git://github.com/msgpack/msgpack-c;branch=master;protocol=https \
            "
 # cpp-3.2.1
 SRCREV = "8085ab8721090a447cf98bb802d1406ad7afe420"

--- a/meta-oe/recipes-devtools/musl/musl-nscd_git.bb
+++ b/meta-oe/recipes-devtools/musl/musl-nscd_git.bb
@@ -12,7 +12,7 @@ DEPENDS += "flex-native bison-native flex bison"
 PV = "1.0.2"
 
 SRCREV = "af581482a3e1059458f3c8b20a56f82807ca3bd4"
-SRC_URI = "git://github.com/pikhq/musl-nscd \
+SRC_URI = "git://github.com/pikhq/musl-nscd;branch=master;protocol=https \
            file://0001-Fix-build-under-GCC-fno-common.patch \
            file://0001-configure-Check-for-flex-if-lex-is-not-found.patch \
            file://0001-nsswitch.y-Replace-empty-bison-extension.patch \

--- a/meta-oe/recipes-devtools/nlohmann-fifo/nlohmann-fifo_git.bb
+++ b/meta-oe/recipes-devtools/nlohmann-fifo/nlohmann-fifo_git.bb
@@ -4,7 +4,7 @@ SECTION = "libs"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.MIT;md5=b67209a1e36b682a8226de19d265b1e0"
 
-SRC_URI = "git://github.com/nlohmann/fifo_map.git"
+SRC_URI = "git://github.com/nlohmann/fifo_map.git;branch=master;protocol=https"
 
 PV = "1.0.0+git${SRCPV}"
 

--- a/meta-oe/recipes-devtools/nlohmann-json/nlohmann-json_3.9.1.bb
+++ b/meta-oe/recipes-devtools/nlohmann-json/nlohmann-json_3.9.1.bb
@@ -4,7 +4,7 @@ SECTION = "libs"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.MIT;md5=dd0607f896f392c8b7d0290a676efc24"
 
-SRC_URI = "git://github.com/nlohmann/json.git;nobranch=1 \
+SRC_URI = "git://github.com/nlohmann/json.git;nobranch=1;protocol=https \
            "
 
 SRCREV = "db78ac1d7716f56fc9f1b030b715f872f93964e4"

--- a/meta-oe/recipes-devtools/openocd/openocd_git.bb
+++ b/meta-oe/recipes-devtools/openocd/openocd_git.bb
@@ -5,10 +5,10 @@ DEPENDS = "libusb-compat libftdi"
 RDEPENDS_${PN} = "libusb1"
 
 SRC_URI = " \
-    git://repo.or.cz/openocd.git;protocol=http;name=openocd \
-    git://repo.or.cz/r/git2cl.git;protocol=http;destsuffix=tools/git2cl;name=git2cl \
-    git://repo.or.cz/r/jimtcl.git;protocol=http;destsuffix=git/jimtcl;name=jimtcl \
-    git://repo.or.cz/r/libjaylink.git;protocol=http;destsuffix=git/src/jtag/drivers/libjaylink;name=libjaylink \
+    git://repo.or.cz/openocd.git;protocol=http;name=openocd;branch=master \
+    git://repo.or.cz/r/git2cl.git;protocol=http;destsuffix=tools/git2cl;name=git2cl;branch=master \
+    git://repo.or.cz/r/jimtcl.git;protocol=http;destsuffix=git/jimtcl;name=jimtcl;branch=master \
+    git://repo.or.cz/r/libjaylink.git;protocol=http;destsuffix=git/src/jtag/drivers/libjaylink;name=libjaylink;branch=master \
 "
 
 SRCREV_FORMAT = "openocd"

--- a/meta-oe/recipes-devtools/pcimem/pcimem_2.0.bb
+++ b/meta-oe/recipes-devtools/pcimem/pcimem_2.0.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 COMPATIBLE_HOST = "(x86_64|aarch64|arm)"
 
 SRCREV = "09724edb1783a98da2b7ae53c5aaa87493aabc9b"
-SRC_URI = "git://github.com/billfarrow/pcimem.git "
+SRC_URI = "git://github.com/billfarrow/pcimem.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-devtools/perl/ipc-run_20200505.0.bb
+++ b/meta-oe/recipes-devtools/perl/ipc-run_20200505.0.bb
@@ -9,7 +9,7 @@ LICENSE = "Artistic-1.0 | GPL-1.0+"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=0ebd37caf53781e8b7223e6b99b63f4e"
 DEPENDS = "perl"
 
-SRC_URI = "git://github.com/toddr/IPC-Run.git"
+SRC_URI = "git://github.com/toddr/IPC-Run.git;branch=master;protocol=https"
 SRCREV = "af435a1635ef9e48a84adc3230099e7ecf20c79d"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-devtools/perl/libdbd-mysql-perl_4.050.bb
+++ b/meta-oe/recipes-devtools/perl/libdbd-mysql-perl_4.050.bb
@@ -15,7 +15,7 @@ DEPENDS += "libdev-checklib-perl-native libdbi-perl-native libmysqlclient"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d0a06964340e5c0cde88b7af611f755c"
 
 SRCREV = "9b5b70ea372f49fe9bc9e592dae3870596d1e3d6"
-SRC_URI = "git://github.com/perl5-dbi/DBD-mysql.git;protocol=https"
+SRC_URI = "git://github.com/perl5-dbi/DBD-mysql.git;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-devtools/perl/libjson-perl_4.03000.bb
+++ b/meta-oe/recipes-devtools/perl/libjson-perl_4.03000.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://README;beginline=1171;endline=1176;md5=3be2cb8159d094
 
 DEPENDS += "perl"
 
-SRC_URI = "git://github.com/makamaka/JSON.git;protocol=https"
+SRC_URI = "git://github.com/makamaka/JSON.git;protocol=https;branch=master"
 
 SRCREV = "ebbae181c5e311fa80ee4c6379b598c7a6400570"
 

--- a/meta-oe/recipes-devtools/ply/ply_git.bb
+++ b/meta-oe/recipes-devtools/ply/ply_git.bb
@@ -7,7 +7,7 @@ DEPENDS += "bison-native"
 
 PV = "2.1.1+git${SRCPV}"
 
-SRC_URI = "git://github.com/iovisor/ply"
+SRC_URI = "git://github.com/iovisor/ply;branch=master;protocol=https"
 SRCREV = "e25c9134b856cc7ffe9f562ff95caf9487d16b59"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-devtools/pmtools/pmtools_git.bb
+++ b/meta-oe/recipes-devtools/pmtools/pmtools_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=0636e73ff0215e8d672dc4c32c317bb3"
 
 PV = "20130209+git${SRCPV}"
 
-SRC_URI = "git://github.com/anyc/pmtools.git \
+SRC_URI = "git://github.com/anyc/pmtools.git;branch=master;protocol=https \
     file://pmtools-switch-to-dynamic-buffer-for-huge-ACPI-table.patch \
 "
 SRCREV = "3ebe0e54c54061b4c627236cbe35d820de2e1168"

--- a/meta-oe/recipes-devtools/protobuf/protobuf-c_1.3.3.bb
+++ b/meta-oe/recipes-devtools/protobuf/protobuf-c_1.3.3.bb
@@ -14,7 +14,7 @@ DEPENDS = "protobuf-native protobuf"
 
 SRCREV = "f20a3fa131c275a0e795d99a28f94b4dbbb5af26"
 
-SRC_URI = "git://github.com/protobuf-c/protobuf-c.git \
+SRC_URI = "git://github.com/protobuf-c/protobuf-c.git;branch=master;protocol=https \
            file://0001-avoid-race-condition.patch \
           "
 

--- a/meta-oe/recipes-devtools/protobuf/protobuf_3.15.2.bb
+++ b/meta-oe/recipes-devtools/protobuf/protobuf_3.15.2.bb
@@ -12,7 +12,7 @@ DEPENDS_append_class-target = " protobuf-native"
 
 SRCREV = "d7e943b8d2bc444a8c770644e73d090b486f8b37"
 
-SRC_URI = "git://github.com/protocolbuffers/protobuf.git \
+SRC_URI = "git://github.com/protocolbuffers/protobuf.git;branch=master;protocol=https \
            file://run-ptest \
            file://0001-protobuf-fix-configure-error.patch \
            file://0001-Makefile.am-include-descriptor.cc-when-building-libp.patch \

--- a/meta-oe/recipes-devtools/rapidjson/rapidjson_git.bb
+++ b/meta-oe/recipes-devtools/rapidjson/rapidjson_git.bb
@@ -4,7 +4,7 @@ SECTION = "libs"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://license.txt;md5=ba04aa8f65de1396a7e59d1d746c2125"
 
-SRC_URI = "git://github.com/miloyip/rapidjson.git;nobranch=1"
+SRC_URI = "git://github.com/miloyip/rapidjson.git;nobranch=1;protocol=https"
 
 SRCREV = "0ccdbf364c577803e2a751f5aededce935314313"
 

--- a/meta-oe/recipes-devtools/serialcheck/serialcheck_1.0.0.bb
+++ b/meta-oe/recipes-devtools/serialcheck/serialcheck_1.0.0.bb
@@ -4,7 +4,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRC_URI = " \
-    git://github.com/nsekhar/serialcheck.git \
+    git://github.com/nsekhar/serialcheck.git;branch=master;protocol=https \
 "
 
 SRCREV = "45eb2ffa5378396e85432872833890b0a1cba872"

--- a/meta-oe/recipes-devtools/sqlite-orm/sqlite-orm_1.5.bb
+++ b/meta-oe/recipes-devtools/sqlite-orm/sqlite-orm_1.5.bb
@@ -8,7 +8,7 @@ inherit cmake
 DEPENDS += "sqlite3"
 
 SRCREV = "e8a9e9416f421303f4b8970caab26dadf8bae98b"
-SRC_URI = "git://github.com/fnc12/sqlite_orm;protocol=https"
+SRC_URI = "git://github.com/fnc12/sqlite_orm;protocol=https;branch=master"
 S = "${WORKDIR}/git"
 
 EXTRA_OECMAKE += "-DSqliteOrm_BuildTests=OFF"

--- a/meta-oe/recipes-devtools/squashfs-tools-ng/squashfs-tools-ng_1.0.2.bb
+++ b/meta-oe/recipes-devtools/squashfs-tools-ng/squashfs-tools-ng_1.0.2.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://COPYING.md;md5=c0de2c0aca56349dab98e97992316f7e \
                     file://licenses/zstd.txt;md5=8df8137b630239cbdd4c0674124cb0c8"
 
 SRCREV = "b96f0fc154feef531be76034bf6e38925636146f"
-SRC_URI = "git://github.com/AgentD/squashfs-tools-ng.git;protocol=https"
+SRC_URI = "git://github.com/AgentD/squashfs-tools-ng.git;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-devtools/suitesparse/suitesparse_5.8.1.bb
+++ b/meta-oe/recipes-devtools/suitesparse/suitesparse_5.8.1.bb
@@ -1,6 +1,6 @@
 LICENSE = "GPLv2 & GPLv3 & BSD-3-Clause & LGPL-2.0 & Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=f9f2b9d61cb769a67c4cd079e1166de7"
-SRC_URI = "git://github.com/DrTimothyAldenDavis/SuiteSparse;protocol=https \
+SRC_URI = "git://github.com/DrTimothyAldenDavis/SuiteSparse;protocol=https;branch=master \
            file://0001-Preserve-CXXFLAGS-from-environment-in-Mongoose.patch \
            file://0002-Preserve-links-when-installing-libmetis.patch \
            file://0003-Add-version-information-to-libmetis.patch \

--- a/meta-oe/recipes-devtools/uftrace/uftrace_0.9.4.bb
+++ b/meta-oe/recipes-devtools/uftrace/uftrace_0.9.4.bb
@@ -12,7 +12,7 @@ inherit autotools
 
 PV .= "+git${SRCPV}"
 SRCREV = "d648bbffedef529220896283fb59e35531c13804"
-SRC_URI = "git://github.com/namhyung/${BPN} \
+SRC_URI = "git://github.com/namhyung/${BPN};branch=master;protocol=https \
            file://0001-aarch64-Fix-a-plthook-crash-on-aarch64-with-binutils.patch \
            "
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-devtools/xmlrpc-c/xmlrpc-c_1.54.02.bb
+++ b/meta-oe/recipes-devtools/xmlrpc-c/xmlrpc-c_1.54.02.bb
@@ -5,7 +5,7 @@ HOMEPAGE = "http://xmlrpc-c.sourceforge.net/"
 LICENSE = "BSD & MIT"
 LIC_FILES_CHKSUM = "file://doc/COPYING;md5=aefbf81ba0750f02176b6f86752ea951"
 
-SRC_URI = "git://github.com/mirror/xmlrpc-c.git \
+SRC_URI = "git://github.com/mirror/xmlrpc-c.git;branch=master;protocol=https \
            file://0001-test-cpp-server_abyss-Fix-build-with-clang-libc.patch \
            file://0002-fix-formatting-issues.patch \
            file://0003-src-Makefile-Fix-Makefile-macro-error.patch \

--- a/meta-oe/recipes-devtools/yajl/yajl_1.0.12.bb
+++ b/meta-oe/recipes-devtools/yajl/yajl_1.0.12.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=da2e9aa80962d54e7c726f232a2bd1e8"
 
 # Use 1.0.12 tag
 SRCREV = "17b1790fb9c8abbb3c0f7e083864a6a014191d56"
-SRC_URI = "git://github.com/lloyd/yajl;nobranch=1"
+SRC_URI = "git://github.com/lloyd/yajl;nobranch=1;protocol=https"
 
 inherit cmake lib_package
 

--- a/meta-oe/recipes-devtools/yajl/yajl_2.1.0.bb
+++ b/meta-oe/recipes-devtools/yajl/yajl_2.1.0.bb
@@ -8,7 +8,7 @@ HOMEPAGE = "http://lloyd.github.com/yajl/"
 LICENSE = "ISC"
 LIC_FILES_CHKSUM = "file://COPYING;md5=39af6eb42999852bdd3ea00ad120a36d"
 
-SRC_URI = "git://github.com/lloyd/yajl"
+SRC_URI = "git://github.com/lloyd/yajl;branch=master;protocol=https"
 SRCREV = "a0ecdde0c042b9256170f2f8890dd9451a4240aa"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-devtools/yasm/yasm_git.bb
+++ b/meta-oe/recipes-devtools/yasm/yasm_git.bb
@@ -9,7 +9,7 @@ DEPENDS += "flex-native bison-native xmlto-native"
 PV = "1.3.0+git${SRCPV}"
 # v1.3.0
 SRCREV = "ba463d3c26c0ece2e797b8d6381b161633b5971a"
-SRC_URI = "git://github.com/yasm/yasm.git \
+SRC_URI = "git://github.com/yasm/yasm.git;branch=master;protocol=https \
            file://0001-Do-not-use-AC_HEADER_STDC.patch \
 "
 

--- a/meta-oe/recipes-extended/beep/beep_1.4.9.bb
+++ b/meta-oe/recipes-extended/beep/beep_1.4.9.bb
@@ -7,7 +7,7 @@ BUGTRACKER = "https://github.com/spkr-beep/beep/issues"
 LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/spkr-beep/beep.git;protocol=https \
+SRC_URI = "git://github.com/spkr-beep/beep.git;protocol=https;branch=master \
            file://0001-Do-not-use-Werror-as-it-fails-with-newer-clang-11.patch \
 "
 SRCREV = "8b85ddd09f73b9fd7caa5679298781a57af194ac"

--- a/meta-oe/recipes-extended/brotli/brotli_1.0.9.bb
+++ b/meta-oe/recipes-extended/brotli/brotli_1.0.9.bb
@@ -6,7 +6,7 @@ BUGTRACKER = "https://github.com/google/brotli/issues"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=941ee9cd1609382f946352712a319b4b"
 
-SRC_URI = "git://github.com/google/brotli.git \
+SRC_URI = "git://github.com/google/brotli.git;branch=master;protocol=https \
            file://838.patch "
 # tag 1.0.9
 SRCREV= "e61745a6b7add50d380cfd7d3883dd6c62fc2c71"

--- a/meta-oe/recipes-extended/cmpi-bindings/cmpi-bindings_1.0.1.bb
+++ b/meta-oe/recipes-extended/cmpi-bindings/cmpi-bindings_1.0.1.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b19ee058d2d5f69af45da98051d91064"
 SECTION = "Development/Libraries"
 DEPENDS = "swig-native python3 sblim-cmpi-devel"
 
-SRC_URI = "git://github.com/kkaempf/cmpi-bindings.git;protocol=http \
+SRC_URI = "git://github.com/kkaempf/cmpi-bindings.git;branch=master;protocol=https \
            file://cmpi-bindings-0.4.17-no-ruby-perl.patch \
            file://cmpi-bindings-0.4.17-sblim-sigsegv.patch \
            file://cmpi-bindings-0.9.5-python-lib-dir.patch \

--- a/meta-oe/recipes-extended/dlt-daemon/dlt-daemon_2.18.7.bb
+++ b/meta-oe/recipes-extended/dlt-daemon/dlt-daemon_2.18.7.bb
@@ -14,7 +14,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=8184208060df880fe3137b93eb88aeea"
 
 DEPENDS = "zlib gzip-native json-c"
 
-SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=https \
+SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=https;branch=master \
     file://0002-Don-t-execute-processes-as-a-specific-user.patch \
     file://0004-Modify-systemd-config-directory.patch \
     file://317.patch \

--- a/meta-oe/recipes-extended/docopt.cpp/docopt.cpp_git.bb
+++ b/meta-oe/recipes-extended/docopt.cpp/docopt.cpp_git.bb
@@ -18,7 +18,7 @@ SRCREV = "42ebcec9dc2c99a1b3a4542787572045763ad196"
 PV = "0.6.3+git${SRCPV}"
 
 SRC_URI = "\
-    git://github.com/docopt/docopt.cpp.git;protocol=https \
+    git://github.com/docopt/docopt.cpp.git;protocol=https;branch=master \
 "
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-extended/dumb-init/dumb-init_1.2.5.bb
+++ b/meta-oe/recipes-extended/dumb-init/dumb-init_1.2.5.bb
@@ -4,7 +4,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=5940d39995ea6857d01b8227109c2e9c"
 
 SRCREV = "89c1502b9d40b5cb4a844498b14d74ba1dd559bf"
-SRC_URI = "git://github.com/Yelp/dumb-init"
+SRC_URI = "git://github.com/Yelp/dumb-init;branch=master;protocol=https"
 S = "${WORKDIR}/git"
 
 EXTRA_OEMAKE = "CC='${CC}' CFLAGS='${CFLAGS} ${LDFLAGS}'"

--- a/meta-oe/recipes-extended/figlet/figlet_git.bb
+++ b/meta-oe/recipes-extended/figlet/figlet_git.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "http://www.figlet.org/"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1688bcd97b27704f1afcac7336409857"
 
-SRC_URI = "git://github.com/cmatsuoka/figlet.git \
+SRC_URI = "git://github.com/cmatsuoka/figlet.git;branch=master;protocol=https \
            file://0001-build-add-autotools-support-to-allow-easy-cross-comp.patch"
 SRCREV = "5bbcd7383a8c3a531299b216b0c734e1495c6db3"
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-extended/haveged/haveged_1.9.14.bb
+++ b/meta-oe/recipes-extended/haveged/haveged_1.9.14.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM="file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
 # v1.9.14
 SRCREV = "4da3080ad4587860e5da73072d6ed54d0052938c"
-SRC_URI = "git://github.com/jirka-h/haveged.git \
+SRC_URI = "git://github.com/jirka-h/haveged.git;branch=master;protocol=https \
 "
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-extended/hexedit/hexedit_1.5.bb
+++ b/meta-oe/recipes-extended/hexedit/hexedit_1.5.bb
@@ -6,7 +6,7 @@ DEPENDS = "ncurses"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=0636e73ff0215e8d672dc4c32c317bb3"
 
-SRC_URI = "git://github.com/pixel/hexedit.git \
+SRC_URI = "git://github.com/pixel/hexedit.git;branch=master;protocol=https \
     "
 
 SRCREV = "baf45a289360a39a05253949fb9d1b50e4668d8a"

--- a/meta-oe/recipes-extended/hiredis/hiredis_0.14.0.bb
+++ b/meta-oe/recipes-extended/hiredis/hiredis_0.14.0.bb
@@ -6,7 +6,7 @@ DEPENDS = "redis"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=d84d659a35c666d23233e54503aaea51"
 SRCREV = "685030652cd98c5414ce554ff5b356dfe8437870"
-SRC_URI = "git://github.com/redis/hiredis;protocol=git \
+SRC_URI = "git://github.com/redis/hiredis;protocol=https;branch=master \
            file://0001-Makefile-remove-hardcoding-of-CC.patch"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-extended/iotop/iotop_0.6.bb
+++ b/meta-oe/recipes-extended/iotop/iotop_0.6.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4325afd396febcb659c36b49533135d4"
 PV .= "+git${SRCPV}"
 
 SRCREV = "1bfb3bc70febb1ffb95146b6dcd65257228099a3"
-SRC_URI = "git://repo.or.cz/iotop.git"
+SRC_URI = "git://repo.or.cz/iotop.git;branch=master"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-extended/isomd5sum/isomd5sum_1.2.3.bb
+++ b/meta-oe/recipes-extended/isomd5sum/isomd5sum_1.2.3.bb
@@ -7,7 +7,7 @@ RDEPENDS_${BPN} = "openssl curl"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=8ca43cbc842c2336e835926c2166c28b"
 
-SRC_URI = "git://github.com/rhinstaller/isomd5sum.git;branch=master \
+SRC_URI = "git://github.com/rhinstaller/isomd5sum.git;branch=master;protocol=https \
            file://0001-tweak-install-prefix.patch \
            file://0002-fix-parallel-error.patch \
 "

--- a/meta-oe/recipes-extended/jpnevulator/jpnevulator_git.bb
+++ b/meta-oe/recipes-extended/jpnevulator/jpnevulator_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=892f569a555ba9c07a568a7c0c4fa63a"
 
 PV = "2.3.6+git${SRCPV}"
 
-SRC_URI = "git://github.com/snarlistic/jpnevulator.git;protocol=http"
+SRC_URI = "git://github.com/snarlistic/jpnevulator.git;branch=master;protocol=https"
 SRCREV = "bc1d4f6587a4a4829b5d55e3ca7ad584da6de545"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-extended/konkretcmpi/konkretcmpi_0.9.2.bb
+++ b/meta-oe/recipes-extended/konkretcmpi/konkretcmpi_0.9.2.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=f673270bfc350d9ce1efc8724c6c1873"
 DEPENDS_append_class-target = " swig-native sblim-cmpi-devel python3"
 DEPENDS_append_class-native = " cmpi-bindings-native"
 
-SRC_URI = "git://github.com/rnovacek/konkretcmpi.git \
+SRC_URI = "git://github.com/rnovacek/konkretcmpi.git;branch=master;protocol=https \
            file://0001-CMakeLists.txt-fix-lib64-can-not-be-shiped-in-64bit-.patch \
            file://0001-drop-including-rpath-cmake-module.patch \
            "

--- a/meta-oe/recipes-extended/libbacktrace/libbacktrace_git.bb
+++ b/meta-oe/recipes-extended/libbacktrace/libbacktrace_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=24b5b3feec63c4be0975e1fea5100440"
 
 DEPENDS += "libunwind"
 
-SRC_URI = "git://github.com/ianlancetaylor/libbacktrace;protocol=https"
+SRC_URI = "git://github.com/ianlancetaylor/libbacktrace;protocol=https;branch=master"
 
 PV = "1.0+git${SRCPV}"
 SRCREV = "4f57c999716847e45505b3df170150876b545088"

--- a/meta-oe/recipes-extended/libblockdev/libblockdev_2.25.bb
+++ b/meta-oe/recipes-extended/libblockdev/libblockdev_2.25.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=c07cb499d259452f324bb90c3067d85c"
 
 inherit autotools gobject-introspection
 
-SRC_URI = "git://github.com/storaged-project/libblockdev;branch=2.x-branch"
+SRC_URI = "git://github.com/storaged-project/libblockdev;branch=2.x-branch;protocol=https"
 SRCREV = "c50869272b54bf4b4bc3825e8c3332a54678b43f"
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-extended/libcec/libcec_6.0.2.bb
+++ b/meta-oe/recipes-extended/libcec/libcec_6.0.2.bb
@@ -10,7 +10,7 @@ DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'libx11 libxrandr', '
 DEPENDS_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' userland', d)}"
 
 SRCREV = "29d82c80bcc62be2878a9ac080de7eb286c4beb9"
-SRC_URI = "git://github.com/Pulse-Eight/libcec.git;branch=release \
+SRC_URI = "git://github.com/Pulse-Eight/libcec.git;branch=release;protocol=https \
            file://0001-CheckPlatformSupport.cmake-Do-not-hardcode-lib-path.patch \
            file://0001-Enhance-reproducibility.patch \
            file://0001-Remove-buggy-test-confusing-host-and-target.patch \

--- a/meta-oe/recipes-extended/libdivecomputer/libdivecomputer_git.bb
+++ b/meta-oe/recipes-extended/libdivecomputer/libdivecomputer_git.bb
@@ -11,7 +11,7 @@ inherit autotools pkgconfig
 PV = "0.6.0"
 
 SRCREV = "1195abc2f4acc7b10175d570ec73549d0938c83e"
-SRC_URI = "git://github.com/libdivecomputer/libdivecomputer.git;protocol=https \
+SRC_URI = "git://github.com/libdivecomputer/libdivecomputer.git;protocol=https;branch=master \
           "
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-extended/libimobiledevice/libplist_2.2.0.bb
+++ b/meta-oe/recipes-extended/libimobiledevice/libplist_2.2.0.bb
@@ -9,7 +9,7 @@ DEPENDS = "libxml2 glib-2.0 swig python3"
 inherit autotools pkgconfig python3native python3targetconfig
 
 SRCREV = "c5a30e9267068436a75b5d00fcbf95cb9c1f4dcd"
-SRC_URI = "git://github.com/libimobiledevice/libplist;protocol=https"
+SRC_URI = "git://github.com/libimobiledevice/libplist;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-extended/libimobiledevice/libusbmuxd_2.0.2.bb
+++ b/meta-oe/recipes-extended/libimobiledevice/libusbmuxd_2.0.2.bb
@@ -9,7 +9,7 @@ inherit autotools pkgconfig gitpkgv
 PKGV = "${GITPKGVTAG}"
 
 SRCREV = "ce98c346b7c1dc2a21faea4fd3f32c88e27ca2af"
-SRC_URI = "git://github.com/libimobiledevice/libusbmuxd;protocol=https"
+SRC_URI = "git://github.com/libimobiledevice/libusbmuxd;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-extended/libleak/libleak_git.bb
+++ b/meta-oe/recipes-extended/libleak/libleak_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://README.md;beginline=18;endline=21;md5=de4f705f12cdedb
 
 DEPENDS += "libbacktrace"
 
-SRC_URI = "gitsm://github.com/WuBingzheng/libleak;protocol=https \
+SRC_URI = "gitsm://github.com/WuBingzheng/libleak;protocol=https;branch=master \
            file://0001-respect-environment-variables.patch \
           "
 

--- a/meta-oe/recipes-extended/liblightmodbus/liblightmodbus_2.0.2.bb
+++ b/meta-oe/recipes-extended/liblightmodbus/liblightmodbus_2.0.2.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 inherit cmake pkgconfig
 
-SRC_URI = "git://github.com/Jacajack/liblightmodbus.git;protocol=https \
+SRC_URI = "git://github.com/Jacajack/liblightmodbus.git;protocol=https;branch=master \
            file://0001-cmake-Use-GNUInstallDirs-instead-of-hardcoding-lib-p.patch \
           "
 SRCREV = "59d2b405f95701e5b04326589786dbb43ce49e81"

--- a/meta-oe/recipes-extended/libnss-nisplus/libnss-nisplus.bb
+++ b/meta-oe/recipes-extended/libnss-nisplus/libnss-nisplus.bb
@@ -17,7 +17,7 @@ PV = "1.3+git${SRCPV}"
 
 SRCREV = "116219e215858f4af9370171d3ead63baca8fdb4"
 
-SRC_URI = "git://github.com/thkukuk/libnss_nisplus \
+SRC_URI = "git://github.com/thkukuk/libnss_nisplus;branch=master;protocol=https \
           "
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-extended/libqb/libqb_1.0.5.bb
+++ b/meta-oe/recipes-extended/libqb/libqb_1.0.5.bb
@@ -11,7 +11,7 @@ inherit autotools pkgconfig
 
 # v1.0.5
 SRCREV = "d08dbcf08b0da418bce9b5427dfd89522916322a"
-SRC_URI = "git://github.com/ClusterLabs/${BPN}.git;branch=version_1 \
+SRC_URI = "git://github.com/ClusterLabs/${BPN}.git;branch=version_1;protocol=https \
            file://0001-build-fix-configure-script-neglecting-re-enable-out-.patch \
           "
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-extended/libreport/libreport_2.10.0.bb
+++ b/meta-oe/recipes-extended/libreport/libreport_2.10.0.bb
@@ -11,7 +11,7 @@ DEPENDS = "xmlrpc-c xmlrpc-c-native intltool-native \
 LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
 
 
-SRC_URI = "git://github.com/abrt/libreport.git;protocol=https"
+SRC_URI = "git://github.com/abrt/libreport.git;protocol=https;branch=master"
 SRC_URI += "file://0001-Makefile.am-remove-doc-and-apidoc.patch \
             file://0002-configure.ac-remove-prog-test-of-xmlto-and-asciidoc.patch \
             file://0003-without-build-plugins.patch \

--- a/meta-oe/recipes-extended/libuio/libuio_0.2.1.bb
+++ b/meta-oe/recipes-extended/libuio/libuio_0.2.1.bb
@@ -3,7 +3,7 @@ SECTION = "base"
 LICENSE = "GPL-2.0"
 LIC_FILES_CHKSUM = "file://COPYING;md5=393a5ca445f6965873eca0259a17f833"
 
-SRC_URI = "git://git.code.sf.net/p/libuio/code \
+SRC_URI = "git://git.code.sf.net/p/libuio/code;branch=master \
            file://replace_inline_with_static-inline.patch \
            file://0001-include-fcntl.h-for-O_RDWR-define.patch \
            "

--- a/meta-oe/recipes-extended/md5deep/md5deep_git.bb
+++ b/meta-oe/recipes-extended/md5deep/md5deep_git.bb
@@ -9,7 +9,7 @@ PV = "4.4+git${SRCPV}"
 
 SRCREV = "877613493ff44807888ce1928129574be393cbb0"
 
-SRC_URI = "git://github.com/jessek/hashdeep.git \
+SRC_URI = "git://github.com/jessek/hashdeep.git;branch=master;protocol=https \
            file://wrong-variable-expansion.patch \
            file://0001-Fix-literal-and-identifier-spacing-as-dictated-by-C-.patch \
            "

--- a/meta-oe/recipes-extended/minifi-cpp/minifi-cpp_0.7.0.bb
+++ b/meta-oe/recipes-extended/minifi-cpp/minifi-cpp_0.7.0.bb
@@ -11,7 +11,7 @@ DEPENDS = "virtual/crypt expat flex python3 bison-native libxml2 nettle lz4"
 RDEPENDS_${PN} = "python3-core"
 
 SRCREV = "aa42957a2e227df41510047cece3cd606dc1cb6a"
-SRC_URI = "git://github.com/apache/nifi-minifi-cpp.git \
+SRC_URI = "git://github.com/apache/nifi-minifi-cpp.git;branch=master;protocol=https \
             https://curl.haxx.se/download/curl-7.64.0.tar.bz2;name=curl;subdir=git/thirdparty \
             https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.8.3.tar.gz;name=libressl;subdir=git/thirdparty \
             ${DEBIAN_MIRROR}/main/o/ossp-uuid/ossp-uuid_1.6.2.orig.tar.gz;name=ossp-uuid;subdir=git/thirdparty \

--- a/meta-oe/recipes-extended/mraa/mraa_git.bb
+++ b/meta-oe/recipes-extended/mraa/mraa_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=91e7de50a8d3cf01057f318d72460acd"
 SRCREV = "7786c7ded5c9ce7773890d0e3dc27632898fc6b1"
 PV = "2.2.0+git${SRCPV}"
 
-SRC_URI = "git://github.com/eclipse/${BPN}.git;protocol=http \
+SRC_URI = "git://github.com/eclipse/${BPN}.git;protocol=http;branch=master;protocol=https \
            file://0001-cmake-Use-a-regular-expression-to-match-x86-architec.patch \
            file://0001-include-Declare-gVERSION-global-as-extern.patch \
            "

--- a/meta-oe/recipes-extended/openwsman/openwsman_2.6.11.bb
+++ b/meta-oe/recipes-extended/openwsman/openwsman_2.6.11.bb
@@ -17,7 +17,7 @@ REQUIRED_DISTRO_FEATURES = "pam"
 
 SRCREV = "d8eba6cb6682b59d84ca1da67a523520b879ade6"
 
-SRC_URI = "git://github.com/Openwsman/openwsman.git \
+SRC_URI = "git://github.com/Openwsman/openwsman.git;branch=master;protocol=https \
            file://libssl-is-required-if-eventint-supported.patch \
            file://openwsmand.service \
            file://0001-lock.c-Define-PTHREAD_MUTEX_RECURSIVE_NP-if-undefine.patch \

--- a/meta-oe/recipes-extended/ostree/ostree_2021.1.bb
+++ b/meta-oe/recipes-extended/ostree/ostree_2021.1.bb
@@ -22,7 +22,7 @@ DEPENDS = " \
 PREMIRRORS = ""
 
 SRC_URI = " \
-    gitsm://github.com/ostreedev/ostree;branch=main \
+    gitsm://github.com/ostreedev/ostree;branch=main;protocol=https \
     file://run-ptest \
 "
 SRCREV = "e9e4b9112083228b8c385ad26924b6c4623f4179"

--- a/meta-oe/recipes-extended/p8platform/p8platform_git.bb
+++ b/meta-oe/recipes-extended/p8platform/p8platform_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://src/os.h;md5=752555fa94e82005d45fd201fee5bd33"
 
 PV = "2.1.0.1"
 
-SRC_URI = "git://github.com/Pulse-Eight/platform.git \
+SRC_URI = "git://github.com/Pulse-Eight/platform.git;branch=master;protocol=https \
            file://0001-Make-resulting-cmake-config-relocatable.patch"
 SRCREV = "2d90f98620e25f47702c9e848380c0d93f29462b"
 

--- a/meta-oe/recipes-extended/pam/pam-plugin-ccreds_11.bb
+++ b/meta-oe/recipes-extended/pam/pam-plugin-ccreds_11.bb
@@ -11,7 +11,7 @@ REQUIRED_DISTRO_FEATURES = "pam"
 
 SRCREV = "e2145df09469bf84878e4729b4ecd814efb797d1"
 
-SRC_URI = "git://github.com/PADL/pam_ccreds"
+SRC_URI = "git://github.com/PADL/pam_ccreds;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-extended/pam/pam-plugin-ldapdb_1.3.bb
+++ b/meta-oe/recipes-extended/pam/pam-plugin-ldapdb_1.3.bb
@@ -11,7 +11,7 @@ inherit features_check
 REQUIRED_DISTRO_FEATURES = "pam"
 
 SRCREV = "84d7b260f1ae6857ae36e014c9a5968e8aa1cbe8"
-SRC_URI = "git://github.com/rmbreak/pam_ldapdb \
+SRC_URI = "git://github.com/rmbreak/pam_ldapdb;branch=master;protocol=https \
            file://0001-include-stdexcept-for-std-invalid_argument.patch \
 "
 

--- a/meta-oe/recipes-extended/pmdk/pmdk_1.9.bb
+++ b/meta-oe/recipes-extended/pmdk/pmdk_1.9.bb
@@ -11,7 +11,7 @@ DEPENDS_append_libc-musl = " fts"
 
 S = "${WORKDIR}/git"
 
-SRC_URI = "git://github.com/pmem/pmdk.git"
+SRC_URI = "git://github.com/pmem/pmdk.git;branch=master;protocol=https"
 
 SRCREV = "1926ffb8f3f5f0617b3b3ed32029d437c272f187"
 

--- a/meta-oe/recipes-extended/properties-cpp/properties-cpp_git.bb
+++ b/meta-oe/recipes-extended/properties-cpp/properties-cpp_git.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=e6a600fd5e1d9cbde2d983680233ad02"
 PV = "0.0.1+git${SRCPV}"
 
 SRCREV = "45863e849b39c4921d6553e6d27e267a96ac7d77"
-SRC_URI = "git://github.com/lib-cpp/${BPN}.git"
+SRC_URI = "git://github.com/lib-cpp/${BPN}.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-extended/redis-plus-plus/redis-plus-plus_1.2.2.bb
+++ b/meta-oe/recipes-extended/redis-plus-plus/redis-plus-plus_1.2.2.bb
@@ -8,7 +8,7 @@ RDEPENDS_${PN} += "hiredis"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 SRCREV = "8ac506e6eb0e5c5b2625785b67400bde705773a1"
-SRC_URI = "git://github.com/sewenew/redis-plus-plus"
+SRC_URI = "git://github.com/sewenew/redis-plus-plus;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-extended/rrdtool/rrdtool_1.7.2.bb
+++ b/meta-oe/recipes-extended/rrdtool/rrdtool_1.7.2.bb
@@ -10,7 +10,7 @@ SRCREV = "56a83f4f52e6745cd4352f9ee008be3183a6dedf"
 PV = "1.7.2"
 
 SRC_URI = "\
-    git://github.com/oetiker/rrdtool-1.x.git;branch=master;protocol=http; \
+    git://github.com/oetiker/rrdtool-1.x.git;branch=master;protocol=http;;protocol=https \
 "
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-extended/rsyslog/libfastjson_0.99.9.bb
+++ b/meta-oe/recipes-extended/rsyslog/libfastjson_0.99.9.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=a958bb07122368f3e1d9b2efe07d231f"
 
 DEPENDS = ""
 
-SRC_URI = "git://github.com/rsyslog/libfastjson.git;protocol=https"
+SRC_URI = "git://github.com/rsyslog/libfastjson.git;protocol=https;branch=master"
 
 SRCREV = "0293afb3913f760c449348551cca4d2df59c1a00"
 

--- a/meta-oe/recipes-extended/sanlock/sanlock_3.8.3.bb
+++ b/meta-oe/recipes-extended/sanlock/sanlock_3.8.3.bb
@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = "file://../README.license;md5=60487bf0bf429d6b5aa72b6d37a0eb2
 
 PV .= "+git${SRCPV}"
 
-SRC_URI = "git://pagure.io/sanlock.git;protocol=http \
+SRC_URI = "git://pagure.io/sanlock.git;protocol=http;branch=master \
            file://0001-sanlock-Replace-cp-a-with-cp-R-no-dereference-preser.patch;patchdir=../ \
           "
 SRCREV = "3a750fed849405c745dcb7b4ceb85f662c53d8d0"

--- a/meta-oe/recipes-extended/sedutil/sedutil_git.bb
+++ b/meta-oe/recipes-extended/sedutil/sedutil_git.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://Common/LICENSE.txt;md5=d32239bcb673463ab874e80d47fae5
 BASEPV = "1.15.1"
 PV = "${BASEPV}+git${SRCPV}"
 SRCREV = "358cc758948be788284d5faba46ccf4cc1813796"
-SRC_URI = "git://github.com/Drive-Trust-Alliance/sedutil.git \
+SRC_URI = "git://github.com/Drive-Trust-Alliance/sedutil.git;branch=master;protocol=https \
 	file://0001-Fix-build-on-big-endian-architectures.patch \
         file://0001-DtaAnnotatedDump-Add-typedef-name-to-the-union.patch \
 "

--- a/meta-oe/recipes-extended/socketcan/can-isotp_git.bb
+++ b/meta-oe/recipes-extended/socketcan/can-isotp_git.bb
@@ -3,7 +3,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=72d977d697c3c05830fdff00a7448931"
 SRCREV = "b31bce98d65f894aad6427bcf6f3f7822e261a59"
 PV = "1.0+git${SRCPV}"
 
-SRC_URI = "git://github.com/hartkopp/can-isotp.git;protocol=https"
+SRC_URI = "git://github.com/hartkopp/can-isotp.git;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-extended/socketcan/can-utils_git.bb
+++ b/meta-oe/recipes-extended/socketcan/can-utils_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://include/linux/can.h;endline=44;md5=a9e1169c6c9a114a61
 
 DEPENDS = "libsocketcan"
 
-SRC_URI = "git://github.com/linux-can/${BPN}.git;protocol=git"
+SRC_URI = "git://github.com/linux-can/${BPN}.git;protocol=https;branch=master"
 
 SRCREV = "eb66451df280f95a9a12e78b151b8d867e1b78ed"
 

--- a/meta-oe/recipes-extended/socketcan/canutils_4.0.6.bb
+++ b/meta-oe/recipes-extended/socketcan/canutils_4.0.6.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 DEPENDS = "libsocketcan"
 
 SRCREV = "299dff7f5322bf0348dcdd60071958ebedf5f09d"
-SRC_URI = "git://git.pengutronix.de/git/tools/canutils.git;protocol=git \
+SRC_URI = "git://git.pengutronix.de/git/tools/canutils.git;protocol=git;branch=master \
     file://0001-canutils-candump-Add-error-frame-s-handling.patch \
 "
 

--- a/meta-oe/recipes-extended/socketcan/libsocketcan_0.0.12.bb
+++ b/meta-oe/recipes-extended/socketcan/libsocketcan_0.0.12.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/libsocketcan.c;beginline=3;endline=17;md5=97e38ad
 
 SRCREV = "077def398ad303043d73339112968e5112d8d7c8"
 
-SRC_URI = "git://git.pengutronix.de/git/tools/libsocketcan.git;protocol=git"
+SRC_URI = "git://git.pengutronix.de/git/tools/libsocketcan.git;protocol=git;branch=master"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-extended/sysdig/sysdig_git.bb
+++ b/meta-oe/recipes-extended/sysdig/sysdig_git.bb
@@ -19,7 +19,7 @@ JIT_powerpc = ""
 DEPENDS += "libb64 lua${JIT} zlib c-ares grpc-native grpc curl ncurses jsoncpp tbb jq openssl elfutils protobuf protobuf-native jq-native"
 RDEPENDS_${PN} = "bash"
 
-SRC_URI = "git://github.com/draios/sysdig.git;branch=dev \
+SRC_URI = "git://github.com/draios/sysdig.git;branch=dev;protocol=https \
            file://0001-fix-build-with-LuaJIT-2.1-betas.patch \
            file://aarch64.patch \
           "

--- a/meta-oe/recipes-extended/tipcutils/tipcutils_git.bb
+++ b/meta-oe/recipes-extended/tipcutils/tipcutils_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "Transparent Inter-Process Communication protocol"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://tipclog/tipc.h;endline=35;md5=985b6ea8735818511d276c1b466cce98"
 
-SRC_URI = "git://git.code.sf.net/p/tipc/tipcutils \
+SRC_URI = "git://git.code.sf.net/p/tipc/tipcutils;branch=master \
            file://0001-include-sys-select.h-for-FD_-definitions.patch \
            file://0002-replace-non-standard-uint-with-unsigned-int.patch \
            file://0001-multicast_blast-tipcc-Fix-struct-type-for-TIPC_GROUP.patch \

--- a/meta-oe/recipes-extended/tmate/tmate_2.4.0.bb
+++ b/meta-oe/recipes-extended/tmate/tmate_2.4.0.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=f7d9aab84ec6567139a4755c48d147fb"
 
 DEPENDS_append = " libevent libssh msgpack-c ncurses"
 SRC_URI = "\
-    git://github.com/tmate-io/tmate.git;protocol=https \
+    git://github.com/tmate-io/tmate.git;protocol=https;branch=master \
 "
 
 SRCREV = "5e00bfa5e137e76c81888727712ced2b3fd99f5b"

--- a/meta-oe/recipes-extended/triggerhappy/triggerhappy_git.bb
+++ b/meta-oe/recipes-extended/triggerhappy/triggerhappy_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 # matches debian/0.5.0-1 tag
 SRCREV = "44a173195986d0d853316cb02a58785ded66c12b"
 PV = "0.5.0+git${SRCPV}"
-SRC_URI = "git://github.com/wertarbyte/${BPN}.git;branch=debian"
+SRC_URI = "git://github.com/wertarbyte/${BPN}.git;branch=debian;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-extended/upm/upm_git.bb
+++ b/meta-oe/recipes-extended/upm/upm_git.bb
@@ -10,7 +10,7 @@ DEPENDS = "libjpeg-turbo mraa"
 SRCREV = "5cf20df96c6b35c19d5b871ba4e319e96b4df72d"
 PV = "2.0.0+git${SRCPV}"
 
-SRC_URI = "git://github.com/eclipse/${BPN}.git;protocol=http \
+SRC_URI = "git://github.com/eclipse/${BPN}.git;protocol=http;branch=master;protocol=https \
            file://0001-CMakeLists.txt-Use-SWIG_SUPPORT_FILES-to-find-the-li.patch \
            file://0001-Use-stdint-types.patch \
            file://0001-initialize-local-variables-before-use.patch \

--- a/meta-oe/recipes-extended/wipe/wipe_0.24.bb
+++ b/meta-oe/recipes-extended/wipe/wipe_0.24.bb
@@ -9,7 +9,7 @@ HOMEPAGE = "http://lambda-diode.com/software/wipe/"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://GPL;md5=0636e73ff0215e8d672dc4c32c317bb3"
 
-SRC_URI = "git://github.com/berke/wipe.git;branch=master \
+SRC_URI = "git://github.com/berke/wipe.git;branch=master;protocol=https \
     file://support-cross-compile-for-linux.patch \
     file://makefile-add-ldflags.patch \
 "

--- a/meta-oe/recipes-extended/wxwidgets/wxwidgets_git.bb
+++ b/meta-oe/recipes-extended/wxwidgets/wxwidgets_git.bb
@@ -22,7 +22,7 @@ DEPENDS += " \
 "
 
 SRC_URI = " \
-    git://github.com/wxWidgets/wxWidgets.git \
+    git://github.com/wxWidgets/wxWidgets.git;branch=master;protocol=https \
     file://0001-wx-config.in-Disable-cross-magic-it-does-not-work-fo.patch \
 "
 PV = "3.1.4"

--- a/meta-oe/recipes-extended/zlog/zlog_1.2.15.bb
+++ b/meta-oe/recipes-extended/zlog/zlog_1.2.15.bb
@@ -4,7 +4,7 @@ LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRCREV = "876099f3c66033f3de11d79f63814766b1021dbe"
-SRC_URI = "git://github.com/HardySimpson/zlog"
+SRC_URI = "git://github.com/HardySimpson/zlog;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-gnome/libjcat/libjcat_0.1.6.bb
+++ b/meta-oe/recipes-gnome/libjcat/libjcat_0.1.6.bb
@@ -8,7 +8,7 @@ DEPENDS = "\
 "
 
 SRC_URI = "\
-    git://github.com/hughsie/libjcat.git \
+    git://github.com/hughsie/libjcat.git;branch=master;protocol=https \
     file://run-ptest \
 "
 SRCREV = "c4f032468c56a5750e1e15b01fa31539b5c7ae51"

--- a/meta-oe/recipes-gnome/libxmlb/libxmlb_0.3.0.bb
+++ b/meta-oe/recipes-gnome/libxmlb/libxmlb_0.3.0.bb
@@ -3,7 +3,7 @@ LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1803fa9c2c3ce8cb06b4861d75310742"
 
 SRC_URI = "\
-    git://github.com/hughsie/libxmlb.git \
+    git://github.com/hughsie/libxmlb.git;branch=master;protocol=https \
     file://run-ptest \
 "
 SRCREV = "8f2f28eda419dbe31cb1a9aa022f0ca9d30ecb6a"

--- a/meta-oe/recipes-gnome/pyxdg/pyxdg_0.26.bb
+++ b/meta-oe/recipes-gnome/pyxdg/pyxdg_0.26.bb
@@ -5,7 +5,7 @@ LICENSE = "LGPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=f30a9716ef3762e3467a2f62bf790f0a"
 
 SRCREV = "7db14dcf4c4305c3859a2d9fcf9f5da2db328330"
-SRC_URI = "git://anongit.freedesktop.org/xdg/pyxdg"
+SRC_URI = "git://anongit.freedesktop.org/xdg/pyxdg;branch=master"
 
 inherit distutils3
 

--- a/meta-oe/recipes-graphics/dietsplash/dietsplash_git.bb
+++ b/meta-oe/recipes-graphics/dietsplash/dietsplash_git.bb
@@ -8,7 +8,7 @@ PV = "0.3"
 PR = "r1"
 
 SRCREV = "ef2e1a390e768e21e6a6268977580ee129a96633"
-SRC_URI = "git://github.com/lucasdemarchi/dietsplash.git \
+SRC_URI = "git://github.com/lucasdemarchi/dietsplash.git;branch=master;protocol=https \
            file://0001-configure.ac-Do-not-demand-linker-hash-style.patch \
            "
 

--- a/meta-oe/recipes-graphics/dnfdragora/dnfdragora_git.bb
+++ b/meta-oe/recipes-graphics/dnfdragora/dnfdragora_git.bb
@@ -3,7 +3,7 @@ LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d32239bcb673463ab874e80d47fae504 \
                    "
 
-SRC_URI = "git://github.com/manatools/dnfdragora.git \
+SRC_URI = "git://github.com/manatools/dnfdragora.git;branch=master;protocol=https \
            file://0001-disable-build-manpages.patch \
            file://0001-Do-not-set-PYTHON_INSTALL_DIR-by-running-python.patch \
            file://0001-To-fix-error-when-do_package.patch \

--- a/meta-oe/recipes-graphics/fbgrab/fbgrab_1.5.bb
+++ b/meta-oe/recipes-graphics/fbgrab/fbgrab_1.5.bb
@@ -4,7 +4,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=ea5bed2f60d357618ca161ad539f7c0a"
 SECTION = "console/utils"
 DEPENDS = "libpng zlib"
-SRC_URI = "git://github.com/GunnarMonell/fbgrab.git;protocol=https"
+SRC_URI = "git://github.com/GunnarMonell/fbgrab.git;protocol=https;branch=master"
 
 SRCREV = "f43ce6d5ce48fb01360eaa7c4a92c2573a1d02f8"
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-graphics/fontforge/fontforge_20190801.bb
+++ b/meta-oe/recipes-graphics/fontforge/fontforge_20190801.bb
@@ -15,7 +15,7 @@ REQUIRED_DISTRO_FEATURES_append_class-target = " x11"
 
 # tag 20190801
 SRCREV = "ac635b818e38ddb8e7e2e1057330a32b4e25476e"
-SRC_URI = "git://github.com/${BPN}/${BPN}.git \
+SRC_URI = "git://github.com/${BPN}/${BPN}.git;branch=master;protocol=https \
            file://0001-include-sys-select-on-non-glibc-platforms.patch \
 "
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-graphics/fvwm/fvwm_2.6.9.bb
+++ b/meta-oe/recipes-graphics/fvwm/fvwm_2.6.9.bb
@@ -32,7 +32,7 @@ DEPENDS = " \
 "
 
 SRC_URI = " \
-    git://github.com/fvwmorg/fvwm.git;protocol=https \
+    git://github.com/fvwmorg/fvwm.git;protocol=https;branch=master \
     file://0001-Fix-compilation-for-disabled-gnome.patch \
 "
 

--- a/meta-oe/recipes-graphics/glm/glm_0.9.9.8.bb
+++ b/meta-oe/recipes-graphics/glm/glm_0.9.9.8.bb
@@ -9,7 +9,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://copying.txt;md5=462e4b97f73ef12f8171c3c546ce4e8d"
 
 SRC_URI = " \
-    git://github.com/g-truc/glm;branch=master \
+    git://github.com/g-truc/glm;branch=master;protocol=https \
     file://0001-Silence-clang-warnings.patch \
     file://glmConfig.cmake.in \
     file://glmConfigVersion.cmake.in \

--- a/meta-oe/recipes-graphics/imlib2/imlib2_git.bb
+++ b/meta-oe/recipes-graphics/imlib2/imlib2_git.bb
@@ -14,7 +14,7 @@ inherit autotools pkgconfig lib_package
 
 AUTO_LIBNAME_PKGS = ""
 
-SRC_URI = "git://git.enlightenment.org/legacy/${BPN}.git;protocol=https"
+SRC_URI = "git://git.enlightenment.org/legacy/${BPN}.git;protocol=https;branch=master"
 S = "${WORKDIR}/git"
 
 PACKAGECONFIG ??= "jpeg png zlib ${@bb.utils.filter('DISTRO_FEATURES', 'x11', d)}"

--- a/meta-oe/recipes-graphics/jasper/jasper_2.0.26.bb
+++ b/meta-oe/recipes-graphics/jasper/jasper_2.0.26.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://jasper-software.github.io/jasper/"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=a80440d1d8f17d041c71c7271d6e06eb"
 
-SRC_URI = "git://github.com/jasper-software/jasper.git;protocol=https"
+SRC_URI = "git://github.com/jasper-software/jasper.git;protocol=https;branch=master"
 SRCREV = "5083b949f0caa5bc6257cd81162a33c15bf8a1d1"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-graphics/libvncserver/libvncserver_0.9.13.bb
+++ b/meta-oe/recipes-graphics/libvncserver/libvncserver_0.9.13.bb
@@ -44,7 +44,7 @@ FILES_libvncclient = "${libdir}/libvncclient.*"
 
 inherit cmake
 
-SRC_URI = "git://github.com/LibVNC/libvncserver"
+SRC_URI = "git://github.com/LibVNC/libvncserver;branch=master;protocol=https"
 SRCREV = "2aa20dad4c23c18948d3f63b33f9dfec1f837729"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-graphics/libyui/libyui-ncurses_4.1.1.bb
+++ b/meta-oe/recipes-graphics/libyui/libyui-ncurses_4.1.1.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://../COPYING.lgpl-3;md5=e6a600fd5e1d9cbde2d983680233ad0
     file://../COPYING.lgpl-2.1;md5=4fbd65380cdd255951079008b364516c \
 "
 
-SRC_URI = "git://github.com/libyui/libyui.git"
+SRC_URI = "git://github.com/libyui/libyui.git;branch=master;protocol=https"
 
 SRC_URI_append_class-target = " file://0001-Fix-the-error-of-can-t-find-header-file.patch"
 

--- a/meta-oe/recipes-graphics/libyui/libyui_4.1.1.bb
+++ b/meta-oe/recipes-graphics/libyui/libyui_4.1.1.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://../COPYING.gpl-3;md5=d32239bcb673463ab874e80d47fae504
                     file://../COPYING.lgpl-3;md5=e6a600fd5e1d9cbde2d983680233ad02 \
                    "
 
-SRC_URI = "git://github.com/libyui/libyui.git \
+SRC_URI = "git://github.com/libyui/libyui.git;branch=master;protocol=https \
            file://0001-Fix-build-with-clang.patch \
            file://0001-Use-relative-install-paths-for-CMake.patch \
            "

--- a/meta-oe/recipes-graphics/openbox/obconf_git.bb
+++ b/meta-oe/recipes-graphics/openbox/obconf_git.bb
@@ -13,7 +13,7 @@ PV = "2.0.4+git${SRCPV}"
 
 SRCREV = "63ec47c5e295ad4f09d1df6d92afb7e10c3fec39"
 SRC_URI = " \
-    git://git.openbox.org/dana/obconf \
+    git://git.openbox.org/dana/obconf;branch=master \
 "
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-graphics/openjpeg/openjpeg_2.4.0.bb
+++ b/meta-oe/recipes-graphics/openjpeg/openjpeg_2.4.0.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=c648878b4840d7babaade1303e7f108c"
 DEPENDS = "libpng tiff lcms zlib"
 
 SRC_URI = " \
-    git://github.com/uclouvain/openjpeg.git \
+    git://github.com/uclouvain/openjpeg.git;branch=master;protocol=https \
     file://0002-Do-not-ask-cmake-to-export-binaries-they-don-t-make-.patch \
     file://0001-This-patch-fixed-include-dir-to-usr-include-.-Obviou.patch \
 "

--- a/meta-oe/recipes-graphics/parallel-deqp-runner/parallel-deqp-runner_git.bb
+++ b/meta-oe/recipes-graphics/parallel-deqp-runner/parallel-deqp-runner_git.bb
@@ -1,7 +1,7 @@
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=4f59d6446bf2e004e80df1a0937129fa"
 
-SRC_URI = "git://gitlab.freedesktop.org/mesa/parallel-deqp-runner.git;protocol=https \
+SRC_URI = "git://gitlab.freedesktop.org/mesa/parallel-deqp-runner.git;protocol=https;branch=master \
            file://0001-meson.build-WORKAROUND-Remove-vulkan-dependency.patch \
            "
 

--- a/meta-oe/recipes-graphics/qrencode/qrencode_4.1.1.bb
+++ b/meta-oe/recipes-graphics/qrencode/qrencode_4.1.1.bb
@@ -6,7 +6,7 @@ LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=2d5025d4aa3495befef8f17206a5b0a1"
 
 SRCREV = "715e29fd4cd71b6e452ae0f4e36d917b43122ce8"
-SRC_URI = "git://github.com/fukuchi/libqrencode.git"
+SRC_URI = "git://github.com/fukuchi/libqrencode.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-graphics/renderdoc/renderdoc_1.7.bb
+++ b/meta-oe/recipes-graphics/renderdoc/renderdoc_1.7.bb
@@ -5,7 +5,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=df7ea9e196efc7014c124747a0ef9772"
 
 SRCREV = "a56af589d94dc851809fd5344d0ae441da70c1f2"
-SRC_URI = "git://github.com/baldurk/${BPN}.git;protocol=http;branch=v1.x \
+SRC_URI = "git://github.com/baldurk/${BPN}.git;protocol=http;branch=v1.x;protocol=https \
 	   file://0001-renderdoc-use-xxd-instead-of-cross-compiling-shim-bi.patch \
 	   file://0001-Remove-glslang-pool_allocator-setAllocator.patch \
 "

--- a/meta-oe/recipes-graphics/spir/spirv-shader-generator_git.bb
+++ b/meta-oe/recipes-graphics/spir/spirv-shader-generator_git.bb
@@ -6,7 +6,7 @@ SECTION = "graphics"
 
 S = "${WORKDIR}/git"
 SRCREV = "ed16b3e69985feaf565efbecea70a1cc2fca2a58"
-SRC_URI = "git://github.com/KhronosGroup/SPIRV-Cross.git \
+SRC_URI = "git://github.com/KhronosGroup/SPIRV-Cross.git;branch=master;protocol=https \
 	file://0001-Add-install-PHONY-target-in-Makefile.patch \
 "
 

--- a/meta-oe/recipes-graphics/tesseract/tesseract-lang_4.1.0.bb
+++ b/meta-oe/recipes-graphics/tesseract/tesseract-lang_4.1.0.bb
@@ -4,7 +4,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 SRCREV = "4767ea922bcc460e70b87b1d303ebdfed0897da8"
-SRC_URI = "git://github.com/tesseract-ocr/tessdata.git"
+SRC_URI = "git://github.com/tesseract-ocr/tessdata.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-graphics/tesseract/tesseract_4.1.1.bb
+++ b/meta-oe/recipes-graphics/tesseract/tesseract_4.1.1.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 BRANCH = "4.1"
 SRCREV = "f4ef2f2050f4c25b28bdbf0063b7d2eb30f41cf7"
-SRC_URI = "git://github.com/${BPN}-ocr/${BPN}.git;branch=${BRANCH} \
+SRC_URI = "git://github.com/${BPN}-ocr/${BPN}.git;branch=${BRANCH};protocol=https \
            file://0001-include-sys-time.h.patch \
           "
 

--- a/meta-oe/recipes-graphics/tigervnc/tigervnc_1.11.0.bb
+++ b/meta-oe/recipes-graphics/tigervnc/tigervnc_1.11.0.bb
@@ -17,7 +17,7 @@ B = "${S}"
 
 SRCREV = "540bfc3278e396321124d4b18a798ac2bc18b6ca"
 
-SRC_URI = "git://github.com/TigerVNC/tigervnc.git;branch=1.11-branch \
+SRC_URI = "git://github.com/TigerVNC/tigervnc.git;branch=1.11-branch;protocol=https \
            file://0002-do-not-build-tests-sub-directory.patch \
            file://0003-add-missing-dynamic-library-to-FLTK_LIBRARIES.patch \
            file://0004-tigervnc-add-fPIC-option-to-COMPILE_FLAGS.patch \

--- a/meta-oe/recipes-graphics/ttf-fonts/ttf-droid_git.bb
+++ b/meta-oe/recipes-graphics/ttf-fonts/ttf-droid_git.bb
@@ -8,7 +8,7 @@ SRCREV = "21e6e2de1f0062f949fcc52d0b4559dfa3246e0e"
 PV = "0.1+gitr${SRCPV}"
 PR = "r3"
 
-SRC_URI = "git://github.com/android/platform_frameworks_base.git;branch=master"
+SRC_URI = "git://github.com/android/platform_frameworks_base.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git/data/fonts"
 

--- a/meta-oe/recipes-graphics/ttf-fonts/ttf-lohit_2.bb
+++ b/meta-oe/recipes-graphics/ttf-fonts/ttf-lohit_2.bb
@@ -8,7 +8,7 @@ LICENSE = "OFL-1.1"
 LIC_FILES_CHKSUM = "file://OFL.txt;md5=7dfa0a236dc535ad2d2548e6170c4402"
 
 SRCREV = "d678f1b1807ea5602586279e90b5db6d62ed475e"
-SRC_URI = "git://github.com/pravins/lohit.git;branch=master"
+SRC_URI = "git://github.com/pravins/lohit.git;branch=master;protocol=https"
 
 DEPENDS = "fontforge-native"
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-graphics/ttf-fonts/ttf-noto-emoji_20190815.bb
+++ b/meta-oe/recipes-graphics/ttf-fonts/ttf-noto-emoji_20190815.bb
@@ -5,7 +5,7 @@ HOMEPAGE = "https://github.com/googlefonts/noto-emoji"
 LICENSE = "OFL-1.1"
 LIC_FILES_CHKSUM = "file://fonts/LICENSE;md5=55719faa0112708e946b820b24b14097"
 
-SRC_URI = "git://github.com/googlefonts/noto-emoji;protocol=https"
+SRC_URI = "git://github.com/googlefonts/noto-emoji;protocol=https;branch=master"
 SRCREV = "833a43d03246a9325e748a2d783006454d76ff66"
 
 PACKAGES = "${PN}-color ${PN}-regular"

--- a/meta-oe/recipes-graphics/unclutter-xfixes/unclutter-xfixes_1.5.bb
+++ b/meta-oe/recipes-graphics/unclutter-xfixes/unclutter-xfixes_1.5.bb
@@ -5,7 +5,7 @@ AUTHOR = "Ingo Bürk"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b25d2c4cca175f44120d1b8e67cb358d"
 
-SRC_URI = "git://github.com/Airblader/unclutter-xfixes.git \
+SRC_URI = "git://github.com/Airblader/unclutter-xfixes.git;branch=master;protocol=https \
            file://0001-build-use-autotools.patch"
 SRCREV = "10fd337bb77e4e93c3380f630a0555372778a948"
 

--- a/meta-oe/recipes-graphics/vdpau/libvdpau_1.4.bb
+++ b/meta-oe/recipes-graphics/vdpau/libvdpau_1.4.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=83af8811a28727a13f04132cc33b7f58"
 DEPENDS = "virtual/libx11 libxext xorgproto"
 
 SRCREV = "c3d1a9dbafdfe6144ff474d0d523dc01b068750f"
-SRC_URI = "git://anongit.freedesktop.org/vdpau/libvdpau"
+SRC_URI = "git://anongit.freedesktop.org/vdpau/libvdpau;branch=master"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-graphics/vk-gl-cts/khronos-cts.inc
+++ b/meta-oe/recipes-graphics/vk-gl-cts/khronos-cts.inc
@@ -4,9 +4,9 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 SRC_URI = "\
 	git://github.com/KhronosGroup/VK-GL-CTS.git;protocol=https;name=vk-gl-cts;nobranch=1 \
 	git://github.com/google/amber;protocol=https;destsuffix=git/external/amber/src;name=amber;branch=main \
-	git://github.com/KhronosGroup/glslang.git;protocol=https;destsuffix=git/external/glslang/src;name=glslang \
-	git://github.com/KhronosGroup/SPIRV-Headers.git;protocol=https;destsuffix=git/external/spirv-headers/src;name=spirv-headers \
-	git://github.com/KhronosGroup/SPIRV-Tools.git;protocol=https;destsuffix=git/external/spirv-tools/src;name=spirv-tools \
+	git://github.com/KhronosGroup/glslang.git;protocol=https;destsuffix=git/external/glslang/src;name=glslang;branch=master \
+	git://github.com/KhronosGroup/SPIRV-Headers.git;protocol=https;destsuffix=git/external/spirv-headers/src;name=spirv-headers;branch=master \
+	git://github.com/KhronosGroup/SPIRV-Tools.git;protocol=https;destsuffix=git/external/spirv-tools/src;name=spirv-tools;branch=master \
 	https://raw.githubusercontent.com/baldurk/renderdoc/v1.1/renderdoc/api/app/renderdoc_app.h;subdir=git/external/renderdoc/src;name=renderdoc \
 "
 

--- a/meta-oe/recipes-graphics/x11vnc/x11vnc_0.9.16.bb
+++ b/meta-oe/recipes-graphics/x11vnc/x11vnc_0.9.16.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
 SRCREV = "87cd0530f438372dda3c70bb491a6fd19f09acc2"
 PV .= "+git${SRCPV}"
 
-SRC_URI = "git://github.com/LibVNC/x11vnc \
+SRC_URI = "git://github.com/LibVNC/x11vnc;branch=master;protocol=https \
            file://starting-fix.patch \
            "
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-graphics/xorg-driver/xf86-video-armsoc_1.4.1.bb
+++ b/meta-oe/recipes-graphics/xorg-driver/xf86-video-armsoc_1.4.1.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=10ce5de3b111315ea652a5f74ec0c602"
 DEPENDS += "virtual/libx11 libdrm xorgproto"
 
 SRCREV = "8bbdb2ae3bb8ef649999a8da33ddbe11a04763b8"
-SRC_URI = "git://anongit.freedesktop.org/xorg/driver/xf86-video-armsoc"
+SRC_URI = "git://anongit.freedesktop.org/xorg/driver/xf86-video-armsoc;branch=master"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-graphics/yad/yad_6.0.bb
+++ b/meta-oe/recipes-graphics/yad/yad_6.0.bb
@@ -5,7 +5,7 @@ AUTHOR = "Victor Ananjevsky"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
-SRC_URI = "git://github.com/v1cont/yad.git"
+SRC_URI = "git://github.com/v1cont/yad.git;branch=master;protocol=https"
 SRCREV = "a5b1a7a3867bc7dffbbc539f586f301687b6ec02"
 
 inherit autotools gsettings features_check

--- a/meta-oe/recipes-kernel/agent-proxy/agent-proxy_1.97.bb
+++ b/meta-oe/recipes-kernel/agent-proxy/agent-proxy_1.97.bb
@@ -10,7 +10,7 @@ EXTRA_OEMAKE = "'CC=${CC}'"
 
 SRCREV = "468fe4c31e6c62c9bbb328b06ba71eaf7be0b76a"
 
-SRC_URI = "git://git.kernel.org/pub/scm/utils/kernel/kgdb/agent-proxy.git;protocol=git \
+SRC_URI = "git://git.kernel.org/pub/scm/utils/kernel/kgdb/agent-proxy.git;protocol=git;branch=master \
            file://0001-Makefile-Add-LDFLAGS-variable.patch \
 "
 

--- a/meta-oe/recipes-kernel/broadcom-bt-firmware/broadcom-bt-firmware_12.0.1.1105_p2.bb
+++ b/meta-oe/recipes-kernel/broadcom-bt-firmware/broadcom-bt-firmware_12.0.1.1105_p2.bb
@@ -9,7 +9,7 @@ LICENSE = "Firmware-Broadcom-WIDCOMM"
 NO_GENERIC_LICENSE[Firmware-Broadcom-WIDCOMM] = "LICENSE.broadcom_bcm20702"
 
 LIC_FILES_CHKSUM = "file://LICENSE.broadcom_bcm20702;md5=c0d5ea0502b00df74173d0f8a48b619d"
-SRC_URI = "git://github.com/winterheart/broadcom-bt-firmware.git"
+SRC_URI = "git://github.com/winterheart/broadcom-bt-firmware.git;branch=master;protocol=https"
 SRCREV = "1af1116f73782951bd7bbe2139928e497c3a634b"
 
 PE = "1"

--- a/meta-oe/recipes-kernel/crash/crash_7.3.0.bb
+++ b/meta-oe/recipes-kernel/crash/crash_7.3.0.bb
@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = "file://COPYING3;md5=d32239bcb673463ab874e80d47fae504"
 DEPENDS = "zlib readline coreutils-native ncurses-native"
 
 S = "${WORKDIR}/git"
-SRC_URI = "git://github.com/crash-utility/${BPN}.git \
+SRC_URI = "git://github.com/crash-utility/${BPN}.git;branch=master;protocol=https \
            ${GNU_MIRROR}/gdb/gdb-7.6.tar.gz;name=gdb;subdir=git \
            file://7001force_define_architecture.patch \
            file://7003cross_ranlib.patch \

--- a/meta-oe/recipes-kernel/kpatch/kpatch.inc
+++ b/meta-oe/recipes-kernel/kpatch/kpatch.inc
@@ -3,7 +3,7 @@ DESCRIPTION = "kpatch is a Linux dynamic kernel patching infrastructure which al
 LICENSE = "GPLv2 & LGPLv2"
 DEPENDS = "elfutils bash"
 
-SRC_URI = "git://github.com/dynup/kpatch.git;protocol=https \
+SRC_URI = "git://github.com/dynup/kpatch.git;protocol=https;branch=master \
 	file://0001-kpatch-build-add-cross-compilation-support.patch \
 	file://0002-kpatch-build-allow-overriding-of-distro-name.patch \
 	"

--- a/meta-oe/recipes-kernel/libbpf/libbpf_0.3.bb
+++ b/meta-oe/recipes-kernel/libbpf/libbpf_0.3.bb
@@ -12,7 +12,7 @@ DEPENDS = "zlib elfutils"
 
 do_compile[depends] += "virtual/kernel:do_shared_workdir"
 
-SRC_URI = "git://github.com/libbpf/libbpf.git;protocol=https"
+SRC_URI = "git://github.com/libbpf/libbpf.git;protocol=https;branch=master"
 SRCREV = "051a4009f94d5633a8f734ca4235f0a78ee90469"
 
 # Backported from version 0.4

--- a/meta-oe/recipes-kernel/makedumpfile/makedumpfile_1.6.8.bb
+++ b/meta-oe/recipes-kernel/makedumpfile/makedumpfile_1.6.8.bb
@@ -24,7 +24,7 @@ PACKAGES =+ "${PN}-tools"
 FILES_${PN}-tools = "${bindir}/*.pl"
 
 SRC_URI = "\
-    git://github.com/makedumpfile/makedumpfile;branch=${SRCBRANCH} \
+    git://github.com/makedumpfile/makedumpfile;branch=${SRCBRANCH};protocol=https \
     file://0001-makedumpfile-replace-hardcode-CFLAGS.patch \
     file://0002-mem_section-Support-only-46-bit-for-MAX_PHYSMEM_BITS.patch \
 "

--- a/meta-oe/recipes-kernel/minicoredumper/minicoredumper_2.0.1.bb
+++ b/meta-oe/recipes-kernel/minicoredumper/minicoredumper_2.0.1.bb
@@ -13,7 +13,7 @@ SRCREV = "16a0d44f1725eaa93096eaa0e086f42ef4c2712c"
 
 PR .= "+git${SRCPV}"
 
-SRC_URI = "git://github.com/diamon/minicoredumper;protocol=https \
+SRC_URI = "git://github.com/diamon/minicoredumper;protocol=https;branch=master \
            file://minicoredumper.service \
            file://minicoredumper.init \
            "

--- a/meta-oe/recipes-kernel/pm-graph/pm-graph_5.5.bb
+++ b/meta-oe/recipes-kernel/pm-graph/pm-graph_5.5.bb
@@ -6,7 +6,7 @@ LICENSE  = "GPL-2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 SRCREV = "cf59527dc24fdd2f314ae4dcaeb3d68a117988f6"
-SRC_URI = "git://github.com/intel/pm-graph.git \
+SRC_URI = "git://github.com/intel/pm-graph.git;branch=master;protocol=https \
            file://0001-Makefile-fix-multilib-build-failure.patch \
            file://0001-sleepgraph.py-use-python3.patch \
            file://0001-sleepgraph-add-support-for-RT-kernel-ftrace-flags.patch \

--- a/meta-oe/recipes-multimedia/jack/a2jmidid_9.bb
+++ b/meta-oe/recipes-multimedia/jack/a2jmidid_9.bb
@@ -11,7 +11,7 @@ DEPENDS_append_libc-musl = " libexecinfo"
 
 SRCREV = "de37569c926c5886768f892c019e3f0468615038"
 SRC_URI = " \
-    git://github.com/linuxaudio/a2jmidid;protocol=https \
+    git://github.com/linuxaudio/a2jmidid;protocol=https;branch=master \
     file://riscv_ucontext.patch \
 "
 

--- a/meta-oe/recipes-multimedia/jack/jack_1.19.17.bb
+++ b/meta-oe/recipes-multimedia/jack/jack_1.19.17.bb
@@ -14,7 +14,7 @@ LIC_FILES_CHKSUM = " \
 
 DEPENDS = "libsamplerate0 libsndfile1 readline"
 
-SRC_URI = "git://github.com/jackaudio/jack2.git \
+SRC_URI = "git://github.com/jackaudio/jack2.git;branch=master;protocol=https \
            file://0001-example-clients-Use-c-compiler-for-jack_simdtests.patch \
           "
 SRCREV = "9e23888b8def6527774889cf4ef6348fb78c7154"

--- a/meta-oe/recipes-multimedia/libass/libass_0.14.0.bb
+++ b/meta-oe/recipes-multimedia/libass/libass_0.14.0.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=a42532a0684420bdb15556c3cdd49a75"
 
 DEPENDS = "enca fontconfig freetype libpng fribidi"
 
-SRC_URI = "git://github.com/libass/libass.git"
+SRC_URI = "git://github.com/libass/libass.git;branch=master;protocol=https"
 SRCREV = "73284b676b12b47e17af2ef1b430527299e10c17"
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-multimedia/mplayer/mpv_0.32.0.bb
+++ b/meta-oe/recipes-multimedia/mplayer/mpv_0.32.0.bb
@@ -14,7 +14,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.GPL;md5=91f1cb870c1cc2d31351a4d2595441cb"
 
 SRCREV_mpv = "70b991749df389bcc0a4e145b5687233a03b4ed7"
 SRC_URI = " \
-    git://github.com/mpv-player/mpv;name=mpv \
+    git://github.com/mpv-player/mpv;name=mpv;branch=master;protocol=https \
     https://waf.io/waf-2.0.20;name=waf;subdir=git \
 "
 SRC_URI[waf.sha256sum] = "bf971e98edc2414968a262c6aa6b88541a26c3cd248689c89f4c57370955ee7f"

--- a/meta-oe/recipes-multimedia/v4l2apps/yavta_git.bb
+++ b/meta-oe/recipes-multimedia/v4l2apps/yavta_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "Yet Another V4L2 Test Application"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING.GPL;md5=751419260aa954499f7abaabaa882bbe"
 
-SRC_URI = "git://git.ideasonboard.org/yavta.git \
+SRC_URI = "git://git.ideasonboard.org/yavta.git;branch=master \
            file://0001-Add-stdout-mode-to-allow-streaming-over-the-network-.patch"
 SRCREV = "7e9f28bedc1ed3205fb5164f686aea96f27a0de2"
 

--- a/meta-oe/recipes-multimedia/webm/libvpx_1.8.2.bb
+++ b/meta-oe/recipes-multimedia/webm/libvpx_1.8.2.bb
@@ -8,7 +8,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d5b04755015be901744a78cc30d390d4"
 
 SRCREV = "7ec7a33a081aeeb53fed1a8d87e4cbd189152527"
-SRC_URI += "git://chromium.googlesource.com/webm/libvpx;protocol=https \
+SRC_URI += "git://chromium.googlesource.com/webm/libvpx;protocol=https;branch=master \
             file://libvpx-configure-support-blank-prefix.patch \
            "
 

--- a/meta-oe/recipes-support/ace-cloud-editor/ace-cloud-editor_git.bb
+++ b/meta-oe/recipes-support/ace-cloud-editor/ace-cloud-editor_git.bb
@@ -4,7 +4,7 @@ SUMMARY = "Ace is a code editor written in JavaScript. This repository has only 
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=794d11c5219c59c9efa2487c2b4066b2"
 
-SRC_URI = "git://github.com/ajaxorg/ace-builds.git;protocol=https"
+SRC_URI = "git://github.com/ajaxorg/ace-builds.git;protocol=https;branch=master"
 
 PV = "02.07.17+git${SRCPV}"
 SRCREV = "812e2c56aed246931a667f16c28b096e34597016"

--- a/meta-oe/recipes-support/avro/avro-c_1.9.2.bb
+++ b/meta-oe/recipes-support/avro/avro-c_1.9.2.bb
@@ -9,7 +9,7 @@ DEPENDS = "jansson zlib xz"
 
 BRANCH = "branch-1.9"
 SRCREV = "bf20128ca6138a830b2ea13e0490f3df6b035639"
-SRC_URI = "git://github.com/apache/avro;branch=${BRANCH} \
+SRC_URI = "git://github.com/apache/avro;branch=${BRANCH};protocol=https \
            file://0001-cmake-Use-GNUInstallDirs-instead-of-hard-coded-paths.patch;patchdir=../../ \
           "
 

--- a/meta-oe/recipes-support/bdwgc/bdwgc_8.0.4.bb
+++ b/meta-oe/recipes-support/bdwgc/bdwgc_8.0.4.bb
@@ -24,7 +24,7 @@ LIC_FILES_CHKSUM = "file://README.QUICK;md5=81b447d779e278628c843aef92f088fa"
 DEPENDS = "libatomic-ops"
 
 SRCREV = "d3dede3ce4462cd82a15f161af797ca51654546a"
-SRC_URI = "git://github.com/ivmai/bdwgc.git;branch=release-8_0"
+SRC_URI = "git://github.com/ivmai/bdwgc.git;branch=release-8_0;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/c-ares/c-ares_1.16.1.bb
+++ b/meta-oe/recipes-support/c-ares/c-ares_1.16.1.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.md;md5=fb997454c8d62aa6a47f07a8cd48b006"
 PV = "1.16.0+gitr${SRCPV}"
 
 SRC_URI = "\
-    git://github.com/c-ares/c-ares.git \
+    git://github.com/c-ares/c-ares.git;branch=master;protocol=https \
     file://cmake-install-libcares.pc.patch \
     file://0001-fix-configure-error-mv-libcares.pc.cmakein-to-libcar.patch \
     file://0001-CVE-2021-3672.patch \

--- a/meta-oe/recipes-support/c-periphery/c-periphery_2.3.1.bb
+++ b/meta-oe/recipes-support/c-periphery/c-periphery_2.3.1.bb
@@ -8,7 +8,7 @@ SECTION = "libs"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=4097ec544cf01e9c7cfc4bdf8e4ed887"
 
-SRC_URI = "git://github.com/vsergeev/c-periphery;protocol=https"
+SRC_URI = "git://github.com/vsergeev/c-periphery;protocol=https;branch=master"
 SRCREV = "23bfa4ab481edbad82a69ee385fc58ce03b63084"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/ceres-solver/ceres-solver_2.0.0.bb
+++ b/meta-oe/recipes-support/ceres-solver/ceres-solver_2.0.0.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=bb761279816b72be19d7ce646e4e2a14"
 
 DEPENDS = "libeigen glog"
 
-SRC_URI = "git://github.com/ceres-solver/ceres-solver.git"
+SRC_URI = "git://github.com/ceres-solver/ceres-solver.git;branch=master;protocol=https"
 SRCREV = "399cda773035d99eaf1f4a129a666b3c4df9d1b1"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/cli11/cli11_1.9.1.bb
+++ b/meta-oe/recipes-support/cli11/cli11_1.9.1.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=b73927b18d5c6cd8d2ed28a6ad539733"
 SRCREV = "5cb3efabce007c3a0230e4cc2e27da491c646b6c"
 PV .= "+git${SRCPV}"
 
-SRC_URI += "gitsm://github.com/CLIUtils/CLI11;branch=v1"
+SRC_URI += "gitsm://github.com/CLIUtils/CLI11;branch=v1;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/cmark/cmark_git.bb
+++ b/meta-oe/recipes-support/cmark/cmark_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/commonmark/cmark"
 LICENSE = "BSD-2-Clause & MIT"
 LIC_FILES_CHKSUM = "file://COPYING;md5=81f9cae6293cc0345a9144b78152ab62"
 
-SRC_URI = "git://github.com/commonmark/cmark.git"
+SRC_URI = "git://github.com/commonmark/cmark.git;branch=master;protocol=https"
 SRCREV = "8daa6b1495124f0b67e6034130e12d7be83e38bd"
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/consolation/consolation_0.0.8.bb
+++ b/meta-oe/recipes-support/consolation/consolation_0.0.8.bb
@@ -14,7 +14,7 @@ DEPENDS = " \
     udev \
 "
 
-SRC_URI = "git://salsa.debian.org/consolation-team/consolation.git"
+SRC_URI = "git://salsa.debian.org/consolation-team/consolation.git;branch=master"
 SRCREV = "4581eaece6e49fa2b687efbdbe23b2de452e7902"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/daemonize/daemonize_git.bb
+++ b/meta-oe/recipes-support/daemonize/daemonize_git.bb
@@ -7,7 +7,7 @@ PV = "1.7.8"
 inherit autotools
 
 SRCREV = "18869a797dab12bf1c917ba3b4782fef484c407c"
-SRC_URI = "git://github.com/bmc/daemonize.git \
+SRC_URI = "git://github.com/bmc/daemonize.git;branch=master;protocol=https \
 "
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/digitemp/digitemp_3.7.2.bb
+++ b/meta-oe/recipes-support/digitemp/digitemp_3.7.2.bb
@@ -4,7 +4,7 @@ DEPENDS = "libusb1"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=44fee82a1d2ed0676cf35478283e0aa0"
 
-SRC_URI = "git://github.com/bcl/digitemp"
+SRC_URI = "git://github.com/bcl/digitemp;branch=master;protocol=https"
 
 SRCREV = "a162e63aad35358aab325388f3d5e88121606419"
 

--- a/meta-oe/recipes-support/dstat/dstat_0.7.4.bb
+++ b/meta-oe/recipes-support/dstat/dstat_0.7.4.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 DEPENDS += "asciidoc-native xmlto-native"
 
-SRC_URI = "git://github.com/dagwieers/dstat.git \
+SRC_URI = "git://github.com/dagwieers/dstat.git;branch=master;protocol=https \
            file://0001-change-dstat-to-python3.patch \
           "
 

--- a/meta-oe/recipes-support/epeg/epeg_git.bb
+++ b/meta-oe/recipes-support/epeg/epeg_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=e7732a9290ea1e4b034fdc15cf49968d \
                     file://COPYING-PLAIN;md5=f59cacc08235a546b0c34a5422133035"
 DEPENDS = "jpeg libexif"
 
-SRC_URI = "git://github.com/mattes/epeg.git"
+SRC_URI = "git://github.com/mattes/epeg.git;branch=master;protocol=https"
 SRCREV = "9a175cd67eaa61fe45413d8da82da72936567047"
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/fmt/fmt_7.1.3.bb
+++ b/meta-oe/recipes-support/fmt/fmt_7.1.3.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://fmt.dev"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.rst;md5=af88d758f75f3c5c48a967501f24384b"
 
-SRC_URI += "git://github.com/fmtlib/fmt"
+SRC_URI += "git://github.com/fmtlib/fmt;branch=master;protocol=https"
 SRCREV = "7bdf0628b1276379886c7f6dda2cef2b3b374f0b"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/freerdp/freerdp_2.3.0.bb
+++ b/meta-oe/recipes-support/freerdp/freerdp_2.3.0.bb
@@ -14,7 +14,7 @@ PE = "1"
 PKGV = "${GITPKGVTAG}"
 
 SRCREV = "14c7f7aed7dd4e2454ee0cd81028b9f790885021"
-SRC_URI = "git://github.com/FreeRDP/FreeRDP.git;branch=stable-2.0 \
+SRC_URI = "git://github.com/FreeRDP/FreeRDP.git;branch=stable-2.0;protocol=https \
     file://winpr-makecert-Build-with-install-RPATH.patch \
 "
 

--- a/meta-oe/recipes-support/function2/function2_4.1.0.bb
+++ b/meta-oe/recipes-support/function2/function2_4.1.0.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=e4224ccaecb14d942c71d31bef20d78c"
 SRCREV = "3a0746bf5f601dfed05330aefcb6854354fce07d"
 PV .= "+git${SRCPV}"
 
-SRC_URI += "gitsm://github.com/Naios/function2"
+SRC_URI += "gitsm://github.com/Naios/function2;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/gd/gd_2.3.3.bb
+++ b/meta-oe/recipes-support/gd/gd_2.3.3.bb
@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=ace63adfdac78400fc30fa22ee9c1bb1"
 
 DEPENDS = "freetype libpng jpeg zlib tiff"
 
-SRC_URI = "git://github.com/libgd/libgd.git;nobranch=1 \
+SRC_URI = "git://github.com/libgd/libgd.git;nobranch=1;protocol=https \
           "
 
 SRCREV = "b5319a41286107b53daa0e08e402aa1819764bdc"

--- a/meta-oe/recipes-support/gflags/gflags_2.2.2.bb
+++ b/meta-oe/recipes-support/gflags/gflags_2.2.2.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/gflags/gflags"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING.txt;md5=c80d1a3b623f72bb85a4c75b556551df"
 
-SRC_URI = "git://github.com/gflags/gflags.git"
+SRC_URI = "git://github.com/gflags/gflags.git;branch=master;protocol=https"
 SRCREV = "e171aa2d15ed9eb17054558e0b3a6a413bb01067"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/glog/glog_0.4.0.bb
+++ b/meta-oe/recipes-support/glog/glog_0.4.0.bb
@@ -7,7 +7,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=dc9db360e0bbd4e46672f3fd91dd6c4b"
 
 SRC_URI = " \
-    git://github.com/google/glog.git;nobranch=1 \
+    git://github.com/google/glog.git;nobranch=1;protocol=https \
     file://0001-Find-Libunwind-during-configure.patch \
     file://libexecinfo.patch \
 "

--- a/meta-oe/recipes-support/gnulib/gnulib_2018-03-07.03.bb
+++ b/meta-oe/recipes-support/gnulib/gnulib_2018-03-07.03.bb
@@ -13,7 +13,7 @@ LICENSE = "LGPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=56a22a6e5bcce45e2c8ac184f81412b5"
 SRCREV = "0d6e3307bbdb8df4d56043d5f373eeeffe4cbef3"
 
-SRC_URI = "git://git.sv.gnu.org/gnulib.git \
+SRC_URI = "git://git.sv.gnu.org/gnulib.git;branch=master \
 "
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/gperftools/gperftools_2.9.1.bb
+++ b/meta-oe/recipes-support/gperftools/gperftools_2.9.1.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=762732742c73dc6c7fbe8632f06c059a"
 DEPENDS_append_libc-musl = " libucontext"
 
 SRCREV = "f7c6fb6c8e99d6b1b725e5994373bcd19ffdf8fd"
-SRC_URI = "git://github.com/gperftools/gperftools \
+SRC_URI = "git://github.com/gperftools/gperftools;branch=master;protocol=https \
            file://0001-Support-Atomic-ops-on-clang.patch \
            file://0001-fix-build-with-musl-libc.patch \
            file://0001-disbale-heap-checkers-and-debug-allocator-on-musl.patch \

--- a/meta-oe/recipes-support/gpm/gpm_git.bb
+++ b/meta-oe/recipes-support/gpm/gpm_git.bb
@@ -13,7 +13,7 @@ SRCREV = "e82d1a653ca94aa4ed12441424da6ce780b1e530"
 
 DEPENDS = "ncurses bison-native"
 
-SRC_URI = "git://github.com/telmich/gpm;protocol=git \
+SRC_URI = "git://github.com/telmich/gpm;protocol=https;branch=master \
            file://init \
            file://gpm.service.in \
            "

--- a/meta-oe/recipes-support/hidapi/hidapi_git.bb
+++ b/meta-oe/recipes-support/hidapi/hidapi_git.bb
@@ -10,7 +10,7 @@ DEPENDS = "libusb udev"
 
 inherit autotools pkgconfig
 
-SRC_URI = "git://github.com/libusb/hidapi.git;protocol=https \
+SRC_URI = "git://github.com/libusb/hidapi.git;protocol=https;branch=master \
            file://0001-configure.ac-remove-duplicate-AC_CONFIG_MACRO_DIR-22.patch \
 "
 PV = "0.10.1"

--- a/meta-oe/recipes-support/htop/htop_3.0.5.bb
+++ b/meta-oe/recipes-support/htop/htop_3.0.5.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4099d367cd5e59b6d4fc1ee33accb891"
 
 DEPENDS = "ncurses"
 
-SRC_URI = "git://github.com/htop-dev/htop.git \
+SRC_URI = "git://github.com/htop-dev/htop.git;branch=master;protocol=https \
            file://0001-Use-pkg-config.patch \
            "
 SRCREV = "ce6d60e7def146c13d0b8bca4642e7401a0a8995"

--- a/meta-oe/recipes-support/hunspell/hunspell-dictionaries.bb
+++ b/meta-oe/recipes-support/hunspell/hunspell-dictionaries.bb
@@ -135,7 +135,7 @@ RDEPENDS_${PN} = "hunspell"
 
 PV = "0.0.0+git${SRCPV}"
 SRCREV = "820a65e539e34a3a8c2a855d2450b84745c624ee"
-SRC_URI = "git://github.com/wooorm/dictionaries.git"
+SRC_URI = "git://github.com/wooorm/dictionaries.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/hunspell/hunspell_1.7.0.bb
+++ b/meta-oe/recipes-support/hunspell/hunspell_1.7.0.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = " \
 "
 
 SRCREV = "4ddd8ed5ca6484b930b111aec50c2750a6119a0f"
-SRC_URI = "git://github.com/${BPN}/${BPN}.git"
+SRC_URI = "git://github.com/${BPN}/${BPN}.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/hwdata/hwdata_git.bb
+++ b/meta-oe/recipes-support/hwdata/hwdata_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1556547711e8246992b999edd9445a57"
 
 PV = "0.346"
 SRCREV = "a2bff16032a68b089eeb169f09dea08094891c9c"
-SRC_URI = "git://github.com/vcrhonek/${BPN}.git"
+SRC_URI = "git://github.com/vcrhonek/${BPN}.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/iksemel/iksemel_1.5.bb
+++ b/meta-oe/recipes-support/iksemel/iksemel_1.5.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d8045f3b8f929c1cb29a1e3fd737b499"
 SRCREV = "978b733462e41efd5db72bc9974cb3b0d1d5f6fa"
 PV = "1.5+git${SRCPV}"
 
-SRC_URI = "git://github.com/meduketto/iksemel.git;protocol=https \
+SRC_URI = "git://github.com/meduketto/iksemel.git;protocol=https;branch=master \
            file://fix-configure-option-parsing.patch \
            file://avoid-obsolete-gnutls-apis.patch"
 

--- a/meta-oe/recipes-support/imagemagick/imagemagick_7.0.10.bb
+++ b/meta-oe/recipes-support/imagemagick/imagemagick_7.0.10.bb
@@ -11,7 +11,7 @@ DEPENDS = "lcms bzip2 jpeg libpng tiff zlib fftw freetype libtool"
 
 BASE_PV := "${PV}"
 PV .= "_25"
-SRC_URI = "git://github.com/ImageMagick/ImageMagick.git "
+SRC_URI = "git://github.com/ImageMagick/ImageMagick.git;branch=master;protocol=https"
 SRCREV = "8b4e00829eb84d4e7b4da11acf1f98f1e8166e5b"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/inih/libinih_git.bb
+++ b/meta-oe/recipes-support/inih/libinih_git.bb
@@ -9,7 +9,7 @@ PR = "r3"
 
 # The github repository provides a cmake and pkg-config integration
 SRCREV = "c858aff8c31fa63ef4d1e0176c10e5928cde9a23"
-SRC_URI = "git://github.com/OSSystems/inih.git \
+SRC_URI = "git://github.com/OSSystems/inih.git;branch=master;protocol=https \
            file://0001-include-install-header-files-without-prefix-dir-inih.patch \
            "
 

--- a/meta-oe/recipes-support/iniparser/iniparser_4.1.bb
+++ b/meta-oe/recipes-support/iniparser/iniparser_4.1.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=e02baf71c76e0650e667d7da133379ac"
 
 DEPENDS = "doxygen-native"
 
-SRC_URI = "git://github.com/ndevilla/iniparser.git;protocol=https \
+SRC_URI = "git://github.com/ndevilla/iniparser.git;protocol=https;branch=master \
 	   file://Add-CMake-support.patch"
 
 # tag 4.1

--- a/meta-oe/recipes-support/inotify-tools/inotify-tools_git.bb
+++ b/meta-oe/recipes-support/inotify-tools/inotify-tools_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=ac6c26e52aea428ee7f56dc2c56424c6"
 SRCREV = "98e8dfa47eb6a6ba52e35de55d2de21b274a4af8"
 PV = "3.20.11.0"
 
-SRC_URI = "git://github.com/rvoicilas/${BPN}"
+SRC_URI = "git://github.com/rvoicilas/${BPN};branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/libatasmart/libatasmart_0.19.bb
+++ b/meta-oe/recipes-support/libatasmart/libatasmart_0.19.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LGPL;md5=2d5025d4aa3495befef8f17206a5b0a1"
 DEPENDS = "udev"
 
 SRCREV = "de6258940960443038b4c1651dfda3620075e870"
-SRC_URI = "git://git.0pointer.de/libatasmart.git \
+SRC_URI = "git://git.0pointer.de/libatasmart.git;branch=master \
            file://0001-Makefile.am-add-CFLAGS-and-LDFLAGS-definiton.patch \
 "
 

--- a/meta-oe/recipes-support/libbytesize/libbytesize_2.4.bb
+++ b/meta-oe/recipes-support/libbytesize/libbytesize_2.4.bb
@@ -10,7 +10,7 @@ S = "${WORKDIR}/git"
 B = "${S}"
 
 SRCREV = "732ee8d28492e4bc9b52c29bcb81a5c19388d002"
-SRC_URI = "git://github.com/rhinstaller/libbytesize;branch=master"
+SRC_URI = "git://github.com/rhinstaller/libbytesize;branch=master;protocol=https"
 
 inherit gettext autotools python3native
 

--- a/meta-oe/recipes-support/libcereal/libcereal_1.3.0.bb
+++ b/meta-oe/recipes-support/libcereal/libcereal_1.3.0.bb
@@ -16,7 +16,7 @@ PROVIDES += "${PN}-dev"
 
 PV .= "+git${SRCPV}"
 SRCREV = "64f50dbd5cecdaba785217e2b0aeea3a4f1cdfab"
-SRC_URI = "git://github.com/USCiLab/cereal.git"
+SRC_URI = "git://github.com/USCiLab/cereal.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/libcppkafka/libcppkafka_git.bb
+++ b/meta-oe/recipes-support/libcppkafka/libcppkafka_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = " \
 file://LICENSE;md5=d8b4ca15d239dc1485ef495c8f1bcc72 \
 "
 
-SRC_URI = "git://github.com/mfontanini/cppkafka;protocol=https"
+SRC_URI = "git://github.com/mfontanini/cppkafka;protocol=https;branch=master"
 SRCREV = "5e4b350806d561473138ce7a982e8f6cf2e77733"
 
 DEPENDS = "librdkafka boost chrpath-replacement-native"

--- a/meta-oe/recipes-support/libcyusbserial/libcyusbserial_git.bb
+++ b/meta-oe/recipes-support/libcyusbserial/libcyusbserial_git.bb
@@ -8,7 +8,7 @@ DEPENDS = "libusb udev"
 PV = "1.0.0+git${SRCPV}"
 
 SRCREV = "655e2d544183d094f0e2d119c7e0c6206a0ddb3f"
-SRC_URI = "git://github.com/cyrozap/${BPN}.git"
+SRC_URI = "git://github.com/cyrozap/${BPN}.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/libfann/libfann_git.bb
+++ b/meta-oe/recipes-support/libfann/libfann_git.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.md;md5=f14599a2f089f6ff8c97e2baa4e3d575"
 inherit cmake
 
 SRCREV ?= "7ec1fc7e5bd734f1d3c89b095e630e83c86b9be1"
-SRC_URI = "git://github.com/libfann/fann.git;branch=master \
+SRC_URI = "git://github.com/libfann/fann.git;branch=master;protocol=https \
           "
 
 PV = "2.2.0+git${SRCPV}"

--- a/meta-oe/recipes-support/libgusb/libgusb_0.3.5.bb
+++ b/meta-oe/recipes-support/libgusb/libgusb_0.3.5.bb
@@ -6,7 +6,7 @@ DEPENDS = "glib-2.0 libusb"
 
 inherit meson gobject-introspection gtk-doc gettext vala
 
-SRC_URI = "git://github.com/hughsie/libgusb.git \
+SRC_URI = "git://github.com/hughsie/libgusb.git;branch=master;protocol=https \
            "
 SRCREV = "1f712812327091c42c62b1ab1148d738d1a22b51"
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/libharu/libharu_2.3.0.bb
+++ b/meta-oe/recipes-support/libharu/libharu_2.3.0.bb
@@ -6,7 +6,7 @@ DESCRIPTION = "libHaru is a library for generating PDF files. \
 LICENSE = "Zlib"
 LIC_FILES_CHKSUM = "file://README;md5=3ee6bc1f64d9cc7907f44840c8e50cb1"
 
-SRC_URI = "git://github.com/libharu/libharu.git;branch=2_3 \
+SRC_URI = "git://github.com/libharu/libharu.git;branch=2_3;protocol=https \
            file://libharu-RELEASE_2_3_0_cmake.patch \
            file://0001-Install-static-lib-into-var-libdir-rather-than-hardc.patch \
 	   "

--- a/meta-oe/recipes-support/libiio/libiio_git.bb
+++ b/meta-oe/recipes-support/libiio/libiio_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING.txt;md5=7c13b3376cea0ce68d2d2da0a1b3a72c"
 SRCREV = "565bf68eccfdbbf22cf5cb6d792e23de564665c7"
 PV = "0.21+git${SRCPV}"
 
-SRC_URI = "git://github.com/analogdevicesinc/libiio.git;protocol=https \
+SRC_URI = "git://github.com/analogdevicesinc/libiio.git;protocol=https;branch=master \
            file://0001-python-Do-not-verify-whether-libiio-is-installed-whe.patch \
 "
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>\d+(\.\d+)+)"

--- a/meta-oe/recipes-support/libmimetic/libmimetic_0.9.8.bb
+++ b/meta-oe/recipes-support/libmimetic/libmimetic_0.9.8.bb
@@ -10,7 +10,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b49da7df0ca479ef01ff7f2d799eabee"
 
 SRCREV = "50486af99b4f9b35522d7b3de40b6ce107505279"
-SRC_URI += "git://github.com/LadislavSopko/mimetic/ \
+SRC_URI += "git://github.com/LadislavSopko/mimetic/;branch=master;protocol=https \
             file://0001-libmimetic-Removing-test-directory-from-the-Makefile.patch \
             file://0001-mimetic-Check-for-MMAP_FAILED-return-from-mmap.patch \
            "

--- a/meta-oe/recipes-support/libmxml/libmxml_3.1.bb
+++ b/meta-oe/recipes-support/libmxml/libmxml_3.1.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 HOMEPAGE = "https://www.msweet.org/mxml/"
 BUGTRACKER = "https://github.com/michaelrsweet/mxml/issues"
 
-SRC_URI = "git://github.com/michaelrsweet/mxml.git"
+SRC_URI = "git://github.com/michaelrsweet/mxml.git;branch=master;protocol=https"
 SRCREV = "e483e5fd8a33386fd46967681521bdd2da2b548f"
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/libp11/libp11_0.4.11.bb
+++ b/meta-oe/recipes-support/libp11/libp11_0.4.11.bb
@@ -9,7 +9,7 @@ LICENSE = "LGPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=fad9b3332be894bab9bc501572864b29"
 DEPENDS = "libtool openssl"
 
-SRC_URI = "git://github.com/OpenSC/libp11.git"
+SRC_URI = "git://github.com/OpenSC/libp11.git;branch=master;protocol=https"
 SRCREV = "9ca6a71c890b5583c8af3b4900172626bca55e72"
 
 UPSTREAM_CHECK_GITTAGREGEX = "libp11-(?P<pver>\d+(\.\d+)+)"

--- a/meta-oe/recipes-support/librdkafka/librdkafka_1.6.1.bb
+++ b/meta-oe/recipes-support/librdkafka/librdkafka_1.6.1.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = " \
 file://LICENSE;md5=2be8675acbfdac48935e73897af5f646 \
 "
 
-SRC_URI = "git://github.com/edenhill/librdkafka;protocol=https \
+SRC_URI = "git://github.com/edenhill/librdkafka;protocol=https;branch=master \
             file://0001_fix_absolute_path_usage.patch"
 SRCREV = "1a722553638bba85dbda5050455f7b9a5ef302de"
 

--- a/meta-oe/recipes-support/librsync/librsync_2.3.2.bb
+++ b/meta-oe/recipes-support/librsync/librsync_2.3.2.bb
@@ -4,7 +4,7 @@ AUTHOR = "Martin Pool, Andrew Tridgell, Donovan Baarda, Adam Schubert"
 LICENSE = "LGPLv2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d8045f3b8f929c1cb29a1e3fd737b499"
 
-SRC_URI = "git://github.com/librsync/librsync.git"
+SRC_URI = "git://github.com/librsync/librsync.git;branch=master;protocol=https"
 SRCREV = "42b636d2a65ab6914ea7cac50886da28192aaf9b"
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/libsoc/libsoc_0.8.2.bb
+++ b/meta-oe/recipes-support/libsoc/libsoc_0.8.2.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://LICENCE;md5=e0bfebea12a718922225ba987b2126a5"
 inherit autotools pkgconfig python3-dir
 
 SRCREV = "fd1ad6e7823fa76d8db0d3c5884faffa8ffddafb"
-SRC_URI = "git://github.com/jackmitch/libsoc.git"
+SRC_URI = "git://github.com/jackmitch/libsoc.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/libteam/libteam_1.31.bb
+++ b/meta-oe/recipes-support/libteam/libteam_1.31.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 DEPENDS = "libnl libdaemon jansson"
 
-SRC_URI = "git://github.com/jpirko/libteam \
+SRC_URI = "git://github.com/jpirko/libteam;branch=master;protocol=https \
            file://0001-include-sys-select.h-for-fd_set-definition.patch \
            file://0002-teamd-Re-adjust-include-header-order.patch \
            file://0001-team_basic_test.py-disable-RedHat-specific-test.patch \

--- a/meta-oe/recipes-support/libtinyxml2/libtinyxml2_8.0.0.bb
+++ b/meta-oe/recipes-support/libtinyxml2/libtinyxml2_8.0.0.bb
@@ -4,7 +4,7 @@ SECTION = "libs"
 LICENSE = "Zlib"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=135624eef03e1f1101b9ba9ac9b5fffd"
 
-SRC_URI = "git://github.com/leethomason/tinyxml2.git"
+SRC_URI = "git://github.com/leethomason/tinyxml2.git;branch=master;protocol=https"
 
 SRCREV = "bf15233ad88390461f6ab0dbcf046cce643c5fcb"
 

--- a/meta-oe/recipes-support/libusb/libusb-compat_0.1.7.bb
+++ b/meta-oe/recipes-support/libusb/libusb-compat_0.1.7.bb
@@ -19,7 +19,7 @@ BBCLASSEXTEND = "native nativesdk"
 PE = "1"
 
 SRC_URI = " \
-    git://github.com/libusb/libusb-compat-0.1.git;protocol=https \
+    git://github.com/libusb/libusb-compat-0.1.git;protocol=https;branch=master \
     file://0001-usb.h-Include-sys-types.h.patch \
 "
 SRCREV = "4a27760ec5954ec8605e052a3207afbe0979eeef"

--- a/meta-oe/recipes-support/libusbg/libusbg_git.bb
+++ b/meta-oe/recipes-support/libusbg/libusbg_git.bb
@@ -8,7 +8,7 @@ inherit autotools update-alternatives
 
 PV = "0.1.0"
 SRCREV = "a826d136e0e8fa53815f1ba05893e6dd74208c15"
-SRC_URI = "git://github.com/libusbg/libusbg.git \
+SRC_URI = "git://github.com/libusbg/libusbg.git;branch=master;protocol=https \
            file://0001-Fix-out-of-tree-builds.patch \
           "
 

--- a/meta-oe/recipes-support/libusbgx/libusbgx_git.bb
+++ b/meta-oe/recipes-support/libusbgx/libusbgx_git.bb
@@ -11,7 +11,7 @@ PV = "0.2.0+git${SRCPV}"
 SRCREV = "45c14ef4d5d7ced0fbf984208de44ced6d5ed898"
 SRCBRANCH = "master"
 SRC_URI = " \
-    git://github.com/libusbgx/libusbgx.git;branch=${SRCBRANCH} \
+    git://github.com/libusbgx/libusbgx.git;branch=${SRCBRANCH};protocol=https \
     file://gadget-start \
     file://usbgx.initd \
     file://usbgx.service \

--- a/meta-oe/recipes-support/libutempter/libutempter.bb
+++ b/meta-oe/recipes-support/libutempter/libutempter.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=2d5025d4aa3495befef8f17206a5b0a1"
 SRCREV = "3ef74fff310f09e2601e241b9f042cd39d591018"
 PV = "1.1.6-alt2+git${SRCPV}"
 
-SRC_URI = "git://git.altlinux.org/people/ldv/packages/libutempter.git \
+SRC_URI = "git://git.altlinux.org/people/ldv/packages/libutempter.git;branch=master \
            file://0001-Fix-macro-error.patch \
            file://0002-Proper-macro-path-generation.patch \
            file://libutempter-remove-glibc-assumption.patch \

--- a/meta-oe/recipes-support/lio-utils/lio-utils_4.1.bb
+++ b/meta-oe/recipes-support/lio-utils/lio-utils_4.1.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://debian/copyright;md5=c3ea231a32635cbb5debedf3e88aa3df
 
 PV = "4.1+git${SRCPV}"
 
-SRC_URI = "git://github.com/Datera/lio-utils.git \
+SRC_URI = "git://github.com/Datera/lio-utils.git;branch=master;protocol=https \
            file://0001-Makefiles-Respect-environment-variables-and-add-LDFL.patch \
            "
 SRCREV = "0ac9091c1ff7a52d5435a4f4449e82637142e06e"

--- a/meta-oe/recipes-support/mcelog/mce-inject_git.bb
+++ b/meta-oe/recipes-support/mcelog/mce-inject_git.bb
@@ -4,7 +4,7 @@ software level into a running Linux kernel. This is intended for \
 validation of the kernel machine check handler."
 SECTION = "System Environment/Base"
 
-SRC_URI = "git://git.kernel.org/pub/scm/utils/cpu/mce/mce-inject.git"
+SRC_URI = "git://git.kernel.org/pub/scm/utils/cpu/mce/mce-inject.git;branch=master"
 
 SRCREV = "4cbe46321b4a81365ff3aafafe63967264dbfec5"
 

--- a/meta-oe/recipes-support/mcelog/mce-test_git.bb
+++ b/meta-oe/recipes-support/mcelog/mce-test_git.bb
@@ -10,7 +10,7 @@ containment and recovery, ACPI/APEI support etc."
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=0636e73ff0215e8d672dc4c32c317bb3"
 
-SRC_URI = "git://git.kernel.org/pub/scm/utils/cpu/mce/mce-test.git;protocol=git \
+SRC_URI = "git://git.kernel.org/pub/scm/utils/cpu/mce/mce-test.git;protocol=git;branch=master \
            file://makefile-remove-ldflags.patch \
            file://0001-gcov_merge.py-scov_merge.py-switch-to-python3.patch \
           "

--- a/meta-oe/recipes-support/mcelog/mcelog_175.bb
+++ b/meta-oe/recipes-support/mcelog/mcelog_175.bb
@@ -5,7 +5,7 @@ and should run on all Linux systems that need error handling."
 HOMEPAGE = "http://mcelog.org/"
 SECTION = "System Environment/Base"
 
-SRC_URI = "git://git.kernel.org/pub/scm/utils/cpu/mce/mcelog.git;protocol=http; \
+SRC_URI = "git://git.kernel.org/pub/scm/utils/cpu/mce/mcelog.git;protocol=http;;branch=master \
     file://0001-test-avoid-the-pfa-test-hang.patch \
     file://run-ptest \
 "

--- a/meta-oe/recipes-support/mg/mg_20210314.bb
+++ b/meta-oe/recipes-support/mg/mg_20210314.bb
@@ -6,7 +6,7 @@ DEPENDS = "ncurses libbsd"
 SECTION = "console/editors"
 
 SRCREV = "598f7a028f01f85f0dee0e798753bccf93233add"
-SRC_URI = "git://github.com/hboetes/mg \
+SRC_URI = "git://github.com/hboetes/mg;branch=master;protocol=https \
            file://0001-fileio-Include-sys-param.h-for-MAXNAMLEN.patch \
            file://0002-fileio-Define-DEFFILEMODE-if-platform-is-missing.patch \
            "

--- a/meta-oe/recipes-support/multipath-tools/multipath-tools_0.8.4.bb
+++ b/meta-oe/recipes-support/multipath-tools/multipath-tools_0.8.4.bb
@@ -29,7 +29,7 @@ DEPENDS = "libdevmapper \
 
 LICENSE = "GPLv2"
 
-SRC_URI = "git://git.opensvc.com/multipath-tools/.git;protocol=http \
+SRC_URI = "git://git.opensvc.com/multipath-tools/.git;protocol=http;branch=master \
            file://multipathd.oe \
            file://multipath.conf.example \
            file://0021-RH-fixup-udev-rules-for-redhat.patch \

--- a/meta-oe/recipes-support/ne10/ne10_1.2.1.bb
+++ b/meta-oe/recipes-support/ne10/ne10_1.2.1.bb
@@ -4,7 +4,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e7fe20c9be97be5579e3ab5d92d3a218"
 SECTION = "libs"
 
-SRC_URI = "git://github.com/projectNe10/Ne10.git \
+SRC_URI = "git://github.com/projectNe10/Ne10.git;branch=master;protocol=https \
            file://0001-CMakeLists.txt-Remove-mthumb-interwork.patch \
            file://0001-Dont-specify-march-explicitly.patch \
            "

--- a/meta-oe/recipes-support/opencl/clinfo_2.2.18.04.06.bb
+++ b/meta-oe/recipes-support/opencl/clinfo_2.2.18.04.06.bb
@@ -7,7 +7,7 @@ HOMEPAGE = "https://github.com/Oblomov/clinfo"
 LICENSE = "CC0-1.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=fd8857f774dfb0eefe1e80c8f9240a7e"
 
-SRC_URI = "git://github.com/Oblomov/clinfo.git;protocol=https"
+SRC_URI = "git://github.com/Oblomov/clinfo.git;protocol=https;branch=master"
 
 SRCREV = "59d0daf898e48d76ccbb788acbba258fa0a8ba7c"
 

--- a/meta-oe/recipes-support/opencv/ade_0.1.1f.bb
+++ b/meta-oe/recipes-support/opencv/ade_0.1.1f.bb
@@ -4,7 +4,7 @@ and processing framework. ADE Framework is suitable for \
 organizing data flow processing and execution."
 HOMEPAGE = "https://github.com/opencv/ade"
 
-SRC_URI = "git://github.com/opencv/ade.git \
+SRC_URI = "git://github.com/opencv/ade.git;branch=master;protocol=https \
            file://0001-use-GNUInstallDirs-for-detecting-install-paths.patch \
            "
 

--- a/meta-oe/recipes-support/opencv/opencv_4.5.2.bb
+++ b/meta-oe/recipes-support/opencv/opencv_4.5.2.bb
@@ -38,13 +38,13 @@ IPP_FILENAME = "${@ipp_filename(d)}"
 IPP_MD5 = "${@ipp_md5sum(d)}"
 
 SRCREV_FORMAT = "opencv_contrib_ipp_boostdesc_vgg"
-SRC_URI = "git://github.com/opencv/opencv.git;name=opencv \
-           git://github.com/opencv/opencv_contrib.git;destsuffix=contrib;name=contrib \
-           git://github.com/opencv/opencv_3rdparty.git;branch=ippicv/master_20191018;destsuffix=ipp;name=ipp \
-           git://github.com/opencv/opencv_3rdparty.git;branch=contrib_xfeatures2d_boostdesc_20161012;destsuffix=boostdesc;name=boostdesc \
-           git://github.com/opencv/opencv_3rdparty.git;branch=contrib_xfeatures2d_vgg_20160317;destsuffix=vgg;name=vgg \
-           git://github.com/opencv/opencv_3rdparty.git;branch=contrib_face_alignment_20170818;destsuffix=face;name=face \
-           git://github.com/WeChatCV/opencv_3rdparty.git;branch=wechat_qrcode;destsuffix=wechat_qrcode;name=wechat-qrcode \
+SRC_URI = "git://github.com/opencv/opencv.git;name=opencv;branch=master;protocol=https \
+           git://github.com/opencv/opencv_contrib.git;destsuffix=contrib;name=contrib;branch=master;protocol=https \
+           git://github.com/opencv/opencv_3rdparty.git;branch=ippicv/master_20191018;destsuffix=ipp;name=ipp;protocol=https \
+           git://github.com/opencv/opencv_3rdparty.git;branch=contrib_xfeatures2d_boostdesc_20161012;destsuffix=boostdesc;name=boostdesc;protocol=https \
+           git://github.com/opencv/opencv_3rdparty.git;branch=contrib_xfeatures2d_vgg_20160317;destsuffix=vgg;name=vgg;protocol=https \
+           git://github.com/opencv/opencv_3rdparty.git;branch=contrib_face_alignment_20170818;destsuffix=face;name=face;protocol=https \
+           git://github.com/WeChatCV/opencv_3rdparty.git;branch=wechat_qrcode;destsuffix=wechat_qrcode;name=wechat-qrcode;protocol=https \
            file://0001-3rdparty-ippicv-Use-pre-downloaded-ipp.patch \
            file://0003-To-fix-errors-as-following.patch \
            file://0001-Temporarliy-work-around-deprecated-ffmpeg-RAW-functi.patch \

--- a/meta-oe/recipes-support/opensc/opensc_0.21.0.bb
+++ b/meta-oe/recipes-support/opensc/opensc_0.21.0.bb
@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=cb8aedd3bced19bd8026d96a8b6876d7"
 
 #v0.21.0
 SRCREV = "30180986a08cf71fe4af4b50251a8bb5b1ab95af"
-SRC_URI = "git://github.com/OpenSC/OpenSC \
+SRC_URI = "git://github.com/OpenSC/OpenSC;branch=master;protocol=https \
           "
 DEPENDS = "virtual/libiconv openssl"
 

--- a/meta-oe/recipes-support/pcsc-tools/pcsc-tools_1.5.7.bb
+++ b/meta-oe/recipes-support/pcsc-tools/pcsc-tools_1.5.7.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://ludovic.rousseau.free.fr/softwares/pcsc-tools"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENCE;md5=94d55d512a9ba36caa9b7df079bae19f"
 
-SRC_URI = "git://github.com/LudovicRousseau/pcsc-tools;protocol=https"
+SRC_URI = "git://github.com/LudovicRousseau/pcsc-tools;protocol=https;branch=master"
 
 SRCREV = "34ac207adbba0d1a951b314c1676610a1d0bba01"
 

--- a/meta-oe/recipes-support/picocom/picocom_git.bb
+++ b/meta-oe/recipes-support/picocom/picocom_git.bb
@@ -9,7 +9,7 @@ PV = "${BASEPV}+git${SRCPV}"
 
 SRCREV = "90385aabe2b51f39fa130627d46b377569f82d4a"
 
-SRC_URI = "git://github.com/npat-efault/picocom \
+SRC_URI = "git://github.com/npat-efault/picocom;branch=master;protocol=https \
            file://0001-Fix-building-with-musl.patch \
            "
 

--- a/meta-oe/recipes-support/pidgin/funyahoo-plusplus_git.bb
+++ b/meta-oe/recipes-support/pidgin/funyahoo-plusplus_git.bb
@@ -7,7 +7,7 @@ DEPENDS = "pidgin json-glib glib-2.0"
 
 inherit pkgconfig
 
-SRC_URI = "git://github.com/EionRobb/funyahoo-plusplus;branch=master;protocol=git"
+SRC_URI = "git://github.com/EionRobb/funyahoo-plusplus;branch=master;protocol=https"
 SRCREV = "fbbd9c591100aa00a0487738ec7b6acd3d924b3f"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/pidgin/icyque_git.bb
+++ b/meta-oe/recipes-support/pidgin/icyque_git.bb
@@ -9,7 +9,7 @@ PV = "0.1+gitr${SRCPV}"
 
 inherit pkgconfig
 
-SRC_URI = "git://github.com/EionRobb/icyque"
+SRC_URI = "git://github.com/EionRobb/icyque;branch=master;protocol=https"
 SRCREV = "513fc162d5d1a201c2b044e2b42941436d1069d5"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/pidgin/purple-skypeweb_git.bb
+++ b/meta-oe/recipes-support/pidgin/purple-skypeweb_git.bb
@@ -7,7 +7,7 @@ DEPENDS = "pidgin json-glib glib-2.0 zlib"
 
 inherit pkgconfig
 
-SRC_URI = "git://github.com/EionRobb/skype4pidgin;branch=master;protocol=git"
+SRC_URI = "git://github.com/EionRobb/skype4pidgin;branch=master;protocol=https"
 SRCREV = "b226d1c457d73900ae89b8a7469247fbe33677a6"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/poco/poco_1.10.1.bb
+++ b/meta-oe/recipes-support/poco/poco_1.10.1.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=4267f48fc738f50380cbeeb76f95cebc"
 DEPENDS = "libpcre zlib"
 
 SRC_URI = " \
-    git://github.com/pocoproject/poco.git;branch=poco-${PV} \
+    git://github.com/pocoproject/poco.git;branch=poco-${PV};protocol=https \
     file://0001-Add-support-of-arch-riscv32.patch \
     file://run-ptest \
    "

--- a/meta-oe/recipes-support/pps-tools/pps-tools_1.0.2.bb
+++ b/meta-oe/recipes-support/pps-tools/pps-tools_1.0.2.bb
@@ -5,7 +5,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
 
 SRCREV = "cb48b7ecf7079ceba7081c78d4e61e507b0e8d2d"
-SRC_URI = "git://github.com/ago/pps-tools.git"
+SRC_URI = "git://github.com/ago/pps-tools.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/re2/re2_2020.11.01.bb
+++ b/meta-oe/recipes-support/re2/re2_2020.11.01.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b5c31eb512bdf3cb11ffd5713963760"
 
 SRCREV = "166dbbeb3b0ab7e733b278e8f42a84f6882b8a25"
 
-SRC_URI = "git://github.com/google/re2.git;branch=master"
+SRC_URI = "git://github.com/google/re2.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/rsnapshot/rsnapshot_git.bb
+++ b/meta-oe/recipes-support/rsnapshot/rsnapshot_git.bb
@@ -25,7 +25,7 @@ RDEPENDS_${PN} = "rsync \
 SRCREV = "a9e29850fc33c503c289e245c7bad350eed746d9"
 PV = "1.4.3+git${SRCPV}"
 
-SRC_URI = "git://github.com/DrHyde/${BPN};branch=master;protocol=git \
+SRC_URI = "git://github.com/DrHyde/${BPN};branch=master;protocol=https \
            file://configure-fix-cmd_rsync.patch \
           "
 

--- a/meta-oe/recipes-support/sass/libsass_git.bb
+++ b/meta-oe/recipes-support/sass/libsass_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=8f34396ca205f5e119ee77aae91fa27d"
 
 inherit autotools
 
-SRC_URI = "git://github.com/sass/libsass.git;branch=master"
+SRC_URI = "git://github.com/sass/libsass.git;branch=master;protocol=https"
 SRCREV = "8d312a1c91bb7dd22883ebdfc829003f75a82396"
 PV = "3.6.4"
 

--- a/meta-oe/recipes-support/sass/sassc_git.bb
+++ b/meta-oe/recipes-support/sass/sassc_git.bb
@@ -6,7 +6,7 @@ DEPENDS = "libsass"
 
 inherit autotools pkgconfig
 
-SRC_URI = "git://github.com/sass/sassc.git"
+SRC_URI = "git://github.com/sass/sassc.git;branch=master;protocol=https"
 SRCREV = "46748216ba0b60545e814c07846ca10c9fefc5b6"
 S = "${WORKDIR}/git"
 PV = "3.6.1"

--- a/meta-oe/recipes-support/satyr/satyr_0.37.bb
+++ b/meta-oe/recipes-support/satyr/satyr_0.37.bb
@@ -7,7 +7,7 @@ LICENSE = "GPLv2"
 
 inherit autotools-brokensep python3native pkgconfig
 
-SRC_URI = "git://github.com/abrt/satyr.git \
+SRC_URI = "git://github.com/abrt/satyr.git;branch=master;protocol=https \
            file://0002-fix-compile-failure-against-musl-C-library.patch \
 "
 SRCREV = "4a7d0a31cdeee23bb13739f57926188a795bdf25"

--- a/meta-oe/recipes-support/serial-utils/pty-forward-native.bb
+++ b/meta-oe/recipes-support/serial-utils/pty-forward-native.bb
@@ -6,7 +6,7 @@ SECTION = "console/network"
 SRCREV = "00dbec2636ae0385ad028587e20e446272ff97ec"
 PV = "1.1+gitr${SRCPV}"
 
-SRC_URI = "git://github.com/freesmartphone/cornucopia.git;protocol=https"
+SRC_URI = "git://github.com/freesmartphone/cornucopia.git;protocol=https;branch=master"
 S = "${WORKDIR}/git/tools/serial_forward"
 
 inherit autotools native

--- a/meta-oe/recipes-support/serial-utils/serial-forward_git.bb
+++ b/meta-oe/recipes-support/serial-utils/serial-forward_git.bb
@@ -6,7 +6,7 @@ SECTION = "console/devel"
 SRCREV = "07c6fdede0870edc37a8d51d033b6e7e29aa7c91"
 PV = "1.1+gitr${SRCPV}"
 
-SRC_URI = "git://github.com/freesmartphone/cornucopia.git \
+SRC_URI = "git://github.com/freesmartphone/cornucopia.git;branch=master;protocol=https \
            file://0001-serial_forward-Disable-default-static-linking.patch;striplevel=3 \
           "
 S = "${WORKDIR}/git/tools/serial_forward"

--- a/meta-oe/recipes-support/span-lite/span-lite_0.8.1.bb
+++ b/meta-oe/recipes-support/span-lite/span-lite_0.8.1.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/martinmoene/span-lite"
 LICENSE = "BSL-1.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=e4224ccaecb14d942c71d31bef20d78c"
 
-SRC_URI += "git://github.com/martinmoene/span-lite"
+SRC_URI += "git://github.com/martinmoene/span-lite;branch=master;protocol=https"
 SRCREV = "937262f25fb702592cbc5c772111a73a5e3c1e07"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/spdlog/spdlog_1.8.2.bb
+++ b/meta-oe/recipes-support/spdlog/spdlog_1.8.2.bb
@@ -4,7 +4,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 SRCREV = "de0dbfa3596a18cd70a4619b6a9766847a941276"
-SRC_URI = "git://github.com/gabime/spdlog.git;protocol=git;branch=v1.x; \
+SRC_URI = "git://github.com/gabime/spdlog.git;protocol=https;branch=v1.x; \
            file://0001-Enable-use-of-external-fmt-library.patch"
 
 DEPENDS += "fmt"

--- a/meta-oe/recipes-support/spitools/spitools_git.bb
+++ b/meta-oe/recipes-support/spitools/spitools_git.bb
@@ -10,7 +10,7 @@ SRCREV = "67937230d70ad87c23c7116a72df83577e309f6f"
 
 S = "${WORKDIR}/git"
 
-SRC_URI = "git://github.com/cpb-/spi-tools.git;protocol=git"
+SRC_URI = "git://github.com/cpb-/spi-tools.git;protocol=https;branch=master"
 
 
 inherit autotools

--- a/meta-oe/recipes-support/thin-provisioning-tools/thin-provisioning-tools_0.8.5.bb
+++ b/meta-oe/recipes-support/thin-provisioning-tools/thin-provisioning-tools_0.8.5.bb
@@ -7,7 +7,7 @@ SECTION = "devel"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 S = "${WORKDIR}/git"
 
-SRC_URI = "git://github.com/jthornber/thin-provisioning-tools;branch=main \
+SRC_URI = "git://github.com/jthornber/thin-provisioning-tools;branch=main;protocol=https \
            file://0001-do-not-strip-pdata_tools-at-do_install.patch \
            file://use-sh-on-path.patch \
 "

--- a/meta-oe/recipes-support/toscoterm/toscoterm_git.bb
+++ b/meta-oe/recipes-support/toscoterm/toscoterm_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://main.c;start_line=5;end_line=16;md5=9ae4bf20caf291afa
 
 # 0.2 version
 SRCREV = "8586d617aed19fc75f5ae1e07270752c1b2f9a30"
-SRC_URI = "git://github.com/OSSystems/toscoterm.git"
+SRC_URI = "git://github.com/OSSystems/toscoterm.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/udisks/udisks2_2.9.2.bb
+++ b/meta-oe/recipes-support/udisks/udisks2_2.9.2.bb
@@ -17,7 +17,7 @@ DEPENDS += "${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)}"
 
 RDEPENDS_${PN} = "acl"
 
-SRC_URI = "git://github.com/storaged-project/udisks.git;branch=master"
+SRC_URI = "git://github.com/storaged-project/udisks.git;branch=master;protocol=https"
 SRCREV = "da6d9480fefeb0ffdf8a84626b5096827d8d7030"
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/uhubctl/uhubctl_2.3.0.bb
+++ b/meta-oe/recipes-support/uhubctl/uhubctl_2.3.0.bb
@@ -7,7 +7,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRCREV = "1b52efddbd68b4395df3ac9cd10eeb984af22439"
-SRC_URI = "git://github.com/mvp/${BPN}"
+SRC_URI = "git://github.com/mvp/${BPN};branch=master;protocol=https"
 S = "${WORKDIR}/git"
 
 # uhubctl gets its program version from "git describe". As we use the source

--- a/meta-oe/recipes-support/uthash/uthash_2.3.0.bb
+++ b/meta-oe/recipes-support/uthash/uthash_2.3.0.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=736712b5904dd42f8678df7172bc5f2b"
 SRCREV = "e493aa90a2833b4655927598f169c31cfcdf7861"
 
 SRC_URI = "\
-    git://github.com/troydhanson/${BPN}.git \
+    git://github.com/troydhanson/${BPN}.git;branch=master;protocol=https \
     file://run-ptest \
 "
 

--- a/meta-oe/recipes-support/utouch/utouch-evemu_git.bb
+++ b/meta-oe/recipes-support/utouch/utouch-evemu_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=f27defe1e96c2e1ecd4e0c9be8967949"
 
 inherit autotools
 
-SRC_URI = "git://bitmath.org/git/evemu.git;protocol=http \
+SRC_URI = "git://bitmath.org/git/evemu.git;protocol=http;branch=master \
            file://0001-Fix-build-on-32bit-arches-with-64bit-time_t.patch \
            "
 SRCREV = "9752b50e922572e4cd214ac45ed95e4ee410fe24"

--- a/meta-oe/recipes-support/utouch/utouch-frame_git.bb
+++ b/meta-oe/recipes-support/utouch/utouch-frame_git.bb
@@ -9,7 +9,7 @@ DEPENDS += "mtdev utouch-evemu"
 
 inherit autotools pkgconfig
 
-SRC_URI = "git://bitmath.org/git/frame.git;protocol=http \
+SRC_URI = "git://bitmath.org/git/frame.git;protocol=http;branch=master \
            file://remove-man-page-creation.patch \
            file://0001-include-sys-stat.h-for-fixing-build-issue-on-musl.patch \
            file://0001-Fix-build-on-32bit-arches-with-64bit-time_t.patch \

--- a/meta-oe/recipes-support/utouch/utouch-mtview_git.bb
+++ b/meta-oe/recipes-support/utouch/utouch-mtview_git.bb
@@ -9,7 +9,7 @@ inherit autotools pkgconfig features_check
 # depends on virtual/libx11
 REQUIRED_DISTRO_FEATURES = "x11"
 
-SRC_URI = "git://bitmath.org/git/mtview.git;protocol=http"
+SRC_URI = "git://bitmath.org/git/mtview.git;protocol=http;branch=master"
 SRCREV = "ad437c38dc111cf3990a03abf14efe1b5d89604b"
 
 DEPENDS += "mtdev utouch-frame utouch-evemu libx11"

--- a/meta-oe/recipes-support/websocketpp/websocketpp_0.8.2.bb
+++ b/meta-oe/recipes-support/websocketpp/websocketpp_0.8.2.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://${S}/COPYING;md5=4d168d763c111f4ffc62249870e4e0ea"
 
 DEPENDS = " ${@bb.utils.contains('DISTRO_FEATURES', 'ptest', 'openssl boost zlib', '', d)} "
 
-SRC_URI = "git://github.com/zaphoyd/websocketpp.git;protocol=https \
+SRC_URI = "git://github.com/zaphoyd/websocketpp.git;protocol=https;branch=master \
            file://0001-cmake-Use-GNUInstallDirs.patch \
            file://855.patch \
            file://857.patch \

--- a/meta-oe/recipes-support/xdelta/xdelta3_3.1.0.bb
+++ b/meta-oe/recipes-support/xdelta/xdelta3_3.1.0.bb
@@ -7,7 +7,7 @@ SECTION = "console/utils"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=393a5ca445f6965873eca0259a17f833"
 
-SRC_URI = "git://github.com/jmacd/xdelta.git;branch=release3_1_apl"
+SRC_URI = "git://github.com/jmacd/xdelta.git;branch=release3_1_apl;protocol=https"
 SRCREV = "4b4aed71a959fe11852e45242bb6524be85d3709"
 S = "${WORKDIR}/git/xdelta3"
 

--- a/meta-oe/recipes-support/xorg-xrdp/xorgxrdp_0.2.5.bb
+++ b/meta-oe/recipes-support/xorg-xrdp/xorgxrdp_0.2.5.bb
@@ -10,7 +10,7 @@ DEPENDS = "virtual/libx11 xserver-xorg xrdp nasm-native"
 inherit features_check
 REQUIRED_DISTRO_FEATURES = "x11 pam"
 
-SRC_URI = "git://github.com/neutrinolabs/xorgxrdp.git"
+SRC_URI = "git://github.com/neutrinolabs/xorgxrdp.git;branch=master;protocol=https"
 
 SRCREV = "c122544f184d4031bbae1ad80fbab554c34a9427"
 

--- a/meta-oe/recipes-support/xrdp/xrdp_0.9.15.bb
+++ b/meta-oe/recipes-support/xrdp/xrdp_0.9.15.bb
@@ -10,7 +10,7 @@ DEPENDS = "openssl virtual/libx11 libxfixes libxrandr libpam nasm-native"
 
 REQUIRED_DISTRO_FEATURES = "x11 pam"
 
-SRC_URI = "git://github.com/neutrinolabs/xrdp.git;branch=devel \
+SRC_URI = "git://github.com/neutrinolabs/xrdp.git;branch=devel;protocol=https \
            file://xrdp.sysconfig \
            file://0001-Added-req_distinguished_name-in-etc-xrdp-openssl.con.patch \
            file://0001-Fix-the-compile-error.patch \

--- a/meta-oe/recipes-support/yaml-cpp/yaml-cpp_0.6.3.bb
+++ b/meta-oe/recipes-support/yaml-cpp/yaml-cpp_0.6.3.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=6a8aaf0595c2efc1a9c2e0913e9c1a2c"
 
 # yaml-cpp releases are stored as archive files in github.
 # download the exact revision of release
-SRC_URI = "git://github.com/jbeder/yaml-cpp.git"
+SRC_URI = "git://github.com/jbeder/yaml-cpp.git;branch=master;protocol=https"
 SRCREV = "9a3624205e8774953ef18f57067b3426c1c5ada6"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/zbar/zbar_git.bb
+++ b/meta-oe/recipes-support/zbar/zbar_git.bb
@@ -9,7 +9,7 @@ SECTION = "graphics"
 LICENSE = "LGPL-2.1"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=5e9ee833a2118adc7d8b5ea38e5b1cef"
 
-SRC_URI = "git://github.com/mchehab/zbar.git;branch=master \
+SRC_URI = "git://github.com/mchehab/zbar.git;branch=master;protocol=https \
     file://0001-qt-Create-subdir-in-Makefile.patch \
     file://0002-zbarcam-Create-subdir-in-Makefile.patch \
 "

--- a/meta-oe/recipes-support/zchunk/zchunk_1.1.9.bb
+++ b/meta-oe/recipes-support/zchunk/zchunk_1.1.9.bb
@@ -4,7 +4,7 @@ AUTHOR = "Jonathan Dieter"
 LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=cd6e590282010ce90a94ef25dd31410f"
 
-SRC_URI = "git://github.com/zchunk/zchunk.git;protocol=https"
+SRC_URI = "git://github.com/zchunk/zchunk.git;protocol=https;branch=master"
 
 SRCREV = "fe3e3af49fd30b68c21a9fcaac340ad8e7f91055"
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-test/bats/bats_1.3.0.bb
+++ b/meta-oe/recipes-test/bats/bats_1.3.0.bb
@@ -6,7 +6,7 @@ HOMEPAGE = "https://github.com/bats-core/bats-core"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=2970203aedf9e829edb96a137a4fe81b"
 
-SRC_URI = "git://github.com/bats-core/bats-core.git \
+SRC_URI = "git://github.com/bats-core/bats-core.git;branch=master;protocol=https \
           "
 # v1.3.0
 SRCREV = "9086c47854652f2731861b40385689c85f12103f"

--- a/meta-oe/recipes-test/catch2/catch2_2.13.4.bb
+++ b/meta-oe/recipes-test/catch2/catch2_2.13.4.bb
@@ -5,7 +5,7 @@ HOMEPAGE = "https://github.com/catchorg/Catch2"
 LICENSE = "BSL-1.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=e4224ccaecb14d942c71d31bef20d78c"
 
-SRC_URI = "git://github.com/catchorg/Catch2.git;branch=v2.x"
+SRC_URI = "git://github.com/catchorg/Catch2.git;branch=v2.x;protocol=https"
 SRCREV = "de6fe184a9ac1a06895cdd1c9b437f0a0bdf14ad"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-test/cmocka/cmocka_1.1.5.bb
+++ b/meta-oe/recipes-test/cmocka/cmocka_1.1.5.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 SRCREV = "a4fc3dd7705c277e3a57432895e9852ea105dac9"
 PV .= "+git${SRCPV}"
-SRC_URI = "git://git.cryptomilk.org/projects/cmocka.git \
+SRC_URI = "git://git.cryptomilk.org/projects/cmocka.git;branch=master \
            file://run-ptest \
           "
 

--- a/meta-oe/recipes-test/evtest/evtest_1.34.bb
+++ b/meta-oe/recipes-test/evtest/evtest_1.34.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
 DEPENDS = "libxml2"
 
 SRCREV = "16e5104127a620686bdddc4a9ad62881134d6c69"
-SRC_URI = "git://gitlab.freedesktop.org/libevdev/evtest.git;protocol=https \
+SRC_URI = "git://gitlab.freedesktop.org/libevdev/evtest.git;protocol=https;branch=master \
            file://add_missing_limits_h_include.patch \
            file://0001-Fix-build-on-32bit-arches-with-64bit-time_t.patch \
            "

--- a/meta-oe/recipes-test/fbtest/fb-test_git.bb
+++ b/meta-oe/recipes-test/fbtest/fb-test_git.bb
@@ -6,7 +6,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=eb723b61539feef013de476e68b5c50a"
 
 SRCREV = "063ec650960c2d79ac51f5c5f026cb05343a33e2"
-SRC_URI = "git://github.com/prpplague/fb-test-app.git"
+SRC_URI = "git://github.com/prpplague/fb-test-app.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-test/googletest/googletest_git.bb
+++ b/meta-oe/recipes-test/googletest/googletest_git.bb
@@ -11,7 +11,7 @@ PROVIDES += "gmock gtest"
 
 S = "${WORKDIR}/git"
 SRCREV = "703bd9caab50b139428cea1aaff9974ebee5742e"
-SRC_URI = "git://github.com/google/googletest.git"
+SRC_URI = "git://github.com/google/googletest.git;branch=master;protocol=https"
 
 inherit cmake
 

--- a/meta-perl/recipes-perl/po4a/po4a_0.49.bb
+++ b/meta-perl/recipes-perl/po4a/po4a_0.49.bb
@@ -6,7 +6,7 @@ HOMEPAGE = "https://po4a.alioth.debian.org"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=a96fc9b4cc36d80659e694ea109f0325"
 
-SRC_URI = "git://github.com/mquinson/po4a.git;protocol=https"
+SRC_URI = "git://github.com/mquinson/po4a.git;protocol=https;branch=master"
 
 # v0.49
 SRCREV = "79ed87a577a543538fe39c7b60079981f5997072"

--- a/meta-python/recipes-connectivity/python-txws/python3-txws_0.9.1.bb
+++ b/meta-python/recipes-connectivity/python-txws/python3-txws_0.9.1.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=76699830db7fa9e897f6a1ad05f98ec8"
 
 DEPENDS = "python3-twisted python3-six python3-vcversioner python3-six-native python3-vcversioner-native"
 
-SRC_URI = "git://github.com/MostAwesomeDude/txWS.git"
+SRC_URI = "git://github.com/MostAwesomeDude/txWS.git;branch=master;protocol=https"
 SRCREV= "88cf6d9b9b685ffa1720644bd53c742afb10a414"
 
 S = "${WORKDIR}/git"

--- a/meta-python/recipes-devtools/gyp/gyp_git.bb
+++ b/meta-python/recipes-devtools/gyp/gyp_git.bb
@@ -4,7 +4,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ab828cb8ce4c62ee82945a11247b6bbd"
 SECTION = "devel"
 
-SRC_URI = "git://chromium.googlesource.com/external/gyp;protocol=https"
+SRC_URI = "git://chromium.googlesource.com/external/gyp;protocol=https;branch=master"
 SRCREV = "caa60026e223fc501e8b337fd5086ece4028b1c6"
 
 S = "${WORKDIR}/git"

--- a/meta-python/recipes-devtools/python/python3-astor_0.8.1.bb
+++ b/meta-python/recipes-devtools/python/python3-astor_0.8.1.bb
@@ -4,7 +4,7 @@ SECTION = "devel/python"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=561205fdabc3ec52cae2d30815b8ade7"
 
-SRC_URI = "git://github.com/berkerpeksag/astor.git \
+SRC_URI = "git://github.com/berkerpeksag/astor.git;branch=master;protocol=https \
            file://0001-rtrip.py-convert-to-python3.patch \
 "
 SRCREV ?= "c7553c79f9222e20783fe9bd8a553f932e918072"

--- a/meta-python/recipes-devtools/python/python3-cvxopt_1.2.6.bb
+++ b/meta-python/recipes-devtools/python/python3-cvxopt_1.2.6.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://cvxopt.org"
 LICENSE = "GPL-3.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ba1a8a73d8ebea5c47a1173aaf476ddd"
 
-SRC_URI = "git://github.com/cvxopt/cvxopt;protocol=https"
+SRC_URI = "git://github.com/cvxopt/cvxopt;protocol=https;branch=master"
 
 SRCREV = "60fdb838e0bb2d8f32ba51129552c83b55acd2a7"
 

--- a/meta-python/recipes-devtools/python/python3-dbussy_1.3.bb
+++ b/meta-python/recipes-devtools/python/python3-dbussy_1.3.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/ldo/dbussy"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=a916467b91076e631dd8edb7424769c7"
 
-SRC_URI = "git://github.com/ldo/dbussy.git"
+SRC_URI = "git://github.com/ldo/dbussy.git;branch=master;protocol=https"
 
 SRCREV = "37ede4242b48def73ada46c2747a4c5cae6abf45"
 

--- a/meta-python/recipes-devtools/python/python3-dt-schema_git.bb
+++ b/meta-python/recipes-devtools/python/python3-dt-schema_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://setup.py;beginline=2;endline=3;md5=c795d4924c5f739424
 
 inherit setuptools3
 
-SRC_URI = "git://github.com/robherring/dt-schema.git"
+SRC_URI = "git://github.com/robherring/dt-schema.git;branch=master;protocol=https"
 SRCREV = "5009e47c1c76e48871f5988e08dad61f3c91196b"
 PV = "0.1+git${SRCPV}"
 

--- a/meta-python/recipes-devtools/python/python3-feedformatter_0.4.bb
+++ b/meta-python/recipes-devtools/python/python3-feedformatter_0.4.bb
@@ -4,7 +4,7 @@ SECTION = "devel/python"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=258e3f39e2383fbd011035d04311008d"
 
-SRC_URI = "git://github.com/marianoguerra/feedformatter.git"
+SRC_URI = "git://github.com/marianoguerra/feedformatter.git;branch=master;protocol=https"
 SRCREV = "7391193c83e10420b5a2d8ef846d23fc368c6d85"
 
 S = "${WORKDIR}/git"

--- a/meta-python/recipes-devtools/python/python3-keras-applications_1.0.8.bb
+++ b/meta-python/recipes-devtools/python/python3-keras-applications_1.0.8.bb
@@ -4,7 +4,7 @@ SECTION = "devel/python"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=366e2fd3c9714f162d3663b6f97cfe41"
 
-SRC_URI = "git://github.com/keras-team/keras-applications.git"
+SRC_URI = "git://github.com/keras-team/keras-applications.git;branch=master;protocol=https"
 SRCREV ?= "3b180cb10eda683dda7913ecee2e6487288d292d"
 
 

--- a/meta-python/recipes-devtools/python/python3-monotonic_1.6.bb
+++ b/meta-python/recipes-devtools/python/python3-monotonic_1.6.bb
@@ -6,7 +6,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d2794c0df5b907fdace235a619d80314"
 
 SRCREV = "80681f6604e136e513550342f977edb98f5fc5ad"
-SRC_URI = "git://github.com/atdt/monotonic.git"
+SRC_URI = "git://github.com/atdt/monotonic.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-python/recipes-devtools/python/python3-ntplib_0.3.4.bb
+++ b/meta-python/recipes-devtools/python/python3-ntplib_0.3.4.bb
@@ -3,7 +3,7 @@ SECTION = "devel/python"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://ntplib.py;beginline=1;endline=23;md5=afa07338a9595257e94c205c3e72224d"
 
-SRC_URI = "git://github.com/cf-natali/ntplib.git"
+SRC_URI = "git://github.com/cf-natali/ntplib.git;branch=master;protocol=https"
 SRCREV ?= "aea7925c26152024ca8cf207e77f403f8127727a"
 
 S = "${WORKDIR}/git"

--- a/meta-python/recipes-devtools/python/python3-pillow_8.2.0.bb
+++ b/meta-python/recipes-devtools/python/python3-pillow_8.2.0.bb
@@ -5,7 +5,7 @@ HOMEPAGE = "https://pillow.readthedocs.io"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=0337b116233da4616ae9fdb130bf6f1a"
 
-SRC_URI = "git://github.com/python-pillow/Pillow.git;branch=8.2.x \
+SRC_URI = "git://github.com/python-pillow/Pillow.git;branch=8.2.x;protocol=https \
            file://0001-support-cross-compiling.patch \
            file://0001-explicitly-set-compile-options.patch \
            file://0001-Limit-sprintf-modes-to-10-characters.patch \

--- a/meta-python/recipes-devtools/python/python3-prctl_1.8.1.bb
+++ b/meta-python/recipes-devtools/python/python3-prctl_1.8.1.bb
@@ -13,7 +13,7 @@ B = "${S}"
 SRCREV = "5e12e398eb5c4e30d7b29b02458c76d2cc780700"
 PV = "1.8.1+git${SRCPV}"
 
-SRC_URI = "git://github.com/seveas/python-prctl;branch=main\
+SRC_URI = "git://github.com/seveas/python-prctl;branch=main;protocol=https \
            file://0001-support-cross-complication.patch \
 "
 inherit setuptools3 python3native

--- a/meta-python/recipes-devtools/python/python3-pybind11-json_0.2.6.bb
+++ b/meta-python/recipes-devtools/python/python3-pybind11-json_0.2.6.bb
@@ -3,7 +3,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=0e25ff0ec476d06d366439e1120cce98"
 
 SRCREV = "d1d00888bc0eb7c50dde6cff1a5eb4586e620b65"
-SRC_URI = "git://github.com/pybind/pybind11_json"
+SRC_URI = "git://github.com/pybind/pybind11_json;branch=master;protocol=https"
 
 DEPENDS += "nlohmann-json python3-pybind11"
 

--- a/meta-python/recipes-devtools/python/python3-pybind11_2.6.2.bb
+++ b/meta-python/recipes-devtools/python/python3-pybind11_2.6.2.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=774f65abd8a7fe3124be2cdf766cd06f"
 
 DEPENDS = "boost"
 
-SRC_URI = "git://github.com/pybind/pybind11.git \
+SRC_URI = "git://github.com/pybind/pybind11.git;branch=master;protocol=https \
            file://0001-Do-not-strip-binaries.patch \
            file://0001-Do-not-check-pointer-size-when-cross-compiling.patch \
 "

--- a/meta-python/recipes-devtools/python/python3-pydbus-manager_git.bb
+++ b/meta-python/recipes-devtools/python/python3-pydbus-manager_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=0fd5bb1dae91ba145745db55870be6a7"
 
 inherit setuptools3
 
-SRC_URI = "git://github.com/seebz/pydbus-manager.git"
+SRC_URI = "git://github.com/seebz/pydbus-manager.git;branch=master;protocol=https"
 SRCREV = "6b576b969cbda50521dca62a7df929167207f9fc"
 PV = "git${SRCPV}"
 

--- a/meta-python/recipes-devtools/python/python3-xlrd_2.0.1.bb
+++ b/meta-python/recipes-devtools/python/python3-xlrd_2.0.1.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=00ea1e843a43c20d9b63a8112239b0d1"
 SRC_URI[sha256sum] = "f72f148f54442c6b056bf931dbc34f986fd0c3b0b6b5a58d013c9aef274d0c88"
 
 
-SRC_URI = "git://github.com/python-excel/xlrd.git \
+SRC_URI = "git://github.com/python-excel/xlrd.git;branch=master;protocol=https \
            file://run-ptest \
 "
 SRCREV = "b8d573e11ec149da695d695c81a156232b89a949"

--- a/meta-python/recipes-extended/python-blivet/python3-blivet_3.1.4.bb
+++ b/meta-python/recipes-extended/python-blivet/python3-blivet_3.1.4.bb
@@ -9,7 +9,7 @@ S = "${WORKDIR}/git"
 B = "${S}"
 
 SRCREV = "9b5ad2d5b5df159963e1c6c24523e1dfe1f71435"
-SRC_URI = "git://github.com/rhinstaller/blivet;branch=3.1-release \
+SRC_URI = "git://github.com/rhinstaller/blivet;branch=3.1-release;protocol=https \
            file://0001-comment-out-selinux.patch \
            file://0002-run_program-support-timeout.patch \
            file://0003-support-infinit-timeout.patch \

--- a/meta-python/recipes-extended/python-blivet/python3-blivetgui_2.1.10.bb
+++ b/meta-python/recipes-extended/python-blivet/python3-blivetgui_2.1.10.bb
@@ -9,7 +9,7 @@ S = "${WORKDIR}/git"
 B = "${S}"
 
 SRCREV = "67ec0b7a0e065ba24ab87963409bfb21b2aac6dd"
-SRC_URI = "git://github.com/rhinstaller/blivet-gui;branch=master \
+SRC_URI = "git://github.com/rhinstaller/blivet-gui;branch=master;protocol=https \
            file://0001-Fix-return-type-of-BlivetUtils.get_disks-1658893.patch \
 "
 

--- a/meta-python/recipes-extended/python-cson/python3-cson_git.bb
+++ b/meta-python/recipes-extended/python-cson/python3-cson_git.bb
@@ -8,7 +8,7 @@ SECTION = "devel/python"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=7709d2635e63ab96973055a23c2a4cac"
 
 SRCREV = "f3f2898c44bb16b951d3e9f2fbf6d1c4158edda2"
-SRC_URI = "git://github.com/gt3389b/python-cson.git"
+SRC_URI = "git://github.com/gt3389b/python-cson.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-webserver/recipes-httpd/apache-mod/apache-websocket_git.bb
+++ b/meta-webserver/recipes-httpd/apache-mod/apache-websocket_git.bb
@@ -11,7 +11,7 @@ RDEPENDS_${PN} += "apache2"
 
 # Original (github.com/disconnect/apache-websocket) is dead since 2012, the
 # fork contains patches from the modules ML and fixes CVE compliance issues
-SRC_URI = "git://github.com/jchampio/apache-websocket.git"
+SRC_URI = "git://github.com/jchampio/apache-websocket.git;branch=master;protocol=https"
 
 SRCREV = "0ee34c77fc78ff08fd548706300b80a7bc7874e4"
 

--- a/meta-webserver/recipes-httpd/cherokee/cherokee_git.bb
+++ b/meta-webserver/recipes-httpd/cherokee/cherokee_git.bb
@@ -9,7 +9,7 @@ DEPENDS = "unzip-native libpcre openssl mysql5 ${@bb.utils.contains('DISTRO_FEAT
 
 SRCREV = "9a75e65b876bcc376cb6b379dca1f7ce4a055c59"
 PV = "1.2.104+git${SRCPV}"
-SRC_URI = "git://github.com/cherokee/webserver \
+SRC_URI = "git://github.com/cherokee/webserver;branch=master;protocol=https \
            file://cherokee.init \
            file://cherokee.service \
            file://cherokee-install-configured.py-once.patch \

--- a/meta-webserver/recipes-httpd/sthttpd/sthttpd_2.27.1.bb
+++ b/meta-webserver/recipes-httpd/sthttpd/sthttpd_2.27.1.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/thttpd.c;beginline=1;endline=26;md5=0c5762c2c34dc
 DEPENDS += "base-passwd virtual/crypt"
 
 SRCREV = "2845bf5bff2b820d2336c8c8061cbfc5f271e720"
-SRC_URI = "git://github.com/blueness/${BPN} \
+SRC_URI = "git://github.com/blueness/${BPN};branch=master;protocol=https \
            file://thttpd.service \
            file://thttpd.conf \
            file://init"

--- a/meta-webserver/recipes-support/fcgi/fcgi_git.bb
+++ b/meta-webserver/recipes-support/fcgi/fcgi_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.TERMS;md5=e3aacac3a647af6e7e31f181cda0a06a"
 SRCREV = "382aa2b0d53a87c27f2f647dfaf670375ba0b85f"
 PV = "2.4.2"
 
-SRC_URI = "git://github.com/FastCGI-Archives/fcgi2.git;protocol=https \
+SRC_URI = "git://github.com/FastCGI-Archives/fcgi2.git;protocol=https;branch=master \
           "
 
 S = "${WORKDIR}/git"

--- a/meta-webserver/recipes-webadmin/netdata/netdata_git.bb
+++ b/meta-webserver/recipes-webadmin/netdata/netdata_git.bb
@@ -3,7 +3,7 @@ SUMMARY = "Real-time performance monitoring"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=fc9b848046ef54b5eaee6071947abd24"
 
-SRC_URI = "git://github.com/firehol/netdata.git;protocol=https"
+SRC_URI = "git://github.com/firehol/netdata.git;protocol=https;branch=master"
 SRCREV = "1be9200ba8e11dc81a2101d85a2725137d43f766"
 PV = "1.22.1"
 

--- a/meta-xfce/recipes-apps/xarchiver/xarchiver_git.bb
+++ b/meta-xfce/recipes-apps/xarchiver/xarchiver_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 
 DEPENDS = "gtk+3 glib-2.0 xfce4-dev-tools-native intltool-native"
 
-SRC_URI = "git://github.com/ib/xarchiver.git"
+SRC_URI = "git://github.com/ib/xarchiver.git;branch=master;protocol=https"
 SRCREV = "9ab958a4023b62b43972c55a3143ff0722bd88a6"
 PV = "0.5.4.14"
 S = "${WORKDIR}/git"

--- a/meta-xfce/recipes-apps/xfce-polkit/xfce-polkit_0.3.bb
+++ b/meta-xfce/recipes-apps/xfce-polkit/xfce-polkit_0.3.bb
@@ -8,7 +8,7 @@ inherit xfce-app features_check
 REQUIRED_DISTRO_FEATURES = "polkit"
 
 SRC_URI = " \
-    git://github.com/ncopa/${BPN}.git \
+    git://github.com/ncopa/${BPN}.git;branch=master;protocol=https \
 "
 SRCREV = "6d3282cc1734c305850d48f5bf4b4d94e88885e9"
 S = "${WORKDIR}/git"

--- a/meta-xfce/recipes-apps/xfce4-datetime-setter/xfce4-datetime-setter_3.32.2.bb
+++ b/meta-xfce/recipes-apps/xfce4-datetime-setter/xfce4-datetime-setter_3.32.2.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=75859989545e37968a99b631ef42722e"
 
 DEPENDS = "glib-2.0-native libxfce4ui"
 
-SRC_URI = "git://github.com/schnitzeltony/xfce4-datetime-setter.git;protocol=https \
+SRC_URI = "git://github.com/schnitzeltony/xfce4-datetime-setter.git;protocol=https;branch=master \
            file://fix-inner-dependency.patch \
 "
 SRCREV = "5c7a73a3824b03b91719e05e2604b97c7a72d50f"

--- a/meta-xfce/recipes-panel-plugins/closebutton/xfce4-closebutton-plugin_git.bb
+++ b/meta-xfce/recipes-panel-plugins/closebutton/xfce4-closebutton-plugin_git.bb
@@ -9,7 +9,7 @@ DEPENDS += "xfce4-dev-tools-native libwnck3 xfconf"
 
 PV = "4.16.0"
 
-SRC_URI = "git://github.com/schnitzeltony/xfce4-closebutton-plugin.git"
+SRC_URI = "git://github.com/schnitzeltony/xfce4-closebutton-plugin.git;branch=master;protocol=https"
 SRCREV = "538f9acfc5d5019f5cde734d056bcc0c95da9b4c"
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This patch updates SRC_URIs using git to include branch=master if no
branch is set and also to use protocol=https for github urls as
generated by the conversion script in OE-Core.
