### PR TITLE
python3-twisted: Add python3-asyncio to RDEPENDS

### DIFF
--- a/meta-python/recipes-devtools/python/python3-twisted_22.10.0.bb
+++ b/meta-python/recipes-devtools/python/python3-twisted_22.10.0.bb
@@ -57,6 +57,7 @@ RDEPENDS:${PN} = "\
 "
 
 RDEPENDS:${PN}-core = "${PYTHON_PN}-appdirs \
+                       ${PYTHON_PN}-asyncio \
                        ${PYTHON_PN}-automat \
                        ${PYTHON_PN}-constantly \
                        ${PYTHON_PN}-core \


### PR DESCRIPTION
To fix crash due to missing module:

from twisted.internet import defer
File "/usr/lib/python3.11/site-packages/twisted/internet/defer.py", line 14, in <module> from asyncio import AbstractEventLoop, Future, iscoroutine ModuleNotFoundError: No module named 'asyncio'

Signed-off-by: Hains van den Bosch <hainsvdbosch@ziggo.nl>