### PR TITLE
dnsmasq: Fix a typo in initscript

### DIFF
--- a/meta-networking/recipes-support/dnsmasq/files/init
+++ b/meta-networking/recipes-support/dnsmasq/files/init
@@ -16,7 +16,7 @@ fi
 DNSMASQ_CONF="/etc/dnsmasq.conf"
 test "/etc/dnsmasq.d/*" != '/etc/dnsmasq.d/*' && DNSMASQ_CONF="${DNSMASQ_CONF} /etc/dnsmasq.d/*"
 
-test -z "${PIDFILE}" && PIFILE="/run/dnsmasq.pid"
+test -z "${PIDFILE}" && PIDFILE="/run/dnsmasq.pid"
 
 if [ -z "$IGNORE_RESOLVCONF" ]
 then


### PR DESCRIPTION
Change `PIFILE` to `PIDFILE`.

This fixes the operation of `/etc/init.d/dnsmasq status`