### PR TITLE
clinfo: use virtual opencl loader provider

### DIFF
--- a/meta-oe/recipes-support/opencl/clinfo_3.0.21.02.21.bb
+++ b/meta-oe/recipes-support/opencl/clinfo_3.0.21.02.21.bb
@@ -13,7 +13,7 @@ SRCREV = "d34bc1a3bdc148e2e1fe64998398e1a0552ab04c"
 
 S = "${WORKDIR}/git"
 
-DEPENDS += "opencl-headers opencl-icd-loader"
+DEPENDS += "opencl-headers virtual/opencl-icd"
 
 do_install() {
         install -D -m 755 clinfo ${D}${bindir}/clinfo


### PR DESCRIPTION
Hello,

Use **virtual/opencl-icd** as OpenCL provider instead of static Khronos **opencl-icd-loader** (similar to **PACKAGECONFIG[opencl]** found in OpenCV recipe).

One might decide to link straight with a specific OpenCL implementation (GPU-vendor specific, PoCL, ...). In that case one only needs to override **PREFERRED_PROVIDER_virtual/opencl-icd** once and for all.