### PR TITLE
sdbus-c++-libsystemd: bugfix dev package is not installed

### DIFF
--- a/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd_250.3.bb
+++ b/meta-oe/recipes-core/sdbus-c++/sdbus-c++-libsystemd_250.3.bb
@@ -59,6 +59,8 @@ EXTRA_OEMESON += "-Dstatic-libsystemd=pic"
 
 S = "${WORKDIR}/git"
 
+RDEPENDS:${PN}-dev = ""
+
 do_compile() {
     ninja -v ${PARALLEL_MAKE} version.h
     ninja -v ${PARALLEL_MAKE} libsystemd.a


### PR DESCRIPTION
since sdbus-c++-libsystemd outputs only static libraries, it will
not be installed inside the SDK.

add RDEPENDS:${PN}-dev = "" to remove the dependency to the empty package
when installing the sdbus-c++-libsystemd-dev into the SDK

without this change the SDK is missing sdbus-c++-dev and sdbus-c++-libsystemd-dev

Signed-off-by: Ben Fekih, Hichem <hichem.benfekih@ifm.com>