### PR TITLE
meta-python: Add stopit

### DIFF
--- a/meta-python/recipes-devtools/python/python3-stopit/LICENSE
+++ b/meta-python/recipes-devtools/python/python3-stopit/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Gilles Lenfant
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/meta-python/recipes-devtools/python/python3-stopit_1.1.2.bb
+++ b/meta-python/recipes-devtools/python/python3-stopit_1.1.2.bb
@@ -1,0 +1,13 @@
+SUMMARY = "Raise asynchronous exceptions in other threads, control the timeout of blocks or callables with two context managers and two decorators."
+HOMEPAGE = "https://pypi.org/project/stopit/"
+SECTION = "devel/python"
+
+SRC_URI += " file://LICENSE "
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;md5=497c556f42b1355b64190da2f3d88f93"
+
+SRC_URI[sha256sum] = "f7f39c583fd92027bd9d06127b259aee7a5b7945c1f1fa56263811e1e766996d"
+
+inherit pypi setuptools3
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
stopit is a library to raise asynchronous exceptions in other threads, control the timeout of blocks or callables with two context managers and two decorators.

The license isn't shipped in the pypi package, so it was extracted from the github repo at [1].

[1] https://github.com/glenfant/stopit/blob/master/LICENSE