### PR TITLE
abseil-cpp: Fix build with gcc11

### DIFF
--- a/meta-oe/recipes-devtools/abseil-cpp/abseil-cpp_git.bb
+++ b/meta-oe/recipes-devtools/abseil-cpp/abseil-cpp_git.bb
@@ -26,7 +26,7 @@ inherit cmake
 
 EXTRA_OECMAKE = "-DBUILD_SHARED_LIBS=ON \
                  -DBUILD_TESTING=OFF    \
-                 -DCMAKE_CXX_STANDARD=14 \
+                 -DCMAKE_CXX_STANDARD=17 \
                 "
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
To use abseil in other recipes it has to be targeted for C++17.