### PR TITLE
Fix build back-end for python3-geomet_1.1.0.bb

### DIFF
--- a/meta-python/recipes-devtools/python/python3-geomet_1.1.0.bb
+++ b/meta-python/recipes-devtools/python/python3-geomet_1.1.0.bb
@@ -12,7 +12,7 @@ S = "${WORKDIR}/git"
 SRC_URI = "git://github.com/geomet/geomet.git;protocol=https;branch=master"
 SRCREV = "6ac73c312b52aca328db2e61d90c5e363b62639f"
 
-inherit setuptools3
+inherit python_flit_core
 
 RDEPENDS:${PN} += "\
     python3-click \


### PR DESCRIPTION
Fix issue with python build back-end. Using setuptools3 was giving no errors but was failing to deploy the module correctly (only AUTHORS.txt, LICENSE, METADATA, RECORD, WHEEL and top_level.txt would be installed under site-packages/geomet-0.0.0.dist-info).