### PR TITLE
Revert "Suppress eol in functionfs setup scripts (#147)"

### DIFF
--- a/meta-oe/recipes-devtools/android-tools/android-tools-conf-configfs/android-gadget-cleanup
+++ b/meta-oe/recipes-devtools/android-tools/android-tools-conf-configfs/android-gadget-cleanup
@@ -6,7 +6,7 @@ cd /sys/kernel/config/usb_gadget
 
 cd adb
 
-echo -n "" > UDC || true
+echo "" > UDC || true
 
 killall adbd || true
 

--- a/meta-oe/recipes-devtools/android-tools/android-tools-conf-configfs/android-gadget-setup
+++ b/meta-oe/recipes-devtools/android-tools/android-tools-conf-configfs/android-gadget-setup
@@ -23,8 +23,8 @@ mkdir configs/c.1
 mkdir functions/ffs.usb0
 mkdir strings/0x409
 mkdir configs/c.1/strings/0x409
-echo -n 0x18d1 > idVendor
-echo -n 0xd002 > idProduct
+echo 0x18d1 > idVendor
+echo 0xd002 > idProduct
 echo "$serial" > strings/0x409/serialnumber
 echo "$manufacturer" > strings/0x409/manufacturer
 echo "$model" > strings/0x409/product

--- a/meta-oe/recipes-devtools/android-tools/android-tools-conf-configfs/android-gadget-start
+++ b/meta-oe/recipes-devtools/android-tools/android-tools-conf-configfs/android-gadget-start
@@ -4,4 +4,4 @@ set -e
 
 sleep 3
 
-ls /sys/class/udc/ | xargs echo -n > /sys/kernel/config/usb_gadget/adb/UDC
+ls /sys/class/udc/ > /sys/kernel/config/usb_gadget/adb/UDC


### PR DESCRIPTION
This reverts commit db5f48734404a52ee5323659082f1d6baa225ca7.

It does not seem to be necessary any more and is impeding startup of adbd on a raspberry pi system built with clang, musl, and toybox.

Signed-off-by: Devendra Tewari <devendra.tewari@gmail.com>