### PR TITLE
kernel-selftest: Add few more testcases

### DIFF
--- a/meta-oe/recipes-kernel/kernel-selftest/kernel-selftest.bb
+++ b/meta-oe/recipes-kernel/kernel-selftest/kernel-selftest.bb
@@ -49,6 +49,8 @@ DEBUG_PREFIX_MAP:remove = "-fcanon-prefix-map"
 TEST_LIST = "\
     ${@bb.utils.filter('PACKAGECONFIG', 'bpf firmware vm', d)} \
     rtc \
+    ptp \
+    timers \
 "
 EXTRA_OEMAKE = '\
     CROSS_COMPILE=${TARGET_PREFIX} \


### PR DESCRIPTION
This commit will build and install following testcases under /usr/kernel-selftest of filesystem,
    * ptp
    * timers