### PR TITLE
python3-gevent: adding missing dependency to python3-zopeevent

### DIFF
--- a/meta-python/recipes-devtools/python/python3-gevent_21.12.0.bb
+++ b/meta-python/recipes-devtools/python/python3-gevent_21.12.0.bb
@@ -9,6 +9,8 @@ DEPENDS += "${PYTHON_PN}-greenlet libev c-ares"
 RDEPENDS:${PN} = "${PYTHON_PN}-greenlet \
 		  ${PYTHON_PN}-mime \
 		  ${PYTHON_PN}-pprint \
+		  ${PYTHON_PN}-zopeevent \
+		  ${PYTHON_PN}-zopeinterface \
 		 "
 
 SRC_URI[sha256sum] = "f48b64578c367b91fa793bf8eaaaf4995cb93c8bc45860e473bf868070ad094e"


### PR DESCRIPTION
... and python3-zopeinterface

This is the PR for backporting the already merged `master`-PR #792 to `kirkstone`