### PR TITLE
add native BBCLASSEXTEND to libbpf

### DIFF
--- a/meta-oe/recipes-kernel/libbpf/libbpf_0.8.0.bb
+++ b/meta-oe/recipes-kernel/libbpf/libbpf_0.8.0.bb
@@ -27,3 +27,5 @@ do_compile() {
 do_install() {
 	oe_runmake install
 }
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
To build `pahole-native` we need `libbpf-native`.