### PR TITLE
lldpd: fix CVE-2023-41910 for kirkstone

### DIFF
--- a/meta-networking/recipes-daemons/lldpd/files/CVE-2023-41910.patch
+++ b/meta-networking/recipes-daemons/lldpd/files/CVE-2023-41910.patch
@@ -1,0 +1,25 @@
+From b961961e5eff35c233a5cb8484d2e51d4b513247 Mon Sep 17 00:00:00 2001
+From: Georg Gebauer <georg.gebauer@zeiss.com>
+Date: Thu, 25 Apr 2024 16:37:25 +0200
+Subject: [PATCH] Fix for CVE-2023-41910 Critical (9.8) issue -  Fix Read
+ overflow when parsing CDP address
+
+References:
+- https://nvd.nist.gov/vuln/detail/CVE-2023-41910
+- https://github.com/lldpd/lldpd/commit/a9aeabdf879c25c584852a0bb5523837632f099b
+---
+ src/daemon/protocols/cdp.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/daemon/protocols/cdp.c b/src/daemon/protocols/cdp.c
+index 4a14ff0..c3a7c22 100644
+--- a/src/daemon/protocols/cdp.c
++++ b/src/daemon/protocols/cdp.c
+@@ -483,6 +483,7 @@ cdp_decode(struct lldpd *cfg, char *frame, int s,
+ 					goto malformed;
+ 				}
+ 				PEEK_DISCARD(address_len);
++				addresses_len -= address_len;
+ 				(void)PEEK_SAVE(pos_next_address);
+ 				/* Next, we go back and try to extract
+ 				   IPv4 address */

--- a/meta-networking/recipes-daemons/lldpd/lldpd_1.0.8.bb
+++ b/meta-networking/recipes-daemons/lldpd/lldpd_1.0.8.bb
@@ -5,11 +5,11 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/ISC;md5=f3b90e
 
 DEPENDS = "libbsd libevent"
 
-SRC_URI = "\
-    http://media.luffy.cx/files/${BPN}/${BPN}-${PV}.tar.gz \
-    file://lldpd.init.d \
-    file://lldpd.default \
-    "
+SRC_URI = "http://media.luffy.cx/files/${BPN}/${BPN}-${PV}.tar.gz \
+           file://lldpd.init.d \
+           file://lldpd.default \
+           file://CVE-2023-41910.patch \
+           "
 
 SRC_URI[md5sum] = "000042dbf5b445f750b5ba01ab25c8ba"
 SRC_URI[sha256sum] = "98d200e76e30f6262c4a4493148c1840827898329146a57a34f8f0f928ca3def"


### PR DESCRIPTION
Apply changes to match fix from [lldpd-Repository commit]( https://github.com/lldpd/lldpd/commit/a9aeabdf879c25c584852a0bb5523837632f099b)


More information about issue:
- https://nvd.nist.gov/vuln/detail/CVE-2023-41910

Suggested-by: Vincent Bernat (vincent@bernat.ch)