### PR TITLE
libwebsockets: add optional support for sd-event loop

### DIFF
--- a/meta-oe/recipes-connectivity/libwebsockets/libwebsockets_4.3.2.bb
+++ b/meta-oe/recipes-connectivity/libwebsockets/libwebsockets_4.3.2.bb
@@ -26,6 +26,11 @@ PACKAGECONFIG[ssl] = "-DLWS_WITH_SSL=ON,-DLWS_WITH_SSL=OFF,openssl"
 PACKAGECONFIG[static] = "-DLWS_WITH_STATIC=ON,-DLWS_WITH_STATIC=OFF -DLWS_LINK_TESTAPPS_DYNAMIC=ON,"
 PACKAGECONFIG[systemd] = "-DLWS_WITH_SDEVENT=ON,-DLWS_WITH_SDEVENT=OFF,systemd"
 
+python __anonymous() {
+  if bb.utils.contains('PACKAGECONFIG', 'systemd', True, False, d) and not bb.utils.contains('DISTRO_FEATURES', 'systemd', True, False, d):
+    bb.fatal("PACKAGECONFIG contains systemd but DISTRO_FEATURES doesn't")
+}
+
 EXTRA_OECMAKE += " \
     -DLIB_SUFFIX=${@d.getVar('baselib').replace('lib', '')} \
 "


### PR DESCRIPTION
Hello!

I'm sending a pull request to add support for building the libwebsockets-evlib-sd plugin for libwebsockets.

This allows using the sd_events based loop.

I am using this in a custom app and thought I would contribute the change.