### PR TITLE
microcom: add new recipe

### DIFF
--- a/meta-oe/recipes-devtools/microcom/microcom_2023.09.0.bb
+++ b/meta-oe/recipes-devtools/microcom/microcom_2023.09.0.bb
@@ -1,0 +1,20 @@
+SUMMARY = "Minimalistic terminal program for communicating with devices over a serial connection"
+HOMEPAGE = "https://github.com/pengutronix/microcom"
+LICENSE = "GPL-2.0-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=c9f7c009791eaa4b9ca90dc4c9538d24"
+
+SRC_URI = "https://github.com/pengutronix/microcom/releases/download/v${PV}/microcom-${PV}.tar.xz"
+SRC_URI[sha256sum] = "ef42184bb35c9762b3e9c70748696f7478efacad8412a88aaf2d9a6a500231a1"
+
+DEPENDS = "readline"
+
+inherit autotools update-alternatives
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[can] = "--enable-can,--disable-can"
+
+EXTRA_OECONF = "--enable-largefile"
+
+# higher priority than busybox' microcom
+ALTERNATIVE:${PN} = "microcom"
+ALTERNATIVE_PRIORITY[microcom] = "100"


### PR DESCRIPTION
A minimalistic terminal program for communicating with devices over a serial connection.

It features connection via RS232 serial interfaces (including setting of transfer rates):

    microcom --speed=115200 --port=/dev/ttyS0

as well as in `telnetmode' as specified in rfc2217

    microcom --telnet=somehost:port

and a (Linux specific) can mode:

    microcom --can=interface:rx_id:tx_id