### PR TITLE
android-tools: fix QA warning about buildpaths

### DIFF
--- a/meta-oe/recipes-devtools/android-tools/android-tools_5.1.1.r37.bb
+++ b/meta-oe/recipes-devtools/android-tools/android-tools_5.1.1.r37.bb
@@ -92,7 +92,7 @@ do_compile() {
 
     # Setting both variables below causing our makefiles to not work with
     # implicit make rules
-    unset CFLAGS
+    CFLAGS="-ffile-prefix-map=${S}=/usr/src/debug/${PN}/${EXTENDPE}${PV}-${PR}"
     unset CPPFLAGS
 
     export SRCDIR=${S}


### PR DESCRIPTION
Replace all filenames in the object with "--file-prefix-map" which is lost when resetting CFLAGS.