### PR TITLE
Fix Syntax Error in CVE-2023-41419.patch (Closes #761)

### DIFF
--- a/meta-python/recipes-devtools/python/python3-gevent/CVE-2023-41419.patch
+++ b/meta-python/recipes-devtools/python/python3-gevent/CVE-2023-41419.patch
@@ -356,7 +356,7 @@ index 0ebe095..078398a 100644
 +                    # we can't be sure we can synchronize and properly parse the next
 +                    # request.
 +                    raise
-+                except socket.error
++                except socket.error:
 +                    # Don't let socket exceptions during discarding
                      # input override any exception that may have been
                      # raised by the application, such as our own _InvalidClientInput.


### PR DESCRIPTION
This pull request addresses the syntax error in the CVE-2023-41419.patch file on the kirkstone branch, as reported in issue #761.

Changes:
- Added missing colon in the except block to fix a syntax error.

Please review and merge these changes. Thank you!
