### PR TITLE
python3-matplotlib: add missing dependency

### DIFF
--- a/meta-python/recipes-devtools/python/python3-matplotlib_3.5.1.bb
+++ b/meta-python/recipes-devtools/python/python3-matplotlib_3.5.1.bb
@@ -50,6 +50,7 @@ RDEPENDS:${PN} = "\
     ${PYTHON_PN}-dateutil \
     ${PYTHON_PN}-kiwisolver \
     ${PYTHON_PN}-pytz \
+    ${PYTHON_PN}-pillow \
 "
 
 ENABLELTO:toolchain-clang:riscv64 = "echo enable_lto = False >> ${S}/mplsetup.cfg"


### PR DESCRIPTION
Using the recipe python3-matplotlib from honister one gets error:
```
$> python3
Python 3.9.9 (main, Nov 15 2021, 18:05:17) 
[GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import matplotlib
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.9/site-packages/matplotlib/__init__.py", line 107, in <module>
    from . import _api, cbook, docstring, rcsetup
  File "/usr/lib/python3.9/site-packages/matplotlib/rcsetup.py", line 24, in <module>
    from matplotlib import _api, animation, cbook
  File "/usr/lib/python3.9/site-packages/matplotlib/animation.py", line 34, in <module>
    from PIL import Image
ModuleNotFoundError: No module named 'PIL'
```
Adding python3-pillow fixes the problem.

Could you also move this change to honister?