### PR TITLE
paho-mqtt-c: Improve performance and disable tests

### DIFF
--- a/meta-oe/recipes-connectivity/paho-mqtt-c/paho-mqtt-c_1.3.12.bb
+++ b/meta-oe/recipes-connectivity/paho-mqtt-c/paho-mqtt-c_1.3.12.bb
@@ -30,4 +30,4 @@ do_install:append() {
     find ${D}${prefix} -maxdepth 1 -type f -delete
 }
 
-EXTRA_OECMAKE = "-DPAHO_WITH_SSL=ON -DPAHO_ENABLE_TESTING=OFF"
+EXTRA_OECMAKE = "-DPAHO_WITH_SSL=ON -DPAHO_ENABLE_TESTING=OFF -DPAHO_HIGH_PERFORMANCE=ON"

--- a/meta-oe/recipes-connectivity/paho-mqtt-c/paho-mqtt-c_1.3.12.bb
+++ b/meta-oe/recipes-connectivity/paho-mqtt-c/paho-mqtt-c_1.3.12.bb
@@ -30,4 +30,4 @@ do_install:append() {
     find ${D}${prefix} -maxdepth 1 -type f -delete
 }
 
-EXTRA_OECMAKE = "-DPAHO_WITH_SSL=ON"
+EXTRA_OECMAKE = "-DPAHO_WITH_SSL=ON -DPAHO_ENABLE_TESTING=OFF"


### PR DESCRIPTION
The paho-mqtt-c library builds with tests and tracing functionality enabled by default, these patches disable both of the settings improving runtime and build performance.