### PR TITLE
iperf3: Fix CVE-2023-38403

### DIFF
--- a/meta-oe/recipes-benchmark/iperf3/iperf3/0001-Fix-memory-allocation-hazard-1542-.-1543.patch
+++ b/meta-oe/recipes-benchmark/iperf3/iperf3/0001-Fix-memory-allocation-hazard-1542-.-1543.patch
@@ -1,0 +1,46 @@
+From 0ef151550d96cc4460f98832df84b4a1e87c65e9 Mon Sep 17 00:00:00 2001
+From: "Bruce A. Mah" <bmah@es.net>
+Date: Fri, 7 Jul 2023 11:35:02 -0700
+Subject: [PATCH] Fix memory allocation hazard (#1542). (#1543)
+
+Reported by:	@someusername123 on GitHub
+---
+ src/iperf_api.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/src/iperf_api.c b/src/iperf_api.c
+index f2d4162..a95e024 100644
+--- a/src/iperf_api.c
++++ b/src/iperf_api.c
+@@ -2670,6 +2670,7 @@ static cJSON *
+ JSON_read(int fd)
+ {
+     uint32_t hsize, nsize;
++    size_t strsize;
+     char *str;
+     cJSON *json = NULL;
+     int rc;
+@@ -2682,7 +2683,9 @@ JSON_read(int fd)
+     if (Nread(fd, (char*) &nsize, sizeof(nsize), Ptcp) >= 0) {
+ 	hsize = ntohl(nsize);
+ 	/* Allocate a buffer to hold the JSON */
+-	str = (char *) calloc(sizeof(char), hsize+1);	/* +1 for trailing null */
++	strsize = hsize + 1;              /* +1 for trailing NULL */
++	if (strsize) {
++	str = (char *) calloc(sizeof(char), strsize);
+ 	if (str != NULL) {
+ 	    rc = Nread(fd, str, hsize, Ptcp);
+ 	    if (rc >= 0) {
+@@ -2701,6 +2704,10 @@ JSON_read(int fd)
+ 	    }
+ 	}
+ 	free(str);
++	}
++	else {
++	    printf("WARNING:  Data length overflow\n");
++	}
+     }
+     return json;
+ }
+-- 
+2.25.1

--- a/meta-oe/recipes-benchmark/iperf3/iperf3_3.7.bb
+++ b/meta-oe/recipes-benchmark/iperf3/iperf3_3.7.bb
@@ -15,6 +15,7 @@ DEPENDS = "openssl"
 
 SRC_URI = "git://github.com/esnet/iperf.git;branch=master;protocol=https \
            file://0002-Remove-pg-from-profile_CFLAGS.patch \
+           file://0001-Fix-memory-allocation-hazard-1542-.-1543.patch \
            "
 
 SRCREV = "dfcea9f6a09ead01089a3c9d20c7032f2c0af2c1"


### PR DESCRIPTION
iperf3 before 3.14 allows peers to cause an integer overflow and heap corruption via a crafted length field.

NVD link: https://nvd.nist.gov/vuln/detail/CVE-2023-38403

Upstream-Status: Backported from https://github.com/esnet/iperf/commit/0ef151550d96cc4460f98832df84b4a1e87c65e9