### PR TITLE
glog: Disable 64bit atomics on armv{5,6}

### DIFF
--- a/meta-oe/recipes-support/glog/glog_0.6.0.bb
+++ b/meta-oe/recipes-support/glog/glog_0.6.0.bb
@@ -22,6 +22,8 @@ PACKAGECONFIG ?= "shared unwind 64bit-atomics"
 PACKAGECONFIG:remove:riscv64 = "unwind"
 PACKAGECONFIG:remove:riscv32 = "unwind 64bit-atomics"
 PACKAGECONFIG:remove:mipsarch = "64bit-atomics"
+PACKAGECONFIG:remove:armv5 = "64bit-atomics"
+PACKAGECONFIG:remove:armv6 = "64bit-atomics"
 
 PACKAGECONFIG:append:libc-musl:riscv64 = " execinfo"
 PACKAGECONFIG:append:libc-musl:riscv32 = " execinfo"


### PR DESCRIPTION
The ARMv5 and ARMv6 architectures do not support 64-bit atomics, so
disable them.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
