### PR TITLE
python3-pynacl: allow -native build

### DIFF
--- a/meta-python/recipes-devtools/python/python3-pynacl_1.5.0.bb
+++ b/meta-python/recipes-devtools/python/python3-pynacl_1.5.0.bb
@@ -34,3 +34,5 @@ RPROVIDES:${PN} = "python3-nacl"
 # in meta-virtualization layer
 #
 RCONFLICTS:${PN} = "python3-nacl"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
This library is a dependency of other packages which we want to use in a native/sdk context. So I propose adding the necessary `BBCLASSEXTEND` to make it buildable here.