### PR TITLE
dbus-broker: update 29 -> 31

### DIFF
--- a/meta-oe/recipes-core/dbus/dbus-broker_31.bb
+++ b/meta-oe/recipes-core/dbus/dbus-broker_31.bb
@@ -7,7 +7,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=7b486c2338d225a1405d979ed2c15ce8"
 
 SRC_URI = "https://github.com/bus1/dbus-broker/releases/download/v${PV}/dbus-broker-${PV}.tar.xz"
-SRC_URI[sha256sum] = "4eca425db52b7ab1027153e93fea9b3f11759db9e93ffbf88759b73ddfb8026a"
+SRC_URI[sha256sum] = "f229d7f1de8a3e344d54a4a30fbcb545387549e968009c06b87f7f1196c97496"
 
 UPSTREAM_CHECK_URI = "https://github.com/bus1/${BPN}/releases"
 


### PR DESCRIPTION
Full changelogs:

https://github.com/bus1/dbus-broker/releases/tag/v30
https://github.com/bus1/dbus-broker/releases/tag/v31

Signed-off-by: Luca Boccassi <bluca@debian.org>