### PR TITLE
Make tvheadend recipe compatible with the latest tvheadend version

### DIFF
--- a/meta-multimedia/recipes-dvb/tvheadend/tvheadend/0001-adjust-for-64bit-time_t.patch
+++ b/meta-multimedia/recipes-dvb/tvheadend/tvheadend/0001-adjust-for-64bit-time_t.patch
@@ -33,12 +33,12 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
    }
 --- a/src/epggrab/module/psip.c
 +++ b/src/epggrab/module/psip.c
-@@ -383,14 +383,14 @@ _psip_eit_callback_channel
+@@ -223,14 +223,14 @@ _psip_eit_callback_channel
  
-     tvhtrace(LS_PSIP, "  %03d: [%s] eventid 0x%04x at %"PRItime_t", duration %d, title: '%s' (%d bytes)",
+     tvhtrace(LS_PSIP, "  %03d: [%s] eventid 0x%04x at %"PRItime_t", duration %d, etmlocation %x, title: '%s' (%d bytes)",
               i, ch ? channel_get_name(ch, channel_blank_name) : "(null)",
--             eventid, start, length,
-+             eventid, (intmax_t)start, length,
+-             eventid, start, length, etmlocation,
++             eventid, (intmax_t)start, length, etmlocation,
               lang_str_get(title, NULL), titlelen);
  
      save2 = changes2 = 0;

--- a/meta-multimedia/recipes-dvb/tvheadend/tvheadend_git.bb
+++ b/meta-multimedia/recipes-dvb/tvheadend/tvheadend_git.bb
@@ -12,7 +12,7 @@ SRC_URI = "git://github.com/tvheadend/tvheadend.git;branch=master;protocol=https
            file://0001-adjust-for-64bit-time_t.patch \
            "
 
-SRCREV = "9a51cea492e4a5579ca3ddf9233fecfa419de078"
+SRCREV = "cc602833684953fc3e6f1c89d4f08f6dfef179e3"
 PV = "4.3+git${SRCPV}"
 PKGV = "4.3+git${GITPKGV}"
 
@@ -30,4 +30,3 @@ EXTRA_OECONF:append:libc-musl = " --disable-execinfo"
 
 EXTRA_OEMAKE = "CFLAGS_NO_WERROR=yes"
 CLEANBROKEN = "1"
-


### PR DESCRIPTION
Update the tvheadend recipe and the included patch so that it is compatible with the latest upstream version of tvheadend.