### PR TITLE
libb64: reactivate BUFFERSIZE patch

### DIFF
--- a/meta-oe/recipes-support/libb64/libb64/0002-use-BUFSIZ-as-buffer-size.patch
+++ b/meta-oe/recipes-support/libb64/libb64/0002-use-BUFSIZ-as-buffer-size.patch
@@ -1,0 +1,57 @@
+From 9ec49389f56816d7ac2331296c03d147531a421a Mon Sep 17 00:00:00 2001
+From: Jakub Wilk <jwilk@debian.org>
+Date: Sat, 27 Mar 2021 22:01:13 -0700
+Subject: [PATCH] use BUFSIZ as buffer size
+
+Bug: http://sourceforge.net/tracker/?func=detail&atid=785907&aid=3591336&group_id=152942
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+---
+ include/b64/decode.h | 3 ++-
+ include/b64/encode.h | 3 ++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/include/b64/decode.h b/include/b64/decode.h
+index b2362e5..8db1d09 100644
+--- a/include/b64/decode.h
++++ b/include/b64/decode.h
+@@ -8,6 +8,7 @@ For details, see http://sourceforge.net/projects/libb64
+ #ifndef BASE64_DECODE_H
+ #define BASE64_DECODE_H
+ 
++#include <cstdio>
+ #include <iostream>
+ 
+ namespace base64
+@@ -22,7 +23,7 @@ namespace base64
+ 		base64_decodestate _state;
+ 		int _buffersize;
+ 
+-		decoder(int buffersize_in = BUFFERSIZE)
++		decoder(int buffersize_in = BUFSIZ)
+ 		: _buffersize(buffersize_in)
+ 		{
+ 			base64_init_decodestate(&_state);
+diff --git a/include/b64/encode.h b/include/b64/encode.h
+index c1a5f88..644e4dd 100644
+--- a/include/b64/encode.h
++++ b/include/b64/encode.h
+@@ -8,6 +8,7 @@ For details, see http://sourceforge.net/projects/libb64
+ #ifndef BASE64_ENCODE_H
+ #define BASE64_ENCODE_H
+ 
++#include <cstdio>
+ #include <iostream>
+ 
+ namespace base64
+@@ -22,7 +23,7 @@ namespace base64
+ 		base64_encodestate _state;
+ 		int _buffersize;
+ 
+-		encoder(int buffersize_in = BUFFERSIZE)
++		encoder(int buffersize_in = BUFSIZ)
+ 			: _buffersize(buffersize_in)
+ 		{
+ 			base64_init_encodestate(&_state);

--- a/meta-oe/recipes-support/libb64/libb64_2.0.0.1.bb
+++ b/meta-oe/recipes-support/libb64/libb64_2.0.0.1.bb
@@ -11,6 +11,7 @@ SRCREV = "ce864b17ea0e24a91e77c7dd3eb2d1ac4175b3f0"
 
 SRC_URI = "git://github.com/libb64/libb64;protocol=https;branch=master \
            file://0001-example-Do-not-run-the-tests.patch \
+           file://0002-use-BUFSIZ-as-buffer-size.patch \
            file://0001-Makefile-fix-parallel-build-of-examples.patch \
            file://0001-examples-Use-proper-function-prototype-for-main.patch \
            "


### PR DESCRIPTION
Bug: http://sourceforge.net/tracker/?func=detail&atid=785907&aid=3591336&group_id=152942 is not fixed in the currently used upstream either.

Signed-off-by: Christian Hohnstaedt <christian@hohnstaedt.de>