### PR TITLE
android-tools-conf-configfs: Allow handling two or more UDC controllers

### DIFF
--- a/meta-oe/recipes-devtools/android-tools/android-tools-conf-configfs/android-gadget-start
+++ b/meta-oe/recipes-devtools/android-tools/android-tools-conf-configfs/android-gadget-start
@@ -4,4 +4,6 @@ set -e
 
 sleep 10
 
-ls /sys/class/udc/ | xargs echo -n > /sys/kernel/config/usb_gadget/adb/UDC
+ls /sys/class/udc/ | head -n 1 | xargs echo -n > /sys/kernel/config/usb_gadget/adb/UDC
+
+bbnote "Setting UDC $(ls /sys/class/udc/ | head -n 1) for USB ADB Gadget usage"


### PR DESCRIPTION
Several Qualcomm platforms support setting two or more (or even all) UDC controllers in 'peripheral' mode. Modify the android-tools-conf-configfs scriptware to handle such cases.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>