### PR TITLE
android-tools-adbd.service: Change /var to /etc in ConditionPathExists

### DIFF
--- a/meta-oe/recipes-devtools/android-tools/android-tools/android-tools-adbd.service
+++ b/meta-oe/recipes-devtools/android-tools/android-tools/android-tools-adbd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Android Debug Bridge
-ConditionPathExists=/var/usb-debugging-enabled
+ConditionPathExists=/etc/usb-debugging-enabled
 Before=android-system.service
 
 [Service]


### PR DESCRIPTION
If android-tools-adbd.service service needs to be up upon boot, then the path assigned to ConditionPathExists must be present at boot time. This means that the path set to ConditionPathExists must be created at build time itself. In this case it is var/usb-debugging-enabled. However, /etc is a better place to keep files and directories that are created at build time rather than /var. /var is expected to house files that are created at run time.

Hence, change ConditionPathExists=/var/usb-debugging-enabled to ConditionPathExists=/etc/usb-debugging-enabled

This helps enablement of android-tools-adbd.service from build by creating /etc/usb-debugging-enabled at build time.