### PR TITLE
frr: fix latest CVEs

### DIFF
--- a/meta-networking/recipes-protocols/frr/frr/CVE-2022-36440.patch
+++ b/meta-networking/recipes-protocols/frr/frr/CVE-2022-36440.patch
@@ -1,0 +1,71 @@
+From 02a0e45f66160f571196a105b217e1bb84d1a835 Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Fri, 30 Sep 2022 08:51:45 -0400
+Subject: [PATCH] bgpd: Ensure FRR has enough data to read 2 bytes in
+ peek_for_as4_capability
+
+In peek_for_as4_capability the code is checking that the
+stream has at least 2 bytes to read ( the opt_type and the
+opt_length ).  However if BGP_OPEN_EXT_OPT_PARAMS_CAPABLE(peer)
+is configured then FRR is reading 3 bytes.  Which is not good
+since the packet could be badly formated.  Ensure that
+FRR has the appropriate data length to read the data.
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+(cherry picked from commit 3e46b43e3788f0f87bae56a86b54d412b4710286)
+
+CVE: CVE-2022-36440
+CVE: CVE-2022-40302
+
+Upstream-Status: Backport
+[https://github.com/FRRouting/frr/commit/02a0e45f66160f571196a105b217e1bb84d1a835]
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ bgpd/bgp_open.c | 27 +++++++++++++++++++++------
+ 1 file changed, 21 insertions(+), 6 deletions(-)
+
+diff --git a/bgpd/bgp_open.c b/bgpd/bgp_open.c
+index c2562c75d3fc..fe4c24a8c979 100644
+--- a/bgpd/bgp_open.c
++++ b/bgpd/bgp_open.c
+@@ -1116,15 +1116,30 @@ as_t peek_for_as4_capability(struct peer *peer, uint16_t length)
+ 		uint8_t opt_type;
+ 		uint16_t opt_length;
+ 
+-		/* Check the length. */
+-		if (stream_get_getp(s) + 2 > end)
++		/* Ensure we can read the option type */
++		if (stream_get_getp(s) + 1 > end)
+ 			goto end;
+ 
+-		/* Fetch option type and length. */
++		/* Fetch the option type */
+ 		opt_type = stream_getc(s);
+-		opt_length = BGP_OPEN_EXT_OPT_PARAMS_CAPABLE(peer)
+-				     ? stream_getw(s)
+-				     : stream_getc(s);
++
++		/*
++		 * Check the length and fetch the opt_length
++		 * If the peer is BGP_OPEN_EXT_OPT_PARAMS_CAPABLE(peer)
++		 * then we do a getw which is 2 bytes.  So we need to
++		 * ensure that we can read that as well
++		 */
++		if (BGP_OPEN_EXT_OPT_PARAMS_CAPABLE(peer)) {
++			if (stream_get_getp(s) + 2 > end)
++				goto end;
++
++			opt_length = stream_getw(s);
++		} else {
++			if (stream_get_getp(s) + 1 > end)
++				goto end;
++
++			opt_length = stream_getc(s);
++		}
+ 
+ 		/* Option length check. */
+ 		if (stream_get_getp(s) + opt_length > end)
+-- 
+2.40.1
+

--- a/meta-networking/recipes-protocols/frr/frr/CVE-2022-40318.patch
+++ b/meta-networking/recipes-protocols/frr/frr/CVE-2022-40318.patch
@@ -1,0 +1,81 @@
+From 72088b05d469a6b6a8b9a2b250885246ea0c2acb Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Fri, 30 Sep 2022 08:57:43 -0400
+Subject: [PATCH] bgpd: Ensure FRR has enough data to read 2 bytes in
+ bgp_open_option_parse
+
+In bgp_open_option_parse the code is checking that the
+stream has at least 2 bytes to read ( the opt_type and
+the opt_length).  However if BGP_OPEN_EXT_OPT_PARAMS_CAPABLE(peer)
+is configured then FRR is reading 3 bytes.  Which is not good
+since the packet could be badly formateed.  Ensure that
+FRR has the appropriate data length to read the data.
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+(cherry picked from commit 1117baca3c592877a4d8a13ed6a1d9bd83977487)
+
+CVE: CVE-2022-40318
+
+Upstream-Status: Backport
+[https://github.com/FRRouting/frr/commit/72088b05d469a6b6a8b9a2b250885246ea0c2acb]
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ bgpd/bgp_open.c | 35 ++++++++++++++++++++++++++++-------
+ 1 file changed, 28 insertions(+), 7 deletions(-)
+
+diff --git a/bgpd/bgp_open.c b/bgpd/bgp_open.c
+index fe4c24a8c979..de550d2ac607 100644
+--- a/bgpd/bgp_open.c
++++ b/bgpd/bgp_open.c
+@@ -1209,19 +1209,40 @@ int bgp_open_option_parse(struct peer *peer, uint16_t length,
+ 		uint8_t opt_type;
+ 		uint16_t opt_length;
+ 
+-		/* Must have at least an OPEN option header */
+-		if (STREAM_READABLE(s) < 2) {
++		/*
++		 * Check that we can read the opt_type and fetch it
++		 */
++		if (STREAM_READABLE(s) < 1) {
+ 			zlog_info("%s Option length error", peer->host);
+ 			bgp_notify_send(peer, BGP_NOTIFY_OPEN_ERR,
+ 					BGP_NOTIFY_OPEN_MALFORMED_ATTR);
+ 			return -1;
+ 		}
+-
+-		/* Fetch option type and length. */
+ 		opt_type = stream_getc(s);
+-		opt_length = BGP_OPEN_EXT_OPT_PARAMS_CAPABLE(peer)
+-				     ? stream_getw(s)
+-				     : stream_getc(s);
++
++		/*
++		 * Check the length of the stream to ensure that
++		 * FRR can properly read the opt_length. Then read it
++		 */
++		if (BGP_OPEN_EXT_OPT_PARAMS_CAPABLE(peer)) {
++			if (STREAM_READABLE(s) < 2) {
++				zlog_info("%s Option length error", peer->host);
++				bgp_notify_send(peer, BGP_NOTIFY_OPEN_ERR,
++						BGP_NOTIFY_OPEN_MALFORMED_ATTR);
++				return -1;
++			}
++
++			opt_length = stream_getw(s);
++		} else {
++			if (STREAM_READABLE(s) < 1) {
++				zlog_info("%s Option length error", peer->host);
++				bgp_notify_send(peer, BGP_NOTIFY_OPEN_ERR,
++						BGP_NOTIFY_OPEN_MALFORMED_ATTR);
++				return -1;
++			}
++
++			opt_length = stream_getc(s);
++		}
+ 
+ 		/* Option length check. */
+ 		if (STREAM_READABLE(s) < opt_length) {
+-- 
+2.40.1
+

--- a/meta-networking/recipes-protocols/frr/frr/CVE-2022-43681.patch
+++ b/meta-networking/recipes-protocols/frr/frr/CVE-2022-43681.patch
@@ -1,0 +1,58 @@
+From f316975cedd8ef17d47b56be0d3d21711fe44a25 Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Wed, 2 Nov 2022 13:24:48 -0400
+Subject: [PATCH] bgpd: Ensure that bgp open message stream has enough data to
+ read
+
+If a operator receives an invalid packet that is of insufficient size
+then it is possible for BGP to assert during reading of the packet
+instead of gracefully resetting the connection with the peer.
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+(cherry picked from commit 766eec1b7accffe2c04a5c9ebb14e9f487bb9f78)
+
+CVE: CVE-2022-43681
+
+Upstream-Status: Backport
+[https://github.com/FRRouting/frr/commit/766eec1b7accffe2c04a5c9ebb14e9f487bb9f78]
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ bgpd/bgp_packet.c | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/bgpd/bgp_packet.c b/bgpd/bgp_packet.c
+index bcd47e32d453..5225db29fe09 100644
+--- a/bgpd/bgp_packet.c
++++ b/bgpd/bgp_packet.c
+@@ -1176,8 +1176,27 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
+ 	    || CHECK_FLAG(peer->flags, PEER_FLAG_EXTENDED_OPT_PARAMS)) {
+ 		uint8_t opttype;
+ 
++		if (STREAM_READABLE(peer->curr) < 1) {
++			flog_err(
++				EC_BGP_PKT_OPEN,
++				"%s: stream does not have enough bytes for extended optional parameters",
++				peer->host);
++			bgp_notify_send(peer, BGP_NOTIFY_OPEN_ERR,
++					BGP_NOTIFY_OPEN_MALFORMED_ATTR);
++			return BGP_Stop;
++		}
++
+ 		opttype = stream_getc(peer->curr);
+ 		if (opttype == BGP_OPEN_NON_EXT_OPT_TYPE_EXTENDED_LENGTH) {
++			if (STREAM_READABLE(peer->curr) < 2) {
++				flog_err(
++					EC_BGP_PKT_OPEN,
++					"%s: stream does not have enough bytes to read the extended optional parameters optlen",
++					peer->host);
++				bgp_notify_send(peer, BGP_NOTIFY_OPEN_ERR,
++						BGP_NOTIFY_OPEN_MALFORMED_ATTR);
++				return BGP_Stop;
++			}
+ 			optlen = stream_getw(peer->curr);
+ 			SET_FLAG(peer->sflags,
+ 				 PEER_STATUS_EXT_OPT_PARAMS_LENGTH);
+-- 
+2.40.1
+

--- a/meta-networking/recipes-protocols/frr/frr_8.2.2.bb
+++ b/meta-networking/recipes-protocols/frr/frr_8.2.2.bb
@@ -14,6 +14,8 @@ SRC_URI = "git://github.com/FRRouting/frr.git;protocol=https;branch=stable/8.2 \
            file://CVE-2022-37032.patch \
            file://CVE-2022-42917.patch \
            file://CVE-2022-36440.patch \
+           file://CVE-2022-40318.patch \
+           file://CVE-2022-43681.patch \
            file://frr.pam \
 	      "
 

--- a/meta-networking/recipes-protocols/frr/frr_8.2.2.bb
+++ b/meta-networking/recipes-protocols/frr/frr_8.2.2.bb
@@ -13,6 +13,7 @@ SRC_URI = "git://github.com/FRRouting/frr.git;protocol=https;branch=stable/8.2 \
            file://CVE-2022-37035.patch \
            file://CVE-2022-37032.patch \
            file://CVE-2022-42917.patch \
+           file://CVE-2022-36440.patch \
            file://frr.pam \
 	      "
 


### PR DESCRIPTION
Add/backport patches for the latest round of CVEs:

* CVE-2022-36440 / CVE-2022-40302 (these seem to describe the same issue)
* CVE-2022-40318
* CVE-2022-43681

First two taken from stable/8.2, last one cherry-picked from master.

Reference:
https://cyberriskleaders.com/new-vulnerabilities-disclosed-in-frrouting-software/