### PR TITLE
redirect unwanted error message in nginx install

### DIFF
--- a/meta-webserver/recipes-httpd/nginx/nginx.inc
+++ b/meta-webserver/recipes-httpd/nginx/nginx.inc
@@ -148,7 +148,7 @@ do_install () {
 
 pkg_postinst:${PN} () {
     if [ -z "$D" ]; then
-        if type systemd-tmpfiles >/dev/null; then
+        if type systemd-tmpfiles >/dev/null 2>&1; then
             systemd-tmpfiles --create
         elif [ -e ${sysconfdir}/init.d/populate-volatile.sh ]; then
             ${sysconfdir}/init.d/populate-volatile.sh update


### PR DESCRIPTION
if we run opkg install nginx on our system (without systemd) we end up getting the following message in the install process

$ opkg install nginx_1.20.1-r0_core2-64.ipk 
...
//var/lib/opkg/info/nginx.postinst: line 3: type: systemd-tmpfiles: not found

this confused some of my coworkers.
as installation also finishes correctly without sytemd-tmpfiles and not having systemd-tempfiles is not really a problem, I think we should redirect the message also to /dev/NULL