### PR TITLE
libebml: Enable shared libraries

### DIFF
--- a/meta-multimedia/recipes-mkv/libebml/libebml_1.4.4.bb
+++ b/meta-multimedia/recipes-mkv/libebml/libebml_1.4.4.bb
@@ -10,6 +10,5 @@ S = "${WORKDIR}/git"
 
 inherit pkgconfig cmake dos2unix
 
-#Static library enabled by default. It has been added in case you want to use it dynamically.
-#EXTRA_OECMAKE = "-DBUILD_SHARED_LIBS=ON"
+EXTRA_OECMAKE = "-DBUILD_SHARED_LIBS=ON"
 


### PR DESCRIPTION
To fix build Gerbera, as:

  /usr/src/debug/libmatroska/1.7.1-r0/src/KaxBlock.cpp:538:(.text+0x4144):
  undefined reference to `libebml::SafeReadIOCallback::EndOfStreamX::EndOfStreamX(unsigned int)'