### PR TITLE
ufw: Fix "could not find required binary 'iptables'"

### DIFF
--- a/meta-networking/recipes-connectivity/ufw/ufw_0.36.1.bb
+++ b/meta-networking/recipes-connectivity/ufw/ufw_0.36.1.bb
@@ -70,5 +70,5 @@ FILES:${PN} += " \
 
 REQUIRED_DISTRO_FEATURES = "ipv6"
 
-DISTUTILS_BUILD_ARGS:append = " --iptables-dir /usr/sbin"
-DISTUTILS_INSTALL_ARGS:append = " --iptables-dir /usr/sbin"
+SETUPTOOLS_BUILD_ARGS:append = " --iptables-dir /usr/sbin"
+SETUPTOOLS_INSTALL_ARGS:append = " --iptables-dir /usr/sbin"


### PR DESCRIPTION
Switch from using DISTUTILS_*_ARGS to SETUPTOOLS_*_ARGS to correspond with the earlier change to use setuptools3_legacy instead of distutils3.

Without this change, you will get the following error if your build host does not have iptables installed:

Fixes:
  ERROR: ufw-0.36.1-r0 do_compile: 'python3 setup.py build ' execution failed.
  Log data follows:
  | DEBUG: Executing shell function do_compile
  | ERROR: could not find required binary 'iptables'
  | ERROR: 'python3 setup.py build ' execution failed.
  | WARNING: exit code 1 from a shell command.
  ERROR: Task ([snip]/meta-openembedded/meta-networking/recipes-connectivity/ufw/ufw_0.36.1.bb:do_compile) failed with exit code '1'

Also, although the build will not fail on a host that has iptables, it could cause a problem if it is installed at a different path than where OpenEmbedded's iptables will be installed on the target.

Fixes: 3e2ed1dcc088 ("ufw: port to setuptools, use setuptools_legacy")
Signed-off-by: Howard Cochran <howard_cochran@jabil.com>