### PR TITLE
fix(nodejs): package-split between nodejs and nodejs-npm

### DIFF
--- a/meta-oe/recipes-devtools/nodejs/nodejs_18.14.2.bb
+++ b/meta-oe/recipes-devtools/nodejs/nodejs_18.14.2.bb
@@ -174,7 +174,7 @@ do_install_ptest () {
 }
 
 PACKAGES =+ "${PN}-npm"
-FILES:${PN}-npm = "${nonarch_libdir}/node_modules ${bindir}/npm ${bindir}/npx"
+FILES:${PN}-npm = "${nonarch_libdir}/node_modules ${bindir}/npm ${bindir}/npx ${bindir}/corepack"
 RDEPENDS:${PN}-npm = "bash python3-core python3-shell python3-datetime \
     python3-misc python3-multiprocessing"
 


### PR DESCRIPTION
The nodejs package contains a symbolic link `/usr/bin/corepack` to a file from the nodejs-npm package.

```shell
build/tmp/work/core2-64-poky-linux/nodejs/18.14.2-r0/packages-split/nodejs/usr/bin$ ls -l
total 31932
lrwxrwxrwx 1 jan jan       45 Feb 21 05:08 corepack -> ../lib/node_modules/corepack/dist/corepack.js
-rwxr-xr-x 2 jan jan 32694304 Feb 21 05:08 node

build/tmp/work/core2-64-poky-linux/nodejs/18.14.2-r0/packages-split/nodejs-npm/usr/lib/node_modules/corepack/dist$ ls -l
total 2428
-rwxr-xr-x 2 jan jan  614216 Feb 21 05:08 corepack.js
```

Due to the link, the build system detects a dependency from package
`nodejs` to package `nodejs-npm`.
Since the `nodejs-npm` package depends on plenty more packages the link
should be moved to the `nodejs-npm` package.