### PR TITLE
bdwgc: Fix typo in EXTRA_OECONF and remove unneeded extra CFLAGS

### DIFF
--- a/meta-oe/recipes-support/bdwgc/bdwgc_8.2.2.bb
+++ b/meta-oe/recipes-support/bdwgc/bdwgc_8.2.2.bb
@@ -30,9 +30,7 @@ S = "${WORKDIR}/git"
 
 inherit autotools pkgconfig
 
-EXTRA_OECONF += "--enable-cpluscplus"
-
-CFLAGS:append:libc-musl = " -D_GNU_SOURCE -DNO_GETCONTEXT -DSEARCH_FOR_DATA_START -DUSE_MMAP -DHAVE_DL_ITERATE_PHDR"
+EXTRA_OECONF += "--enable-cplusplus"
 
 FILES:${PN}-doc = "${datadir}"
 


### PR DESCRIPTION
* fix typo in "--enable-cplusplus"
* "-D_GNU_SOURCE -DNO_GETCONTEXT -DSEARCH_FOR_DATA_START -DUSE_MMAP -DHAVE_DL_ITERATE_PHDR" not needed any more