### PR TITLE
python3-stopit: add missing run-time dependencies

### DIFF
--- a/meta-python/recipes-devtools/python/python3-stopit_1.1.2.bb
+++ b/meta-python/recipes-devtools/python/python3-stopit_1.1.2.bb
@@ -10,4 +10,8 @@ SRC_URI[sha256sum] = "f7f39c583fd92027bd9d06127b259aee7a5b7945c1f1fa56263811e1e7
 
 inherit pypi setuptools3
 
+RDEPENDS_${PN} += "\
+    ${PYTHON_PN}-setuptools \
+    "
+
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
The stopit package needs setuptools python module so add it to RDEPENDS.

This fixes:
    File "/usr/lib64/python3.9/site-packages/stopit/__init__.py", line 10, in <module>                                                                           │azaharia@otp-linux03:~/lts-builds/lts21_intel-x86-64_HEAD/layers/meta-openembedded/meta-python/recipes-devtools/python$ git status
	import pkg_resources                                                                                                                                       │HEAD detached from 97f83c3439
    ModuleNotFoundError: No module named 'pkg_resources'                                                                                                                                                               │        ImportError: No module named pkg_resources