### PR TITLE
Fix CMake flag

### DIFF
--- a/meta-oe/recipes-support/spdlog/spdlog_1.9.2.bb
+++ b/meta-oe/recipes-support/spdlog/spdlog_1.9.2.bb
@@ -12,7 +12,7 @@ DEPENDS += "fmt"
 S = "${WORKDIR}/git"
 
 BBCLASSEXTEND = "native"
-# no need to build example&text&benchmarks on pure yocto
-EXTRA_OECMAKE += "-DSPDLOG_INSTALL=on -DSPDLOG_BUILD_SHARED=on -DSPDLOG_BUILD_EXAMPLES=off -DSPDLOG_BUILD_TESTS=off -DSPDLOG_BUILD_BENCH=off -DSPDLOG_FMT_EXTERNAL=on"
+# no need to build example & tests & benchmarks on pure yocto
+EXTRA_OECMAKE += "-DSPDLOG_INSTALL=on -DSPDLOG_BUILD_SHARED=on -DSPDLOG_BUILD_EXAMPLE=off -DSPDLOG_BUILD_TESTS=off -DSPDLOG_BUILD_BENCH=off -DSPDLOG_FMT_EXTERNAL=on"
 
 inherit cmake


### PR DESCRIPTION
This is more a cosmetic issue as the example is (currently) not being installed by spdlog.
Same typo in multiple branches. Not sure how to proceed with this.

https://github.com/gabime/spdlog/blob/eb3220622e73a4889eee355ffa37972b3cac3df5/CMakeLists.txt#L72

