### PR TITLE
Use old override syntax for dunfell

### DIFF
--- a/meta-python/recipes-devtools/python/python3-fasteners_0.16.3.bb
+++ b/meta-python/recipes-devtools/python/python3-fasteners_0.16.3.bb
@@ -8,7 +8,7 @@ SRC_URI[sha256sum] = "b1ab4e5adfbc28681ce44b3024421c4f567e705cc3963c732bf1cba334
 
 inherit pypi setuptools3
 
-RDEPENDS:${PN} += "\
+RDEPENDS_${PN} += "\
     ${PYTHON_PN}-logging \
     ${PYTHON_PN}-fcntl \
 "


### PR DESCRIPTION
https://github.com/openembedded/meta-openembedded/blob/dunfell/meta-python/recipes-devtools/python/python3-fasteners_0.16.3.bb

My dunfell bitbake cannot parse this file after updating to the latest changeset because it is using the new override format.