### PR TITLE
kernel-selftest: Add few more testcases

### DIFF
--- a/meta-oe/recipes-kernel/kernel-selftest/kernel-selftest.bb
+++ b/meta-oe/recipes-kernel/kernel-selftest/kernel-selftest.bb
@@ -44,6 +44,8 @@ S = "${WORKDIR}/${BP}"
 TEST_LIST = "\
     ${@bb.utils.filter('PACKAGECONFIG', 'bpf firmware vm', d)} \
     rtc \
+    ptp \
+    timers \
 "
 
 EXTRA_OEMAKE = '\


### PR DESCRIPTION
This commit will build and install following testcases under /usr/kernel-selftest of filesystem,
    * ptp
    * timers