### PR TITLE
spidev-test: Update common-licenses reference

### DIFF
--- a/meta-oe/recipes-kernel/spidev-test/spidev-test.bb
+++ b/meta-oe/recipes-kernel/spidev-test/spidev-test.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Test SPI devices"
 DESCRIPTION = "SPI testing utility using the spidev driver"
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 PROVIDES = "virtual/spidev-test"
 
 inherit bash-completion kernelsrc kernel-arch


### PR DESCRIPTION
The license files were renamed in oe-core to match the SPDX names.

Most recipes here were already updated in commit ed54f12e19
("recipes: Update common-licenses references to match new names"),
but spidev-test was still missing.

Signed-off-by: Daniel Klauer <daniel.klauer@gin.de>
Signed-off-by: Khem Raj <raj.khem@gmail.com>