### PR TITLE
 etcd: systemd unit support for clustering

### DIFF
--- a/meta-oe/recipes-extended/etcd/etcd/etcd-existing.conf
+++ b/meta-oe/recipes-extended/etcd/etcd/etcd-existing.conf
@@ -1,0 +1,37 @@
+# This is the configuration file to start the etcd server with
+# existing cluster configuration in the data directory.
+
+# Initial cluster state ('new' or 'existing').
+ETCD_INITIAL_CLUSTER_STATE='existing'
+
+# Path to the data directory.
+ETCD_DATA_DIR='/var/lib/etcd'
+
+# Time (in milliseconds) of a heartbeat interval.
+ETCD_HEARTBEAT_INTERVAL=100
+
+# Time (in milliseconds) for an election to timeout.
+ETCD_ELECTION_TIMEOUT=1000
+
+# List of comma separated URLs to listen on for peer traffic.
+ETCD_LISTEN_PEER_URLS=http://localhost:2380
+
+# List of comma separated URLs to listen on for client traffic.
+ETCD_LISTEN_CLIENT_URLS=http://localhost:2379
+
+# List of this member's peer URLs to advertise to the rest of the cluster.
+# The URLs needed to be a comma-separated list.
+ETCD_INITIAL_ADVERTISE_PEER_URLS=http://localhost:2380
+
+# List of this member's client URLs to advertise to the public.
+# The URLs needed to be a comma-separated list.
+ETCD_ADVERTISE_CLIENT_URLS=http://localhost:2379
+
+# Enable info-level logging for etcd.
+ETCD_LOG_LEVEL='info'
+
+# Specify 'stdout' or 'stderr' to skip journald logging even when running under systemd.
+ETCD_LOG_OUTPUTS='default'
+
+# etcd is not officially supported on arm64
+ETCD_UNSUPPORTED_ARCH='arm'

--- a/meta-oe/recipes-extended/etcd/etcd/etcd-new.path
+++ b/meta-oe/recipes-extended/etcd/etcd/etcd-new.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Monitor the etcd config file changes
+
+[Path]
+PathChanged=/run/etcd-new.conf
+Unit=etcd-new.service
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-oe/recipes-extended/etcd/etcd/etcd-new.service
+++ b/meta-oe/recipes-extended/etcd/etcd/etcd-new.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=etcd cluster member start/add service
+Documentation=https://etcd.io/docs/v3.5/op-guide/clustering/
+ConditionPathExists=!/var/lib/etcd/member
+ConditionPathExists=/run/etcd-new.conf
+OnFailure=etcd.service
+
+[Service]
+Type=notify
+EnvironmentFile=/run/etcd-new.conf
+ExecStart=/usr/bin/etcd
+Restart=no
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-oe/recipes-extended/etcd/etcd/etcd.service
+++ b/meta-oe/recipes-extended/etcd/etcd/etcd.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=etcd key-value store
+Documentation=https://github.com/etcd-io/etcd
+After=network-online.target local-fs.target remote-fs.target time-sync.target
+Wants=network-online.target local-fs.target remote-fs.target time-sync.target
+ConditionPathExists=/var/lib/etcd/member
+
+[Service]
+Type=notify
+EnvironmentFile=/etc/etcd.d/etcd-existing.conf
+ExecStart=/usr/bin/etcd
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-oe/recipes-extended/etcd/etcd_3.5.7.bb
+++ b/meta-oe/recipes-extended/etcd/etcd_3.5.7.bb
@@ -10,6 +10,8 @@ SRC_URI = " \
     file://0001-test_lib.sh-remove-gobin-requirement-during-build.patch;patchdir=src/${GO_IMPORT} \
     file://etcd.service \
     file://etcd-existing.conf \
+    file://etcd-new.service \
+    file://etcd-new.path \
 "
 
 SRCREV = "215b53cf3b48ee761f4c40908b3874b2e5e95e9f"
@@ -53,7 +55,7 @@ go_do_compile:prepend() {
 
 REQUIRED_DISTRO_FEATURES = "systemd"
 SYSTEMD_PACKAGES = "${PN}"
-SYSTEMD_SERVICE:${PN}:append = " etcd.service"
+SYSTEMD_SERVICE:${PN}:append = " etcd.service etcd-new.service etcd-new.path"
 
 do_install:append() {
     install -d ${D}${bindir}/
@@ -63,6 +65,8 @@ do_install:append() {
     install -m 0644 ${WORKDIR}/etcd-existing.conf -D -t ${D}${sysconfdir}/etcd.d
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/etcd.service ${D}${systemd_system_unitdir}/
+    install -m 0644 ${WORKDIR}/etcd-new.service ${D}${systemd_system_unitdir}/
+    install -m 0644 ${WORKDIR}/etcd-new.path ${D}${systemd_system_unitdir}/
 }
 
 FILES:${PN}:append = " ${sysconfdir}/etcd.d/etcd-existing.conf"


### PR DESCRIPTION
Refer  etcd documentation https://etcd.io/docs/v3.5/op-guide/clustering/
for etcd based cluster design details.

Added  required systemd unit and configuration files to start a new cluster and restart existing etcd cluster.
