### PR TITLE
cppzmq-dev expects /usr/lib/libzmq.a

### DIFF
--- a/meta-oe/recipes-connectivity/zeromq/cppzmq_4.10.0.bb
+++ b/meta-oe/recipes-connectivity/zeromq/cppzmq_4.10.0.bb
@@ -16,5 +16,5 @@ EXTRA_OECMAKE = "-DCPPZMQ_BUILD_TESTS=OFF"
 
 PACKAGES = "${PN}-dev"
 
-RDEPENDS:${PN}-dev = "zeromq-dev"
+RDEPENDS:${PN}-dev = "zeromq-dev zeromq-staticdev"
 DEV_PKG_DEPENDENCY = ""


### PR DESCRIPTION
When following the build instructions for cppzmq, it's recommended to use cmake and find_package
https://github.com/zeromq/cppzmq?tab=readme-ov-file#build-instructions

`#find cppzmq wrapper, installed by make of cppzmq
find_package(cppzmq)
target_link_libraries(*Your Project Name* cppzmq)`

When including this recipe as cppzmq-dev, it does include the base c library zeromq-dev, shared but doesn't include the static lib dependency that this header only library seems to expect:

`CMake Error at /usr/lib/cmake/ZeroMQ/ZeroMQTargets.cmake:97 (message):
  The imported target "libzmq-static" references the file

     "/usr/lib/libzmq.a"

  but this file does not exist.  Possible reasons include:`

This change ensures that the build instructions for cppzmq work as expected if you request cppzmq-dev.  Without this, the user would need to also include zeromq-staticdev on their own or modify the upstream cmake file/create their own cmake file.