### PR TITLE
android-tools: sleep more in android-gadget-start

### DIFF
--- a/meta-oe/recipes-devtools/android-tools/android-tools-conf-configfs/android-gadget-start
+++ b/meta-oe/recipes-devtools/android-tools/android-tools-conf-configfs/android-gadget-start
@@ -2,6 +2,6 @@
 
 set -e
 
-sleep 3
+sleep 10
 
 ls /sys/class/udc/ | xargs echo -n > /sys/kernel/config/usb_gadget/adb/UDC


### PR DESCRIPTION
Increase sleep to 10 seconds otherwise interface is not ready on rpi0w.

Verified on rpi0w system built with clang, musl, and toybox and/or busybox.

Signed-off-by: Devendra Tewari <devendra.tewari@gmail.com>