### PR TITLE
polkit: fix rules.d permissions

### DIFF
--- a/meta-oe/recipes-extended/polkit/polkit_123.bb
+++ b/meta-oe/recipes-extended/polkit/polkit_123.bb
@@ -46,7 +46,9 @@ SYSTEMD_AUTO_ENABLE = "disable"
 do_install:append() {
 	#Fix up permissions on polkit rules.d to work with rpm4 constraints
 	chmod 700 ${D}/${datadir}/polkit-1/rules.d
+	chmod 700 ${D}/${sysconfdir}/polkit-1/rules.d
 	chown polkitd:root ${D}/${datadir}/polkit-1/rules.d
+	chown polkitd:root ${D}/${sysconfdir}/polkit-1/rules.d
 }
 
 FILES:${PN} += "${libdir}/polkit-1 ${nonarch_libdir}/polkit-1 ${datadir}"


### PR DESCRIPTION
Fix conflicting installations of
polkit-group-rule-{network/datetime/udisks2}. Ensure {sysconfdir}/polkit-1/rules.d permissions match the current recipe during installation to prevent conflicts in do_rootfs of an image.

Signed-off-by: Maxime Roussin-Belanger <maxime.roussinbelanger@gmail.com>