### PR TITLE
googletests: Update SRC_URI to 9e71237 to move closer to latest version

### DIFF
--- a/meta-oe/recipes-test/googletest/googletest_git.bb
+++ b/meta-oe/recipes-test/googletest/googletest_git.bb
@@ -9,7 +9,7 @@ PV = "1.11.0+git${SRCPV}"
 PROVIDES += "gmock gtest"
 
 S = "${WORKDIR}/git"
-SRCREV = "e2239ee6043f73722e7aa812a459f54a28552929"
+SRCREV = "9e712372214d75bb30ec2847a44bf124d48096f3"
 SRC_URI = "git://github.com/google/googletest.git;branch=main;protocol=https"
 
 inherit cmake

--- a/meta-oe/recipes-test/googletest/googletest_git.bb
+++ b/meta-oe/recipes-test/googletest/googletest_git.bb
@@ -26,5 +26,5 @@ do_configure:prepend() {
     # the scripts are already python3 compatible since https://github.com/google/googletest/commit/d404af0d987a9c38cafce82a7e26ec8468c88361 and other fixes like this
     # but since this oe-core change http://git.openembedded.org/openembedded-core/commit/?id=5f8f16b17f66966ae91aeabc23e97de5ecd17447
     # there isn't python in HOSTTOOLS so "env python" fails
-    sed -i 's@^#!/usr/bin/env python$@#!/usr/bin/env python3@g' ${S}/googlemock/scripts/*py ${S}/googlemock/scripts/generator/*py ${S}/googlemock/scripts/generator/cpp/*py ${S}/googlemock/test/*py ${S}/googletest/scripts/*py ${S}/googletest/test/*py
+    sed -i 's@^#!/usr/bin/env python$@#!/usr/bin/env python3@g' ${S}/googlemock/test/*py ${S}/googletest/test/*py
 }


### PR DESCRIPTION
Picked https://github.com/google/googletest/commit/9e712372214d75bb30ec2847a44bf124d48096f3
as the latest Verified commit and move closer to the HEAD of
googletests. Googletests does not make releases that often and some good
to have features are missing.

Updated the do_config to reflect the new python scripts used in googletests.

Current python scripts are in
```
$ git grep "/usr/bin/env python"
googlemock/test/gmock_leak_test.py:#!/usr/bin/env python
googlemock/test/gmock_leak_test.py:#!/usr/bin/env python
googlemock/test/gmock_output_test.py:#!/usr/bin/env python
googletest/test/googletest-break-on-failure-unittest.py:#!/usr/bin/env python
googletest/test/googletest-catch-exceptions-test.py:#!/usr/bin/env python
googletest/test/googletest-color-test.py:#!/usr/bin/env python
googletest/test/googletest-env-var-test.py:#!/usr/bin/env python
googletest/test/googletest-failfast-unittest.py:#!/usr/bin/env python
googletest/test/googletest-filter-unittest.py:#!/usr/bin/env python
googletest/test/googletest-json-outfiles-test.py:#!/usr/bin/env python
googletest/test/googletest-json-output-unittest.py:#!/usr/bin/env python
googlemock/test/gmock_leak_test.py:#!/usr/bin/env python
googlemock/test/gmock_leak_test.py:#!/usr/bin/env python
googlemock/test/gmock_output_test.py:#!/usr/bin/env python
googletest/test/googletest-break-on-failure-unittest.py:#!/usr/bin/env python
googletest/test/googletest-catch-exceptions-test.py:#!/usr/bin/env python
googletest/test/googletest-color-test.py:#!/usr/bin/env python
googletest/test/googletest-env-var-test.py:#!/usr/bin/env python
googletest/test/googletest-failfast-unittest.py:#!/usr/bin/env python
googletest/test/googletest-filter-unittest.py:#!/usr/bin/env python
googletest/test/googletest-json-outfiles-test.py:#!/usr/bin/env python
googletest/test/googletest-json-output-unittest.py:#!/usr/bin/env python
googletest/test/googletest-list-tests-unittest.py:#!/usr/bin/env python
googletest/test/googletest-output-test.py:#!/usr/bin/env python
googletest/test/googletest-param-test-invalid-name1-test.py:#!/usr/bin/env python
googletest/test/googletest-param-test-invalid-name2-test.py:#!/usr/bin/env python
googletest/test/googletest-setuptestsuite-test.py:#!/usr/bin/env python
googletest/test/googletest-shuffle-test.py:#!/usr/bin/env python
googletest/test/googletest-throw-on-failure-test.py:#!/usr/bin/env python
googletest/test/googletest-uninitialized-test.py:#!/usr/bin/env python
googletest/test/gtest_help_test.py:#!/usr/bin/env python
googletest/test/gtest_list_output_unittest.py:#!/usr/bin/env python
googletest/test/gtest_skip_check_output_test.py:#!/usr/bin/env python
googletest/test/gtest_skip_environment_check_output_test.py:#!/usr/bin/env python
googletest/test/gtest_testbridge_test.py:#!/usr/bin/env python
googletest/test/gtest_xml_outfiles_test.py:#!/usr/bin/env python
googletest/test/gtest_xml_output_unittest.py:#!/usr/bin/env python
```

Signed-off-by: Willy Tu <wltu@google.com>