### PR TITLE
xdg-desktop-portal: add missing glib-2.0-native dependency

### DIFF
--- a/meta-oe/recipes-support/xdg-desktop-portal/xdg-desktop-portal_1.18.1.bb
+++ b/meta-oe/recipes-support/xdg-desktop-portal/xdg-desktop-portal_1.18.1.bb
@@ -8,6 +8,7 @@ REQUIRED_DISTRO_FEATURES = "polkit"
 DEPENDS = " \
     json-glib \
     glib-2.0 \
+    glib-2.0-native \
     flatpak \
     libportal \
     geoclue \


### PR DESCRIPTION
Without this we get this error `| ../git/src/meson.build:3:29: ERROR: Program 'gdbus-codegen' not found or not executable`

and glib-2.0-native provides gdbus-codegen

Signed-off-by: Maxime Roussin-Bélanger <maxime.roussinbelanger@gmail.com>