### PR TITLE
ot-br-posix: Add dep to ipset as used by firewall

### DIFF
--- a/meta-networking/recipes-connectivity/openthread/ot-br-posix_git.bb
+++ b/meta-networking/recipes-connectivity/openthread/ot-br-posix_git.bb
@@ -57,7 +57,7 @@ EXTRA_OECMAKE = "-DBUILD_TESTING=OFF \
                  -DOT_DHCP6_SERVER=ON \
                  "
 
-RDEPENDS:${PN} = "iproute2 avahi-daemon"
+RDEPENDS:${PN} = "iproute2 ipset avahi-daemon"
 
 RCONFLICTS:${PN} = "ot-daemon"
 


### PR DESCRIPTION
ipset is used by firewall module of ot-br-posix:

   third_party/openthread/repo/src/posix/platform/firewall.cpp:\
   return ExecuteCommand("%s add %s %s -exist", kIpsetCommand, aSetName, aAddress);

Related observed issue looked like:

```
oniro@oniro-linux-blueprint-gateway-raspberrypi4-64:~$ sudo journalctl -u otbr-agent.service
Apr 28 17:42:32 oniro-linux-blueprint-gateway-raspberrypi4-64 systemd[1]: Started OpenThread Border Router Agent.
Apr 28 17:42:38 oniro-linux-blueprint-gateway-raspberrypi4-64 otbr-agent[330]: sh: ipset: not found
```

Relate-to: https://gitlab.eclipse.org/eclipse/oniro-blueprints/transparent-gateway/meta-oniro-blueprints-gateway/-/issues/6
Cc: Stefan Schmidt <stefan.schmidt@huawei.com>
Forwarded: https://github.com/openembedded/meta-openembedded/pulls?q=author%3Arzr
Signed-off-by: Philippe Coval <philippe.coval.ext@huawei.com>