### PR TITLE
Fix python3-twisted issue on scarthgap

### DIFF
--- a/meta-python/recipes-devtools/python/python3-twisted_24.3.0.bb
+++ b/meta-python/recipes-devtools/python/python3-twisted_24.3.0.bb
@@ -15,7 +15,7 @@ do_install:append() {
     find ${D} \( -name "*.bat" -o -name "*.c" -o -name "*.h" \) -exec rm -f {} \;
 }
 
-PACKAGES += "\
+PACKAGES =+ "\
     ${PN}-zsh \
     ${PN}-test \
     ${PN}-protocols \


### PR DESCRIPTION
Cherrry-pick bd1b5cde348dbc20e3d332de69617a8a95fe5ff3 from main branch.

Title: python3-twisted: prepend split PACKAGES
Description: Fixes an issue where split packages were no populated since all the files were picked up by FILES:${PN}

Without this, building an image, that depends on python3-twisted fails with scarthgrap branch:

```
Error: 
 Problem: package packagegroup-wpewebkit-depends-1.0-r0.cortexa7t2hf_neon_vfpv4 from oe-repo requires packagegroup-wpewebkit-depends-tests, but none of the providers can be installed
  - package packagegroup-wpewebkit-depends-tests-1.0-r0.cortexa7t2hf_neon_vfpv4 from oe-repo requires python3-twisted, but none of the providers can be installed
  - conflicting requests
  - nothing provides python3-twisted-core needed by python3-twisted-24.3.0-r0.cortexa7t2hf_neon_vfpv4 from oe-repo
  - nothing provides python3-twisted-conch needed by python3-twisted-24.3.0-r0.cortexa7t2hf_neon_vfpv4 from oe-repo
...
```