### PR TITLE
python3-gevent: adding missing dependency to python3-zopeevent

### DIFF
--- a/meta-python/recipes-devtools/python/python3-gevent_24.2.1.bb
+++ b/meta-python/recipes-devtools/python/python3-gevent_24.2.1.bb
@@ -9,6 +9,8 @@ DEPENDS += "python3-greenlet libev libuv c-ares python3-cython-native"
 RDEPENDS:${PN} = "python3-greenlet \
 		  python3-mime \
 		  python3-pprint \
+		  python3-zopeevent \
+		  python3-zopeinterface \
 		 "
 
 SRC_URI += "file://0001-_setuputils.py-Do-not-add-sys_inc_dir.patch"


### PR DESCRIPTION
... and python3-zopeinterface

As of [gevent/setup.py](https://github.com/gevent/gevent/blob/a67891991c95b5ffca78dc1f1a11f956ec3963ca/setup.py#L232), gevent depends on zope.event and zope.interfaces -> add those runtime dependencies to the recipe.