### PR TITLE
nginx: kirkstone: upgrade to 1.24.0 release

### DIFF
--- a/meta-webserver/recipes-httpd/nginx/nginx_1.24.0.bb
+++ b/meta-webserver/recipes-httpd/nginx/nginx_1.24.0.bb
@@ -1,0 +1,6 @@
+require nginx.inc
+
+LIC_FILES_CHKSUM = "file://LICENSE;md5=175abb631c799f54573dc481454c8632"
+
+SRC_URI[sha256sum] = "77a2541637b92a621e3ee76776c8b7b40cf6d707e69ba53a940283e30ff2f55d"
+


### PR DESCRIPTION
According to http://nginx.org/en/CHANGES nginx supports the openssl 3.x component only from version 1.21.2. In Kirstone openssl 3.x is included but all provided versions of nginx are older, so there is currently an incompatibility. With this patch this incompatibility get removed.