### PR TITLE
pim435: Relocate sources to eclipse

### DIFF
--- a/meta-oe/recipes-core/pim435/pim435_git.bb
+++ b/meta-oe/recipes-core/pim435/pim435_git.bb
@@ -9,8 +9,8 @@ written in C"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSES/MIT.txt;md5=7dda4e90ded66ab88b86f76169f28663"
 
-SRC_URI = "git://booting.oniroproject.org/distro/components/pim435;protocol=https;branch=main"
-SRCREV = "ee07a83de4d0ecdf4b5de20a7e374d36a9a6f5d5"
+SRC_URI = "git://gitlab.eclipse.org/eclipse/oniro-blueprints/core/pim435;protocol=https;branch=main"
+SRCREV = "445ed623ec8d3ecbb1d566900b4ef3fb3031d689"
 S = "${WORKDIR}/git"
 
 DEPENDS = "i2c-tools"


### PR DESCRIPTION
This driver is now part of Eclipse's oniro-blueprints project

Note: Once transition is finished,
existing copies will be need to be archived
For history referer to related tickets if curious.

Relate-to: https://gitlab.eclipse.org/eclipse/oniro-core/oniro/-/issues/787
Relate-to: https://gitlab.eclipse.org/eclipse/oniro-blueprints/vending-machine/meta-oniro-blueprints-vending-machine/-/issues/1
Relate-to: https://gitlab.eclipse.org/pcoval/pim435/-/issues/2
Relate-to: https://git.ostc-eu.org/distro/components/vending-machine-control-application/-/issues/2
Forwarded: https://github.com/openembedded/meta-openembedded/pull/603
Origin: https://github.com/astrolabe-coop/meta-openembedded
Signed-off-by: Philippe Coval <philippe.coval.ext@huawei.com>
Signed-off-by: Khem Raj <raj.khem@gmail.com>