### PR TITLE
python3-asyncinotify: upgrade 2.0.3 -> 2.0.5

### DIFF
--- a/meta-python/recipes-devtools/python/python3-asyncinotify_2.0.5.bb
+++ b/meta-python/recipes-devtools/python/python3-asyncinotify_2.0.5.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://gitlab.com/Taywee/asyncinotify"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=6ec941a1cd6616454970d03cb9c9e8f8"
 
-SRC_URI[sha256sum] = "a14baf680a3d3e1cf54e082ab56f56c475d59d3644cfc25c00c460e56d9bbdf7"
+SRC_URI[sha256sum] = "e4d95cba362f10d33b6fdd558afd39f0ea7a5be1a9694434e738141cbed366d9"
 
 inherit pypi setuptools3
 


### PR DESCRIPTION
Update asyncinotify to newest 2.0.5 version from pypi.

Signed-off-by: Marc Lasch <marc.lasch@husqvarnagroup.com>