### PR TITLE
abseil-cpp: force use of -std=c++14

### DIFF
--- a/meta-oe/recipes-devtools/abseil-cpp/abseil-cpp_git.bb
+++ b/meta-oe/recipes-devtools/abseil-cpp/abseil-cpp_git.bb
@@ -25,6 +25,8 @@ ASNEEDED:class-nativesdk = ""
 
 inherit cmake
 
+CXXFLAGS += "-std=c++14"
+
 EXTRA_OECMAKE = "-DBUILD_SHARED_LIBS=ON \
                  -DBUILD_TESTING=OFF    \
                  -DABSL_ENABLE_INSTALL=ON \


### PR DESCRIPTION
Protobuf is compiled with -std=c++14, so abseil must be as well. Details can be found here: https://github.com/protocolbuffers/protobuf/issues/10768