### PR TITLE
packagegroup-meta-networking: remove ntpdate

### DIFF
--- a/meta-networking/recipes-core/packagegroups/packagegroup-meta-networking.bb
+++ b/meta-networking/recipes-core/packagegroups/packagegroup-meta-networking.bb
@@ -214,7 +214,7 @@ RDEPENDS:packagegroup-meta-networking-support = "\
     yp-tools \
     mtr \
     netsniff-ng \
-    ntp ntpdate sntp ntpdc ntpq ntp-tickadj ntp-utils \
+    ntp sntp ntpdc ntpq ntp-tickadj ntp-utils \
     ${@bb.utils.contains("DISTRO_FEATURES", "x11", "ntpsec", "", d)} \
     nbd-client \
     nbd-server \


### PR DESCRIPTION
Follow https://github.com/openembedded/meta-openembedded/commit/6315006aadd52e44c15986c9e00ca8162623be85