### PR TITLE
mbedtls: Do not set LIB_INSTALL_DIR to an absolute path to make MbedTLSTargets.cmake relocateable.

### DIFF
--- a/meta-networking/recipes-connectivity/mbedtls/mbedtls_3.6.0.bb
+++ b/meta-networking/recipes-connectivity/mbedtls/mbedtls_3.6.0.bb
@@ -44,8 +44,6 @@ PACKAGECONFIG[werror] = "-DMBEDTLS_FATAL_WARNINGS=ON,-DMBEDTLS_FATAL_WARNINGS=OF
 PACKAGECONFIG[psa] = ""
 PACKAGECONFIG[tests] = "-DENABLE_TESTING=ON,-DENABLE_TESTING=OFF"
 
-EXTRA_OECMAKE = "-DLIB_INSTALL_DIR:STRING=${libdir}"
-
 # For now the only way to enable PSA is to explicitly pass a -D via CFLAGS
 CFLAGS:append = "${@bb.utils.contains('PACKAGECONFIG', 'psa', ' -DMBEDTLS_USE_PSA_CRYPTO', '', d)}"
 


### PR DESCRIPTION
Before the change `_IMPORT_PREFIX` is set to an absolute path:
```
set(_IMPORT_PREFIX "/usr")
```
in MbedTLSTargets.cmake. Applying the change, the `IMPORT_PREFIX` becomes relative to the installation directory:
```
# Compute the installation prefix relative to this file.
get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
# Use original install prefix when loaded through a
# cross-prefix symbolic link such as /lib -> /usr/lib.
get_filename_component(_realCurr "${_IMPORT_PREFIX}" REALPATH)
get_filename_component(_realOrig "/usr/lib/cmake/MbedTLS" REALPATH)
if(_realCurr STREQUAL _realOrig)
  set(_IMPORT_PREFIX "/usr/lib/cmake/MbedTLS")
endif()
unset(_realOrig)
unset(_realCurr)
get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
if(_IMPORT_PREFIX STREQUAL "/")
  set(_IMPORT_PREFIX "")
endif()
```

With absolute pathes, following errors can occur when trying to find the package:
```
| CMake Error at /home/tschuster/project-lms/build/tmp/work/armv8a-lms-linux/open62541/1.3.8/recipe-sysroot/usr/lib/cmake/MbedTLS/MbedTLSTargets.cmake:133 (message):
|   The imported target "MbedTLS::everest" references the file
| 
|      "/usr/lib/libeverest.a"
| 
|   but this file does not exist.  Possible reasons include:
```