### PR TITLE
Fix tigervnc crash due to missing xkbcomp rdepends

### DIFF
--- a/meta-oe/recipes-graphics/tigervnc/tigervnc_1.10.1.bb
+++ b/meta-oe/recipes-graphics/tigervnc/tigervnc_1.10.1.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://www.tigervnc.com/"
 LICENSE = "GPLv2+"
 SECTION = "x11/utils"
 DEPENDS = "xserver-xorg gnutls jpeg libxtst gettext-native fltk"
-RDEPENDS_${PN} = "coreutils hicolor-icon-theme perl"
+RDEPENDS_${PN} = "coreutils hicolor-icon-theme perl xkbcomp"
 
 LIC_FILES_CHKSUM = "file://LICENCE.TXT;md5=75b02c2872421380bbd47781d2bd75d3"
 


### PR DESCRIPTION
Signed-off-by: Alexander Thoma [a.thoma@rational-online.com](mailto:a.thoma@rational-online.com)
Signed-off-by: Florian Wühr [f.wuehr@rational-online.com](mailto:f.wuehr@rational-online.com)