### PR TITLE
avro: add recipe for c++

### DIFF
--- a/meta-oe/recipes-support/avro/avro-c++/0001-Remove-cpp-unittest-compilation.patch
+++ b/meta-oe/recipes-support/avro/avro-c++/0001-Remove-cpp-unittest-compilation.patch
@@ -1,0 +1,88 @@
+From 6be1c45e1f7ee78499bdca76c25ec23a61317134 Mon Sep 17 00:00:00 2001
+From: Rui Costa <rui.ms.costa@ctw.bmwgroup.com>
+Date: Wed, 20 Mar 2024 14:58:27 +0000
+Subject: [PATCH 1/2] Remove cpp unittest compilation
+
+Upstream-Status: Inappropriate [oe-specific]
+---
+ lang/c++/CMakeLists.txt | 61 -----------------------------------------
+ 1 file changed, 61 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4a3793152..d94ba42d3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -131,70 +131,9 @@ set_target_properties (avrocpp_s PROPERTIES
+ target_link_libraries (avrocpp ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
+ target_include_directories(avrocpp PRIVATE ${SNAPPY_INCLUDE_DIR})
+
+-add_executable (precompile test/precompile.cc)
+-
+-target_link_libraries (precompile avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
+-
+-macro (gen file ns)
+-    add_custom_command (OUTPUT ${file}.hh
+-        COMMAND avrogencpp
+-            -p -
+-            -i ${CMAKE_CURRENT_SOURCE_DIR}/jsonschemas/${file}
+-            -o ${file}.hh -n ${ns} -U
+-        DEPENDS avrogencpp ${CMAKE_CURRENT_SOURCE_DIR}/jsonschemas/${file})
+-    add_custom_target (${file}_hh DEPENDS ${file}.hh)
+-endmacro (gen)
+-
+-gen (empty_record empty)
+-gen (bigrecord testgen)
+-gen (bigrecord_r testgen_r)
+-gen (bigrecord2 testgen2)
+-gen (tweet testgen3)
+-gen (union_array_union uau)
+-gen (union_map_union umu)
+-gen (union_conflict uc)
+-gen (recursive rec)
+-gen (reuse ru)
+-gen (circulardep cd)
+-gen (tree1 tr1)
+-gen (tree2 tr2)
+-gen (crossref cr)
+-gen (primitivetypes pt)
+-gen (cpp_reserved_words cppres)
+-
+ add_executable (avrogencpp impl/avrogencpp.cc)
+ target_link_libraries (avrogencpp avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
+
+-enable_testing()
+-
+-macro (unittest name)
+-    add_executable (${name} test/${name}.cc)
+-    target_link_libraries (${name} avrocpp ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
+-    add_test (NAME ${name} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+-        COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${name})
+-endmacro (unittest)
+-
+-unittest (buffertest)
+-unittest (unittest)
+-unittest (SchemaTests)
+-unittest (LargeSchemaTests)
+-unittest (CodecTests)
+-unittest (StreamTests)
+-unittest (SpecificTests)
+-unittest (DataFileTests)
+-unittest (JsonTests)
+-unittest (AvrogencppTests)
+-unittest (CompilerTests)
+-unittest (AvrogencppTestReservedWords)
+-
+-add_dependencies (AvrogencppTestReservedWords cpp_reserved_words_hh)
+-
+-add_dependencies (AvrogencppTests bigrecord_hh bigrecord_r_hh bigrecord2_hh
+-    tweet_hh
+-    union_array_union_hh union_map_union_hh union_conflict_hh
+-    recursive_hh reuse_hh circulardep_hh tree1_hh tree2_hh crossref_hh
+-    primitivetypes_hh empty_record_hh)
+-
+ include (InstallRequiredSystemLibraries)
+
+ set (CPACK_PACKAGE_FILE_NAME "avrocpp-${AVRO_VERSION_MAJOR}")
+--
+2.44.0
+

--- a/meta-oe/recipes-support/avro/avro-c++/0002-Add-package-configuration-files.patch
+++ b/meta-oe/recipes-support/avro/avro-c++/0002-Add-package-configuration-files.patch
@@ -1,0 +1,79 @@
+From 56feaa90d070a5011f380d3ae47c01643b9fafe0 Mon Sep 17 00:00:00 2001
+From: Rui Costa <rui.ms.costa@ctw.bmwgroup.com>
+Date: Fri, 22 Mar 2024 13:27:38 +0000
+Subject: [PATCH 2/2] Add package configuration files
+
+Upstream-Status: Pending
+---
+ lang/c++/CMakeLists.txt            | 35 +++++++++++++++++++++++++++---
+ lang/c++/cmake/AvroCppConfig.cmake |  5 +++++
+ 2 files changed, 37 insertions(+), 3 deletions(-)
+ create mode 100644 lang/c++/cmake/AvroCppConfig.cmake
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d94ba42d3..2e5a394cb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -140,12 +140,16 @@ set (CPACK_PACKAGE_FILE_NAME "avrocpp-${AVRO_VERSION_MAJOR}")
+
+ include (CPack)
+
+-install (TARGETS avrocpp avrocpp_s
++install (TARGETS avrocpp
++    EXPORT AvroCppTargets
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib
+-    RUNTIME DESTINATION lib)
++    RUNTIME DESTINATION lib
++    INCLUDES DESTINATION include)
+
+-install (TARGETS avrogencpp RUNTIME DESTINATION bin)
++install (TARGETS avrogencpp
++    EXPORT AvroCppTargets
++    RUNTIME DESTINATION bin)
+
+ install (DIRECTORY api/ DESTINATION include/avro
+     FILES_MATCHING PATTERN *.hh)
+@@ -155,3 +159,28 @@ if (NOT CMAKE_BUILD_TYPE)
+       "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
+       FORCE)
+ endif (NOT CMAKE_BUILD_TYPE)
++
++# Create cmake config files
++include(CMakePackageConfigHelpers)
++write_basic_package_version_file(
++    "${CMAKE_CURRENT_BINARY_DIR}/AvroCppConfigVersion.cmake"
++    VERSION ${AVRO_VERSION_MAJOR}.${AVRO_VERSION_MINOR}.${AVRO_VERSION_PATCH}
++    COMPATIBILITY AnyNewerVersion
++)
++
++configure_file(cmake/AvroCppConfig.cmake
++    "${CMAKE_CURRENT_BINARY_DIR}/AvroCppConfig.cmake"
++    COPYONLY
++)
++
++set(ConfigPackageLocation lib/cmake/avrocpp)
++install(EXPORT AvroCppTargets
++    FILE AvroCppTargets.cmake
++    NAMESPACE AvroCpp::
++    DESTINATION ${ConfigPackageLocation}
++)
++install(FILES
++    "cmake/AvroCppConfig.cmake"
++    "${CMAKE_CURRENT_BINARY_DIR}/AvroCppConfigVersion.cmake"
++    DESTINATION ${ConfigPackageLocation}
++    COMPONENT Devel)
+diff --git a/cmake/AvroCppConfig.cmake b/cmake/AvroCppConfig.cmake
+new file mode 100644
+index 000000000..deb8aaa31
+--- /dev/null
++++ b/cmake/AvroCppConfig.cmake
+@@ -0,0 +1,5 @@
++include(CMakeFindDependencyMacro)
++find_dependency(Boost 1.38 REQUIRED
++    COMPONENTS filesystem iostreams program_options regex system)
++
++include("${CMAKE_CURRENT_LIST_DIR}/AvroCppTargets.cmake")
+--
+2.44.0
+

--- a/meta-oe/recipes-support/avro/avro-c++/0003-Update-CXX-standard-to-CXX14.patch
+++ b/meta-oe/recipes-support/avro/avro-c++/0003-Update-CXX-standard-to-CXX14.patch
@@ -1,0 +1,26 @@
+From 640c51c61536913b3d43714bebe228b32f043144 Mon Sep 17 00:00:00 2001
+From: Rui Costa <rui.ms.costa@ctw.bmwgroup.com>
+Date: Fri, 5 Apr 2024 11:33:51 +0000
+Subject: [PATCH 3/3] Update CXX standard to CXX14
+
+Upstream-Status: Inappropriate [oe-specific]
+---
+ lang/c++/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2e5a394cb..f29a532ef 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -21,7 +21,7 @@ cmake_minimum_required (VERSION 3.1)
+ set (CMAKE_LEGACY_CYGWIN_WIN32 0)
+
+ if (NOT DEFINED CMAKE_CXX_STANDARD)
+-    set(CMAKE_CXX_STANDARD 11)
++    set(CMAKE_CXX_STANDARD 14)
+ endif()
+
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+--
+2.44.0
+

--- a/meta-oe/recipes-support/avro/avro-c++_1.11.3.bb
+++ b/meta-oe/recipes-support/avro/avro-c++_1.11.3.bb
@@ -1,0 +1,20 @@
+SUMMARY = "Apache Avro data serialization system."
+HOMEPAGE = "http://apr.apache.org/"
+SECTION = "libs"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=43abf34d8b9908494f83c55d213a7f89"
+
+DEPENDS = "boost zlib xz"
+
+BRANCH = "branch-1.11"
+SRCREV = "35ff8b997738e4d983871902d47bfb67b3250734"
+SRC_URI = "git://github.com/apache/avro;branch=${BRANCH};protocol=https \
+           file://0001-Remove-cpp-unittest-compilation.patch \
+           file://0002-Add-package-configuration-files.patch \
+           file://0003-Update-CXX-standard-to-CXX14.patch \
+          "
+
+S = "${WORKDIR}/git/lang/c++"
+
+inherit cmake pkgconfig


### PR DESCRIPTION
- remove the unittests from the compilation step
- add cmake configuration files to use with find_package