### PR TITLE
python3-twisted: Add python3-typing-extensions to RDEPENDS

### DIFF
--- a/meta-python/recipes-devtools/python/python3-twisted_22.10.0.bb
+++ b/meta-python/recipes-devtools/python/python3-twisted_22.10.0.bb
@@ -65,6 +65,7 @@ RDEPENDS:${PN}-core = "${PYTHON_PN}-appdirs \
                        ${PYTHON_PN}-incremental \
                        ${PYTHON_PN}-pyhamcrest \
                        ${PYTHON_PN}-pyserial \
+                       ${PYTHON_PN}-typing-extensions \
                        ${PYTHON_PN}-unixadmin \
                        ${PYTHON_PN}-zopeinterface \
 "


### PR DESCRIPTION
To fix crash due to missing module:

File "/usr/lib/python3.11/site-packages/twisted/internet/defer.py", line 42, in <module> from typing_extensions import Literal, ParamSpec, Protocol ModuleNotFoundError: No module named 'typing_extensions'

Signed-off-by: Hains van den Bosch <hainsvdbosch@ziggo.nl>