### PR TITLE
pim435: Add recipe for C implementation for userspace driver app

### DIFF
--- a/meta-oe/recipes-core/pim435/pim435_git.bb
+++ b/meta-oe/recipes-core/pim435/pim435_git.bb
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Huawei Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+HOMEPAGE = "https://booting.oniroproject.org/distro/components/pim435"
+SUMMARY = "A userspace driver application for PIM435 written in C"
+DESCRIPTION = "A userspace driver application for PIM435 (Pimoroni LED matrix) \
+written in C"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSES/MIT.txt;md5=7dda4e90ded66ab88b86f76169f28663"
+
+SRC_URI = "git://booting.oniroproject.org/distro/components/pim435;protocol=https;branch=main"
+SRCREV = "57214788a7b1e2288db624bf3087388946f93333"
+S = "${WORKDIR}/git"
+
+DEPENDS = "i2c-tools"
+
+EXTRA_OEMAKE += "DESTDIR=${D}"
+
+do_install() {
+    oe_runmake install
+}

--- a/meta-oe/recipes-core/pim435/pim435_git.bb
+++ b/meta-oe/recipes-core/pim435/pim435_git.bb
@@ -10,7 +10,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSES/MIT.txt;md5=7dda4e90ded66ab88b86f76169f28663"
 
 SRC_URI = "git://booting.oniroproject.org/distro/components/pim435;protocol=https;branch=main"
-SRCREV = "57214788a7b1e2288db624bf3087388946f93333"
+SRCREV = "ee07a83de4d0ecdf4b5de20a7e374d36a9a6f5d5"
 S = "${WORKDIR}/git"
 
 DEPENDS = "i2c-tools"


### PR DESCRIPTION
Origin: https://booting.oniroproject.org/distro/oniro/-/merge_requests/402
Forwarded: https://github.com/openembedded/meta-openembedded/pulls?q=rzr
Relate-to: https://git.ostc-eu.org/distro/components/vending-machine-control-application/-/issues/2
Relate-to: https://booting.oniroproject.org/distro/oniro/-/merge_requests/416
Thanks-to: Andrei Gherzan's avatarAndrei Gherzan <andrei.gherzan@huawei.com>
Signed-off-by: Philippe Coval <philippe.coval@huawei.com>