### PR TITLE
serial: Fix empty package and use shared lib instead of static lib.

### DIFF
--- a/meta-oe/recipes-support/serial/serial/0001-build-shared-lib-and-skip-example.patch
+++ b/meta-oe/recipes-support/serial/serial/0001-build-shared-lib-and-skip-example.patch
@@ -1,0 +1,41 @@
+From 1798dc93ab65be94e14faad33a19cab051eef788 Mon Sep 17 00:00:00 2001
+From: yangxuenian <yangxn@cicvd.com>
+Date: Thu, 11 Apr 2024 16:36:29 +0800
+Subject: [PATCH] build shared lib and skip example
+
+---
+ CMakeLists.txt | 14 ++++++++++----
+ 1 file changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a72acb8..89abeda 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -45,7 +45,7 @@ else()
+ endif()
+ 
+ ## Add serial library
+-add_library(${PROJECT_NAME} ${serial_SRCS})
++add_library(${PROJECT_NAME} SHARED ${serial_SRCS})
+ if(APPLE)
+ 	target_link_libraries(${PROJECT_NAME} ${FOUNDATION_LIBRARY} ${IOKIT_LIBRARY})
+ elseif(UNIX)
+@@ -55,9 +55,15 @@ else()
+ endif()
+ 
+ ## Uncomment for example
+-add_executable(serial_example examples/serial_example.cc)
+-add_dependencies(serial_example ${PROJECT_NAME})
+-target_link_libraries(serial_example ${PROJECT_NAME})
++#add_executable(serial_example examples/serial_example.cc)
++#add_dependencies(serial_example ${PROJECT_NAME})
++#target_link_libraries(serial_example ${PROJECT_NAME})
++
++set (SERIAL_VERSION_MAJOR 1)
++set (SERIAL_VERSION_MINOR 0)
++set (SERIAL_VERSION_PATCH 0)
++set (SERIAL_VERSION_STRING ${SERIAL_VERSION_MAJOR}.${SERIAL_VERSION_MINOR}.${SERIAL_VERSION_PATCH})
++set_target_properties (${PROJECT_NAME} PROPERTIES VERSION ${SERIAL_VERSION_STRING} SOVERSION ${SERIAL_VERSION_MAJOR})
+ 
+ ## Include headers
+ include_directories(include)

--- a/meta-oe/recipes-support/serial/serial_1.2.1.bb
+++ b/meta-oe/recipes-support/serial/serial_1.2.1.bb
@@ -6,6 +6,7 @@ LIC_FILES_CHKSUM = "file://README.md;beginline=53;endline=62;md5=049c68d559533f9
 SRC_URI = " \
     git://github.com/wjwwood/${BPN}.git;protocol=https;branch=main \
     file://Findcatkin.cmake \
+    file://0001-build-shared-lib-and-skip-example.patch \
 "
 SRCREV = "10ac4e1c25c2cda1dc0a32a8e12b87fd89f3bb4f"
 SRC_URI[sha256sum] = "c8cd235dda2ef7d977ba06dfcb35c35e42f45cfd9149ba3ad257756123d8ff96"


### PR DESCRIPTION
The older recipe of serial built a static lib `libserial.a`.

Which was contained in `FILES_${PN}-dev` and `FILES_${PN}` is empty.

This will make bitbake unhapply and raise `Nothing provides serial needed by other-recipe` problem.

To fix it we need add CMake `set_target_properties` function.

see also: 
1. https://docs.yoctoproject.org/pipermail/yocto/2015-January/022921.html
2. https://stackoverflow.com/questions/59091938/yocto-oe-recipe-with-cmake-install-a-shared-library-so