### PR TITLE
python3-wxgtk4: replace deprecated inspect.getargspec

### DIFF
--- a/meta-python/recipes-devtools/python3-wxgtk4/python3-wxgtk4/0001-pypubsub-Replace-deprecated-inspect.getargspec.patch
+++ b/meta-python/recipes-devtools/python3-wxgtk4/python3-wxgtk4/0001-pypubsub-Replace-deprecated-inspect.getargspec.patch
@@ -1,0 +1,65 @@
+Upstream-Status: Backport [https://github.com/wxWidgets/Phoenix/commit/9986a0d5]
+
+Signed-off-by: Kai Kang <kai.kang@windriver.com>
+
+From 9986a0d5c24b5d45ddf571d60351f68765a8a9be Mon Sep 17 00:00:00 2001
+From: Scott Talbert <swt@techie.net>
+Date: Mon, 8 Aug 2022 22:35:58 -0400
+Subject: [PATCH] pypubsub: Replace deprecated inspect.getargspec
+
+inspect.getargspec was removed in Python 3.11.  This is a backport of:
+https://github.com/schollii/pypubsub/commit/089c7a73f85c76a3aa22e4b10c71db1bf65a8637
+---
+ wx/lib/pubsub/core/callables.py | 23 +++++++++++++++--------
+ 1 file changed, 15 insertions(+), 8 deletions(-)
+
+diff --git a/wx/lib/pubsub/core/callables.py b/wx/lib/pubsub/core/callables.py
+index 65eb1ebe..7e798c54 100644
+--- a/wx/lib/pubsub/core/callables.py
++++ b/wx/lib/pubsub/core/callables.py
+@@ -12,7 +12,7 @@ CallArgsInfo regarding its autoTopicArgName data member.
+ 
+ """
+ 
+-from inspect import getargspec, ismethod, isfunction
++from inspect import ismethod, isfunction, signature, Parameter
+ 
+ from .. import py2and3
+ 
+@@ -133,19 +133,26 @@ class CallArgsInfo:
+         self.autoTopicArgName = None."""
+ 
+         #args, firstArgIdx, defaultVals, acceptsAllKwargs
+-        (allParams, varParamName, varOptParamName, defaultVals) = getargspec(func)
+-        if defaultVals is None:
+-            defaultVals = []
+-        else:
+-            defaultVals = list(defaultVals)
++        allParams = []
++        defaultVals = []
++        varParamName = None
++        varOptParamName = None
++        for argName, param in signature(func).parameters.items():
++            if param.default != Parameter.empty:
++                defaultVals.append(param.default)
++            if param.kind == Parameter.VAR_POSITIONAL:
++                varParamName = argName
++            elif param.kind == Parameter.VAR_KEYWORD:
++                varOptParamName = argName
++            else:
++                allParams.append(argName)
+ 
+         self.acceptsAllKwargs      = (varOptParamName is not None)
+         self.acceptsAllUnnamedArgs = (varParamName    is not None)
+-
+         self.allParams = allParams
+-        del self.allParams[0:firstArgIdx] # does nothing if firstArgIdx == 0
+ 
+         self.numRequired = len(self.allParams) - len(defaultVals)
++        assert len(self.allParams) >= len(defaultVals)
+         assert self.numRequired >= 0
+ 
+         # if listener wants topic, remove that arg from args/defaultVals
+-- 
+2.34.1
+

--- a/meta-python/recipes-devtools/python3-wxgtk4/python3-wxgtk4_4.2.0.bb
+++ b/meta-python/recipes-devtools/python3-wxgtk4/python3-wxgtk4_4.2.0.bb
@@ -13,6 +13,7 @@ PYPI_PACKAGE = "wxPython"
 SRC_URI += "file://add-back-option-build-base.patch \
             file://wxgtk-fixup-build-scripts.patch \
             file://not-overwrite-cflags-cxxflags.patch \
+            file://0001-pypubsub-Replace-deprecated-inspect.getargspec.patch \
             "
 SRC_URI[sha256sum] = "663cebc4509d7e5d113518865fe274f77f95434c5d57bc386ed58d65ceed86c7"
 
@@ -29,6 +30,7 @@ RDEPENDS:${PN} = "\
     python3-image \
     python3-numpy \
     python3-pillow \
+    python3-pip \
     python3-pprint \
     python3-pycairo \
     python3-six \


### PR DESCRIPTION
Backport patch to replace deprecated inspect.getargspec in lib pubsub.

And add python3-pip to RDEPENDS which is required by utils wxdemo, wxdocs and wxget provided by python3-wxgtk4.

Signed-off-by: Kai Kang <kai.kang@windriver.com>