### PR TITLE
meta-oe(collectd): add package config option to build with mqtt plugin

### DIFF
--- a/meta-oe/recipes-extended/collectd/collectd_5.12.0.bb
+++ b/meta-oe/recipes-extended/collectd/collectd_5.12.0.bb
@@ -37,6 +37,7 @@ PACKAGECONFIG[mysql] = "--enable-mysql --with-libmysql=yes, \
         --disable-mysql --with-libmysql=no,mysql5"
 PACKAGECONFIG[dbi] = "--enable-dbi,--disable-dbi,libdbi"
 PACKAGECONFIG[modbus] = "--enable-modbus,--disable-modbus,libmodbus"
+PACKAGECONFIG[mqtt] = "--enable-mqtt,--disable-mqtt,libmosquitto"
 PACKAGECONFIG[libowcapi] = "--with-libowcapi,--without-libowcapi,owfs"
 PACKAGECONFIG[sensors] = "--enable-sensors --with-libsensors=yes, \
         --disable-sensors --with-libsensors=no,lmsensors"


### PR DESCRIPTION
Add package config option for the `collectd` recipe to include the MQTT plugin in the collectd package.

This enables collectd to publish its metrics to MQTT broker where the metrics can be subscribed to by other components.