### PR TITLE
cli11: switch from default master branch to main to fix do_fetch failure

### DIFF
--- a/meta-oe/recipes-support/cli11/cli11_1.8.0.bb
+++ b/meta-oe/recipes-support/cli11/cli11_1.8.0.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=b73927b18d5c6cd8d2ed28a6ad539733"
 SRCREV = "13becaddb657eacd090537719a669d66d393b8b2"
 PV .= "+git${SRCPV}"
 
-SRC_URI += "gitsm://github.com/CLIUtils/CLI11;branch=master;protocol=https \
+SRC_URI += "gitsm://github.com/CLIUtils/CLI11;branch=main;protocol=https \
             file://0001-Add-CLANG_TIDY-check.patch \
             file://0001-Use-GNUInstallDirs-instead-of-hard-coded-path.patch \
            "


### PR DESCRIPTION
The branch was renamed in the upstream repository

Signed-off-by: Christian Ege <christian.ege@ifm.com>