### PR TITLE
Revert back to stable versions of libqmi and libmbim

### DIFF
--- a/meta-oe/recipes-connectivity/libmbim/libmbim_1.30.0.bb
+++ b/meta-oe/recipes-connectivity/libmbim/libmbim_1.30.0.bb
@@ -9,10 +9,10 @@ LIC_FILES_CHKSUM = " \
 
 DEPENDS = "glib-2.0 glib-2.0-native libgudev"
 
-inherit meson pkgconfig bash-completion gobject-introspection
+inherit meson pkgconfig bash-completion gobject-introspection upstream-version-is-even
 
-SRCREV = "9c0309fcd3142411c921c14f7dd675cac086bab6"
-SRC_URI = "git://gitlab.freedesktop.org/mobile-broadband/libmbim.git;protocol=https;branch=main"
+SRCREV = "8415687e4f30ae5e36f407f179c8147f1529725c"
+SRC_URI = "git://gitlab.freedesktop.org/mobile-broadband/libmbim.git;protocol=https;branch=mbim-1-30"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-connectivity/libqmi/libqmi_1.34.0.bb
+++ b/meta-oe/recipes-connectivity/libqmi/libqmi_1.34.0.bb
@@ -10,10 +10,10 @@ LIC_FILES_CHKSUM = " \
 
 DEPENDS = "glib-2.0 glib-2.0-native"
 
-inherit meson pkgconfig bash-completion gobject-introspection
+inherit meson pkgconfig bash-completion gobject-introspection upstream-version-is-even
 
-SRCREV = "72d92e75a430900c00aeb1a471965d53eb307708"
-SRC_URI = "git://gitlab.freedesktop.org/mobile-broadband/libqmi.git;protocol=https;branch=main"
+SRCREV = "3f07d6e5b4677558543b3b4484ea88ad92257e92"
+SRC_URI = "git://gitlab.freedesktop.org/mobile-broadband/libqmi.git;protocol=https;branch=qmi-1-34"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The odd version numbers of libqmi and libmbim are unstable/development releases.
With the Scarthgap behind the door I'd really suggest to use the stable releases only as we used to.