### PR TITLE
udpcast: add recipe

### DIFF
--- a/meta-networking/recipes-core/packagegroups/packagegroup-meta-networking.bb
+++ b/meta-networking/recipes-core/packagegroups/packagegroup-meta-networking.bb
@@ -236,6 +236,7 @@ RDEPENDS:packagegroup-meta-networking-support = "\
     rdma-core \
     tcpreplay \
     tinyproxy \
+    udpcast \
     uftp \
     unbound \
     vnstat \

--- a/meta-networking/recipes-support/udpcast/udpcast/0001-include-stddef.h-for-ptrdiff_t.patch
+++ b/meta-networking/recipes-support/udpcast/udpcast/0001-include-stddef.h-for-ptrdiff_t.patch
@@ -1,0 +1,27 @@
+From 5203821a936b1927c401034fe323686ad9eafb04 Mon Sep 17 00:00:00 2001
+From: Enguerrand de Ribaucourt <enguerrand.de-ribaucourt@savoirfairelinux.com>
+Date: Thu, 6 Jun 2024 15:57:12 +0200
+Subject: [PATCH 1/1] include stddef.h for ptrdiff_t
+
+This fixes compilation with musl.
+
+Upstream-Status: Pending
+
+Signed-off-by: Enguerrand de Ribaucourt <enguerrand.de-ribaucourt@savoirfairelinux.com>
+---
+ receivedata.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/receivedata.c b/receivedata.c
+index 9a68f67..0aa797f 100644
+--- a/receivedata.c
++++ b/receivedata.c
+@@ -1,4 +1,5 @@
+ #include <assert.h>
++#include <stddef.h>
+ #include <sys/types.h>
+ #include <unistd.h>
+ #include <stdlib.h>
+-- 
+2.34.1
+

--- a/meta-networking/recipes-support/udpcast/udpcast_20230924.bb
+++ b/meta-networking/recipes-support/udpcast/udpcast_20230924.bb
@@ -1,0 +1,22 @@
+SUMMARY = "UDP broadcast file distribution and installation"
+DESCRIPTION = "UDPcast is a file transfer tool that can send data \
+simultaneously to many destinations on a LAN. This can for instance be \
+used to install entire classrooms of PC's at once. The advantage of UDPcast \
+over using other methods (nfs, ftp, whatever) is that UDPcast uses UDP's \
+multicast abilities: it won't take longer to install 15 machines than it would \
+to install just 2."
+HOMEPAGE = "http://www.udpcast.linux.lu/"
+SECTION = "console/network"
+LICENSE = "GPL-2.0-or-later & BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://COPYING;md5=e3cf524a29c8476be354bb329d36ff80"
+
+SRC_URI = "http://www.udpcast.linux.lu/download/${BP}.tar.gz \
+           file://0001-include-stddef.h-for-ptrdiff_t.patch \
+           "
+SRC_URI[sha256sum] = "17b5cd8b1e54f7e2e53357ac02ee86e4198bf704096987a03a3b5c402a0ecea1"
+
+# Installation of rateGovernor.h fails without brokensep
+inherit autotools-brokensep manpages
+
+# pod2man required to build manpages
+DEPENDS += "perl-native"


### PR DESCRIPTION
udpcast is a file transfer tool that can send data simultaneously to many destinations on a LAN.

It is an alternative to uftp which is already in meta-networking.

On a lossy network, udpcast provided 10x faster transfer rates with error correction enabled while using a half as much CPU thanks to a simpler algorithm.