### PR TITLE
image_types_sparse: Fix syntax error

### DIFF
--- a/meta-oe/classes/image_types_sparse.bbclass
+++ b/meta-oe/classes/image_types_sparse.bbclass
@@ -8,9 +8,10 @@ inherit image_types
 SPARSE_BLOCK_SIZE ??= "4096"
 
 CONVERSIONTYPES += "sparse"
-CONVERSION_CMD:sparse() {
-    INPUT="${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type}"
-    truncate --no-create --size=%${SPARSE_BLOCK_SIZE} "$INPUT"
-    img2simg -s "$INPUT" "$INPUT.sparse" ${SPARSE_BLOCK_SIZE}
-}
+
+CONVERSION_CMD:sparse = " \
+    truncate --no-create --size=%${SPARSE_BLOCK_SIZE} "${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type}"; \
+    img2simg -s "${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type}" "${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type}.sparse" ${SPARSE_BLOCK_SIZE}; \
+ "
+
 CONVERSION_DEPENDS_sparse = "android-tools-native"


### PR DESCRIPTION
This has been applied to master:

https://github.com/openembedded/meta-openembedded/commit/dff205f5a3b15cbe1d63c5e351dae7a659042213

but the IMAGE_NAME_SUFFIX variable is still used in mickledore, so need to create new commit as opposed to cherry-pick backport.