### PR TITLE
kernel_add_regdb: Change the task order

### DIFF
--- a/meta-networking/classes/kernel_wireless_regdb.bbclass
+++ b/meta-networking/classes/kernel_wireless_regdb.bbclass
@@ -17,4 +17,4 @@ do_kernel_add_regdb() {
     cp ${STAGING_LIBDIR_NATIVE}/crda/db.txt ${S}/net/wireless/db.txt
 }
 do_kernel_add_regdb[dirs] = "${S}"
-addtask kernel_add_regdb before do_build after do_configure
+addtask kernel_add_regdb before do_compile after do_configure


### PR DESCRIPTION
The kernel_add_regdb should run before do_compile to make it take effect.

Change-Id: I6e3c4cc0c6fbef2610998ebf181b87c1536e9eba