### PR TITLE
ntpd: switch service type from forking to simple

### DIFF
--- a/meta-networking/recipes-support/ntp/ntp/ntpd.service
+++ b/meta-networking/recipes-support/ntp/ntp/ntpd.service
@@ -3,9 +3,8 @@ Description=Network Time Service
 After=network.target
 
 [Service]
-Type=forking
-PIDFile=/run/ntpd.pid
-ExecStart=/usr/sbin/ntpd -u ntp:ntp -p /run/ntpd.pid -g
+Type=simple
+ExecStart=/usr/sbin/ntpd -u ntp:ntp -n -g
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Type=forking means systemd waits untill the main process, /usr/sbin/ntpd in this case, has exited. However, the ntpd daemon does not seem to call fork() or vfork() and runs endlessly untill killed. Eventually, this causes systemd to trigger a timeout, and the ntpd service is killed. All the while, "systemctl status ntpd" shows "activating (start)" instead of "active (running)". This is fixed by switching Type=forking to Type=simple.

Reading ntpd(8) shows that the "-n" option requests ntpd not to fork, so also use that to be safe.

Finally, there is no need anymore to keep a pidfile around.