### PR TITLE
python3-bleak: add recipe

### DIFF
--- a/meta-python/recipes-devtools/python/python3-bleak/0001-fix-poetry-version-compatibility.patch
+++ b/meta-python/recipes-devtools/python/python3-bleak/0001-fix-poetry-version-compatibility.patch
@@ -1,0 +1,21 @@
+--- a/pyproject.toml	2023-04-19 19:04:47.159474100 -0300
++++ b/pyproject.toml	2023-05-04 08:08:12.289941765 -0300
+@@ -31,15 +31,15 @@
+ bleak-winrt = { version = "^1.2.0", markers = "platform_system=='Windows'" }
+ dbus-fast = { version = "^1.83.0", markers = "platform_system == 'Linux'" }
+ 
+-[tool.poetry.group.docs.dependencies]
++#[tool.poetry.group.docs.dependencies]
+ Sphinx = { version = "^5.1.1", python = ">=3.8" }
+ sphinx-rtd-theme = "^1.0.0"
+ 
+-[tool.poetry.group.lint.dependencies]
++#[tool.poetry.group.lint.dependencies]
+ black = "^22.1.0"
+ flake8 = { version = "^5.0.0", python = ">=3.8" }
+ 
+-[tool.poetry.group.test.dependencies]
++#[tool.poetry.group.test.dependencies]
+ asynctest = { version = "^0.13.0",  python = "<3.8" }
+ pytest = "^7.0.0"
+ pytest-asyncio = "^0.19.0"

--- a/meta-python/recipes-devtools/python/python3-bleak_0.20.2.bb
+++ b/meta-python/recipes-devtools/python/python3-bleak_0.20.2.bb
@@ -1,0 +1,20 @@
+SUMMARY = "Bleak is a GATT client software, capable of connecting to BLE devices acting as GATT servers."
+HOMEPAGE = "https://github.com/hbldh/bleak"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=bcbc2069a86cba1b5e47253679f66ed7"
+
+SRC_URI:append = " \
+    file://0001-fix-poetry-version-compatibility.patch \
+"
+
+SRC_URI[sha256sum] = "6c92a47abe34e6dea8ffc5cea9457cbff6e1be966854839dbc25cddb36b79ee4"
+
+PYPI_PACKAGE = "bleak"
+
+inherit pypi python_poetry_core
+
+RDEPENDS:${PN} += " \
+    python3-core (>=3.7) \
+    python3-async-timeout \
+    python3-dbus-fast \
+"


### PR DESCRIPTION
Bleak is a GATT client software, capable of connecting to BLE devices acting as GATT servers.