### PR TITLE
mctp: install the .target files

### DIFF
--- a/meta-networking/recipes-support/mctp/mctp_git.bb
+++ b/meta-networking/recipes-support/mctp/mctp_git.bb
@@ -22,13 +22,16 @@ PACKAGECONFIG ??= " \
 # mctpd will only be built if pkg-config detects libsystemd; in which case
 # we'll want to declare the dep and install the service.
 PACKAGECONFIG[systemd] = ",,systemd,libsystemd"
-SYSTEMD_SERVICE:${PN} = "mctpd.service"
+SYSTEMD_SERVICE:${PN} = "mctpd.service mctp.target mctp-local.target"
+SYSTEMD_AUTO_ENABLE_${PN} = "enable"
 
 do_install:append () {
     if ${@bb.utils.contains('PACKAGECONFIG', 'systemd', 'true', 'false', d)}; then
         install -d ${D}${systemd_system_unitdir}
         install -m 0644 ${S}/conf/mctpd.service \
                 ${D}${systemd_system_unitdir}/mctpd.service
+        install -m 0644 ${S}/conf/*.target \
+                ${D}${systemd_system_unitdir}/
         install -d ${D}${datadir}/dbus-1/system.d
         install -m 0644 ${S}/conf/mctpd-dbus.conf \
                 ${D}${datadir}/dbus-1/system.d/mctpd.conf


### PR DESCRIPTION
Need the targets file to enable the mctpd.service on systemd.

Signed-off-by: Hao Jiang <jianghao@google.com>
Change-Id: I8d48d3767760dc1f34ae7e1266600d350ac93281