### PR TITLE
fluidsynth: update SRC_URI to remove non-existing 2.2.x branch

### DIFF
--- a/meta-multimedia/recipes-multimedia/fluidsynth/fluidsynth.inc
+++ b/meta-multimedia/recipes-multimedia/fluidsynth/fluidsynth.inc
@@ -4,7 +4,7 @@ SECTION = "libs/multimedia"
 LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=fc178bcd425090939a8b634d1d6a9594"
 
-SRC_URI = "git://github.com/FluidSynth/fluidsynth.git;branch=2.2.x;protocol=https"
+SRC_URI = "git://github.com/FluidSynth/fluidsynth.git;branch=master;protocol=https"
 SRCREV = "8b00644751578ba67b709a827cbe5133d849d339"
 S = "${WORKDIR}/git"
 PV = "2.2.6"


### PR DESCRIPTION
Remove branch 2.2.x from SRC_URI as fluidsynth github removed the branch. The SRCREV is on master branch.

Signed-off-by: Preeti Sachan <preeti.sachan@intel.com>
Signed-off-by: Khem Raj <raj.khem@gmail.com>