### PR TITLE
image_types_sparse: Fix syntax error

### DIFF
--- a/meta-oe/classes/image_types_sparse.bbclass
+++ b/meta-oe/classes/image_types_sparse.bbclass
@@ -8,9 +8,10 @@ inherit image_types
 SPARSE_BLOCK_SIZE ??= "4096"
 
 CONVERSIONTYPES += "sparse"
-CONVERSION_CMD:sparse() {
-    INPUT="${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type}"
-    truncate --no-create --size=%${SPARSE_BLOCK_SIZE} "$INPUT"
-    img2simg -s "$INPUT" "$INPUT.sparse" ${SPARSE_BLOCK_SIZE}
-}
+
+CONVERSION_CMD:sparse = " \
+    truncate --no-create --size=%${SPARSE_BLOCK_SIZE} "${IMAGE_NAME}.${type}"; \
+    img2simg -s "${IMAGE_NAME}.${type}" "${IMAGE_NAME}.${type}.sparse" ${SPARSE_BLOCK_SIZE}; \
+ "
+
 CONVERSION_DEPENDS_sparse = "android-tools-native"


### PR DESCRIPTION
When using the image type:

	IMAGE_FSTYPES += " wic.sparse"
	IMAGE_CLASSES += " image_types_sparse"

The following error arises:

	Syntax error: Bad function name

So need to remove function in favor of variable.

Also remove IMAGE_NAME_SUFFIX as per:

https://git.openembedded.org/openembedded-core/commit/?id=26d97acc71379ab6702fa54a23b6542a3f51779c