### PR TITLE
libcamera: add pkg-config files

### DIFF
--- a/meta-multimedia/recipes-multimedia/libcamera/libcamera.bb
+++ b/meta-multimedia/recipes-multimedia/libcamera/libcamera.bb
@@ -9,7 +9,9 @@ LIC_FILES_CHKSUM = "\
 "
 
 SRC_URI = " \
-        git://git.libcamera.org/libcamera/libcamera.git;protocol=https;branch=master \
+    git://git.libcamera.org/libcamera/libcamera.git;protocol=https;branch=master \
+    file://libcamera.pc \
+    file://libcamera-base.pc \
 "
 
 SRCREV = "acf8d028edda0a59b10e15962c2606137a4940af"
@@ -37,6 +39,8 @@ do_configure:prepend() {
 do_install:append() {
     chrpath -d ${D}${libdir}/libcamera.so.0.0.0
     chrpath -d ${D}${libdir}/libcamera-base.so.0.0.0
+    install -D -m 0644 ${WORKDIR}/libcamera.pc ${D}${libdir}/pkgconfig/libcamera.pc
+    install -D -m 0644 ${WORKDIR}/libcamera-base.pc ${D}${libdir}/pkgconfig/libcamera-base.pc
 }
 
 addtask do_recalculate_ipa_signatures_package after do_package before do_packagedata

--- a/meta-multimedia/recipes-multimedia/libcamera/libcamera/libcamera-base.pc
+++ b/meta-multimedia/recipes-multimedia/libcamera/libcamera/libcamera-base.pc
@@ -1,0 +1,9 @@
+prefix=/usr
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: libcamera-base
+Description: Camera support base utility library
+Version: 0.0.0
+Libs: -L${libdir} -lcamera-base
+Cflags: -I${includedir}/libcamera

--- a/meta-multimedia/recipes-multimedia/libcamera/libcamera/libcamera.pc
+++ b/meta-multimedia/recipes-multimedia/libcamera/libcamera/libcamera.pc
@@ -1,0 +1,10 @@
+prefix=/usr
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: libcamera
+Description: Complex Camera Support Library
+Version: 0.0.0
+Requires: libcamera-base
+Libs: -L${libdir} -lcamera
+Cflags: -I${includedir}/libcamera


### PR DESCRIPTION
pkg-config files are required to build applications such as [libcamera-apps](https://github.com/raspberrypi/libcamera-apps).