### PR TITLE
python3-twisted: Fix broken package split

### DIFF
--- a/meta-python/recipes-devtools/python/python3-twisted_24.3.0.bb
+++ b/meta-python/recipes-devtools/python/python3-twisted_24.3.0.bb
@@ -22,6 +22,7 @@ PACKAGES += "\
     ${PN}-conch \
     ${PN}-mail \
     ${PN}-names \
+    ${PN}-newsfragments \
     ${PN}-runner \
     ${PN}-web \
     ${PN}-words \
@@ -64,10 +65,13 @@ RDEPENDS:${PN}-test = "${PN} python3-pyhamcrest"
 RDEPENDS:${PN}-conch = "${PN}-core ${PN}-protocols python3-bcrypt python3-cryptography python3-pickle"
 RDEPENDS:${PN}-mail = "${PN}-core ${PN}-protocols"
 RDEPENDS:${PN}-names = "${PN}-core"
+RDEPENDS:${PN}-newsfragements = "${PN}-core"
 RDEPENDS:${PN}-runner = "${PN}-core ${PN}-protocols"
 RDEPENDS:${PN}-web += "${PN}-core ${PN}-protocols"
 RDEPENDS:${PN}-words += "${PN}-core"
 RDEPENDS:${PN}-pair += "${PN}-core"
+
+FILES:${PN} = "${PYTHON_SITEPACKAGES_DIR}/${PYPI_PACKAGE}-${PV}.dist-info/*"
 
 FILES:${PN}-test = " \
     ${PYTHON_SITEPACKAGES_DIR}/twisted/test \
@@ -174,3 +178,6 @@ FILES:${PN}-doc += " \
     ${PYTHON_SITEPACKAGES_DIR}/twisted/python/_pydoctortemplates \
 "
 
+FILES:${PN}-newsfragments = " \
+    ${PYTHON_SITEPACKAGES_DIR}/twisted/newsfragments \
+"


### PR DESCRIPTION
Without FILES:${PN} only main, dbg, dev, doc and test packages are being build. python3-twisted-core, python3-twisted-web, python3-twisted-conch, etc are missing.

Add python3-twisted-newsfragments to packages to fix.

WARNING: python3-twisted-24.3.0-r0 do_package: QA Issue: python3-twisted: Files/directories were installed but not shipped in any package:
  /usr/lib/python3.12/site-packages/twisted/newsfragments
  /usr/lib/python3.12/site-packages/twisted/newsfragments/.gitignore