### PR TITLE
dbus-daemon-proxy: add missing `return` statement

### DIFF
--- a/meta-oe/recipes-core/dbus/dbus-daemon-proxy/0001-dbus-daemon-proxy-Return-DBUS_HANDLER_RESULT_NOT_YET.patch
+++ b/meta-oe/recipes-core/dbus/dbus-daemon-proxy/0001-dbus-daemon-proxy-Return-DBUS_HANDLER_RESULT_NOT_YET.patch
@@ -21,7 +21,7 @@ index 009e4fd..f3f0d80 100644
  
    if (!dbus_conn)
 -    return;
-+    DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
++    return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
  
    if (verbose)
      g_print ("New message from server: type='%d' path='%s' iface='%s'"


### PR DESCRIPTION
The missing `return` statement leads to a `SIGABRT`.

Signed-off-by: Leif Middelschulte <Leif.Middelschulte@klsmartin.com>