### PR TITLE
libvpx: remove explicit armv5 and armv6 support

### DIFF
--- a/meta-oe/recipes-multimedia/webm/libvpx_1.13.1.bb
+++ b/meta-oe/recipes-multimedia/webm/libvpx_1.13.1.bb
@@ -24,8 +24,6 @@ BUILD_LDFLAGS += "-pthread"
 export CC
 export LD = "${CC}"
 
-VPXTARGET:armv5te = "armv5te-linux-gcc"
-VPXTARGET:armv6 = "armv6-linux-gcc"
 VPXTARGET:armv7a = "${@bb.utils.contains("TUNE_FEATURES","neon","armv7-linux-gcc","generic-gnu",d)}"
 VPXTARGET ?= "generic-gnu"
 


### PR DESCRIPTION
Remove armv6 and armv5 targets from libvpx recipe, they don't build anymore (in case the toolchain name is specified) - the upstream project has dropped [armv6 it in 2016](https://github.com/webmproject/libvpx/commit/d55724fae9cb27e070add7952394fc0427ef2061) and [armv5 in 2014](https://github.com/webmproject/libvpx/commit/eafa0d0ce73ddefee7d1af4b7f7cf97041d1d52c).

The recipe builds in case the fallthrough `generic-gnu` value is used.