### PR TITLE
Include UPSTREAM_CHECK_COMMITS to fix UNKNOWN_BROKEN status when running devtool check-upgrade-status

### DIFF
--- a/meta-oe/recipes-benchmark/libc-bench/libc-bench_git.bb
+++ b/meta-oe/recipes-benchmark/libc-bench/libc-bench_git.bb
@@ -13,6 +13,9 @@ SRC_URI = "git://git.musl-libc.org/libc-bench;branch=master \
            file://0001-build-Do-not-override-ldflags-from-environment.patch \
            "
 
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 do_install () {

--- a/meta-oe/recipes-benchmark/s-suite/s-suite_git.bb
+++ b/meta-oe/recipes-benchmark/s-suite/s-suite_git.bb
@@ -6,6 +6,10 @@ SRCREV = "f97f1ae321d1fb8111a2c638075702ed2512ff07"
 PV = "3.6"
 SRC_URI = "git://github.com/Algodev-github/S.git;protocol=https;branch=master"
 
+# Current PV is not a git tag but a Readme content, track commits to detect
+# upstream updates
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 # installing in /opt/S-suite since the package has

--- a/meta-oe/recipes-bsp/con2fbmap/con2fbmap_git.bb
+++ b/meta-oe/recipes-bsp/con2fbmap/con2fbmap_git.bb
@@ -13,6 +13,9 @@ SRC_URI = "git://gitlab.com/pibox/con2fbmap.git;protocol=https;branch=master \
            file://0001-con2fbmap-Add-missing-include-on-string.h.patch \
            "
 
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 inherit autotools

--- a/meta-oe/recipes-bsp/cpufrequtils/cpufrequtils_008.bb
+++ b/meta-oe/recipes-bsp/cpufrequtils/cpufrequtils_008.bb
@@ -14,6 +14,9 @@ SRC_URI = "git://github.com/emagii/cpufrequtils.git;branch=master;protocol=https
            file://0001-dont-unset-cflags.patch \
 "
 
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 EXTRA_OEMAKE:append = " ${@['', 'NLS=false']['${USE_NLS}' == 'no']} "
 
 

--- a/meta-oe/recipes-bsp/firmwared/firmwared_git.bb
+++ b/meta-oe/recipes-bsp/firmwared/firmwared_git.bb
@@ -13,6 +13,9 @@ SRC_URI = "git://github.com/teg/firmwared.git;branch=master;protocol=https \
 PV = "0+git"
 SRCREV = "2e6b5db43d63a5c0283a4cae9a6a20b7ad107a04"
 
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 DEPENDS = "glib-2.0 systemd"

--- a/meta-oe/recipes-core/dbus/dbus-daemon-proxy_git.bb
+++ b/meta-oe/recipes-core/dbus/dbus-daemon-proxy_git.bb
@@ -8,6 +8,10 @@ PV = "0.0.0+git"
 SRC_URI = "git://github.com/alban/dbus-daemon-proxy;branch=master;protocol=https \
            file://0001-dbus-daemon-proxy-Return-DBUS_HANDLER_RESULT_NOT_YET.patch \
            "
+
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 inherit pkgconfig

--- a/meta-oe/recipes-core/musl-rpmatch/musl-rpmatch_git.bb
+++ b/meta-oe/recipes-core/musl-rpmatch/musl-rpmatch_git.bb
@@ -7,6 +7,9 @@ SRC_URI = "gitsm://github.com/pullmoll/musl-rpmatch.git;protocol=https;branch=ma
 PV = "1.0+git"
 SRCREV = "46267b154987d3e1f25d3a75423faa62bb5ee342"
 
+# Upstream repo has not made releases/tags after 1.0
+UPSTREAM_CHECK_COMMITS = "1"
+
 inherit autotools
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-core/pim435/pim435_git.bb
+++ b/meta-oe/recipes-core/pim435/pim435_git.bb
@@ -11,6 +11,10 @@ LIC_FILES_CHKSUM = "file://LICENSES/MIT.txt;md5=7dda4e90ded66ab88b86f76169f28663
 
 SRC_URI = "git://gitlab.eclipse.org/eclipse/oniro-blueprints/core/pim435;protocol=https;branch=main"
 SRCREV = "445ed623ec8d3ecbb1d566900b4ef3fb3031d689"
+
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 DEPENDS = "i2c-tools"

--- a/meta-oe/recipes-devtools/kconfig-frontends/kconfig-frontends_4.11.0.1.bb
+++ b/meta-oe/recipes-devtools/kconfig-frontends/kconfig-frontends_4.11.0.1.bb
@@ -20,6 +20,9 @@ SRC_URI = "git://gitlab.com/ymorin/kconfig-frontends.git;protocol=https;branch=4
 
 SRCREV = "f22fce3a308be1c7790ebefc6bbedb33c5f7c86a"
 
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 inherit autotools pkgconfig

--- a/meta-oe/recipes-devtools/libubox/libubox_git.bb
+++ b/meta-oe/recipes-devtools/libubox/libubox_git.bb
@@ -22,6 +22,9 @@ SRC_URI = "\
 SRCREV = "07413cce72e19520af55dfcbc765484f5ab41dd9"
 PV = "1.0.1+git"
 
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 inherit cmake pkgconfig

--- a/meta-oe/recipes-devtools/pcimem/pcimem_2.0.bb
+++ b/meta-oe/recipes-devtools/pcimem/pcimem_2.0.bb
@@ -10,6 +10,9 @@ COMPATIBLE_HOST = "(x86_64|aarch64|arm|riscv64)"
 SRCREV = "09724edb1783a98da2b7ae53c5aaa87493aabc9b"
 SRC_URI = "git://github.com/billfarrow/pcimem.git;branch=master;protocol=https"
 
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 do_install() {

--- a/meta-oe/recipes-extended/libbacktrace/libbacktrace_git.bb
+++ b/meta-oe/recipes-extended/libbacktrace/libbacktrace_git.bb
@@ -13,6 +13,9 @@ SRC_URI = "git://github.com/ianlancetaylor/libbacktrace;protocol=https;branch=ma
 PV = "1.0+git"
 SRCREV = "9ae4f4ae4481b1e69d38ed810980d33103544613"
 
+# The current PV is not a git tag but a README content
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 inherit autotools

--- a/meta-oe/recipes-extended/pam/pam-plugin-ccreds_11.bb
+++ b/meta-oe/recipes-extended/pam/pam-plugin-ccreds_11.bb
@@ -15,6 +15,9 @@ SRC_URI = "git://github.com/PADL/pam_ccreds;branch=master;protocol=https \
            file://0001-configure-Check-for-function-from-libdb-during-confi.patch \
            "
 
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 inherit autotools

--- a/meta-oe/recipes-extended/properties-cpp/properties-cpp_git.bb
+++ b/meta-oe/recipes-extended/properties-cpp/properties-cpp_git.bb
@@ -11,6 +11,9 @@ PV = "0.0.1+git"
 SRCREV = "45863e849b39c4921d6553e6d27e267a96ac7d77"
 SRC_URI = "git://github.com/lib-cpp/${BPN}.git;branch=master;protocol=https"
 
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 do_configure:prepend() {

--- a/meta-oe/recipes-extended/qad/qad_git.bb
+++ b/meta-oe/recipes-extended/qad/qad_git.bb
@@ -14,6 +14,9 @@ SRC_URI = "git://gitlab.com/CodethinkLabs/qad/qad;branch=main;protocol=https \
 
 SRCREV = "ae0c099c1fdc0ca6f5d631cea6b302937122b362"
 
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 PV = "0.0+git"
 

--- a/meta-oe/recipes-extended/socketcan/can-isotp_git.bb
+++ b/meta-oe/recipes-extended/socketcan/can-isotp_git.bb
@@ -5,6 +5,8 @@ PV = "1.0+git"
 
 SRC_URI = "git://github.com/hartkopp/can-isotp.git;protocol=https;branch=master"
 
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-extended/zsync/zsync-curl_git.bb
+++ b/meta-oe/recipes-extended/zsync/zsync-curl_git.bb
@@ -12,6 +12,9 @@ SRCREV = "00141c2806ccc4ddf2ff6263ee1612d19c0b713f"
 
 PV = "0.6.2+git"
 
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 inherit autotools
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-multimedia/v4l2apps/yavta_git.bb
+++ b/meta-oe/recipes-multimedia/v4l2apps/yavta_git.bb
@@ -9,6 +9,9 @@ SRCREV = "65f740aa1758531fd810339bc1b7d1d33666e28a"
 PV = "0.0"
 S = "${WORKDIR}/git"
 
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 EXTRA_OEMAKE = "-e MAKEFLAGS="
 
 # The yavta sources include copies of the headers required to build in the

--- a/meta-oe/recipes-support/devmem2/devmem2_2.0.bb
+++ b/meta-oe/recipes-support/devmem2/devmem2_2.0.bb
@@ -5,6 +5,9 @@ LIC_FILES_CHKSUM = "file://devmem2.c;endline=38;md5=a9eb9f3890384519f435aedf9862
 SRC_URI = "git://github.com/denix0/devmem2.git;protocol=https;branch=main"
 SRCREV = "5b395a946894eb4f4ef5d07c80a50a88573a541e"
 
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 CFLAGS += "-DFORCE_STRICT_ALIGNMENT"

--- a/meta-oe/recipes-support/edid-decode/edid-decode_git.bb
+++ b/meta-oe/recipes-support/edid-decode/edid-decode_git.bb
@@ -9,6 +9,10 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=2ef696d66c156139232201f223c22592"
 SRC_URI= "git://git.linuxtv.org/edid-decode.git;protocol=https;branch=master"
 SRCREV = "5920bf2a756b2f748c49ff6a08b9f421026473c5"
 PV = "0.0+git"
+
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 do_install() {

--- a/meta-oe/recipes-support/hunspell/hunspell-dictionaries.bb
+++ b/meta-oe/recipes-support/hunspell/hunspell-dictionaries.bb
@@ -135,7 +135,7 @@ RDEPENDS:${PN} = "hunspell"
 
 PV = "0.0.0+git"
 SRCREV = "820a65e539e34a3a8c2a855d2450b84745c624ee"
-SRC_URI = "git://github.com/wooorm/dictionaries.git;branch=master;protocol=https"
+SRC_URI = "git://github.com/wooorm/dictionaries.git;branch=main;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/hunspell/hunspell-dictionaries.bb
+++ b/meta-oe/recipes-support/hunspell/hunspell-dictionaries.bb
@@ -137,6 +137,9 @@ PV = "0.0.0+git"
 SRCREV = "820a65e539e34a3a8c2a855d2450b84745c624ee"
 SRC_URI = "git://github.com/wooorm/dictionaries.git;branch=main;protocol=https"
 
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 do_install() {

--- a/meta-oe/recipes-support/iksemel/iksemel_1.5.bb
+++ b/meta-oe/recipes-support/iksemel/iksemel_1.5.bb
@@ -11,6 +11,9 @@ SRC_URI = "git://github.com/meduketto/iksemel.git;protocol=https;branch=master \
            file://fix-configure-option-parsing.patch \
            file://avoid-obsolete-gnutls-apis.patch"
 
+# The current PV is not a git tag but a README content
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 inherit autotools pkgconfig lib_package texinfo

--- a/meta-oe/recipes-support/pidgin/funyahoo-plusplus_git.bb
+++ b/meta-oe/recipes-support/pidgin/funyahoo-plusplus_git.bb
@@ -10,6 +10,9 @@ inherit pkgconfig
 SRC_URI = "git://github.com/EionRobb/funyahoo-plusplus;branch=master;protocol=https"
 SRCREV = "fbbd9c591100aa00a0487738ec7b6acd3d924b3f"
 
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 do_compile() {

--- a/meta-oe/recipes-support/pidgin/icyque_git.bb
+++ b/meta-oe/recipes-support/pidgin/icyque_git.bb
@@ -12,6 +12,9 @@ inherit pkgconfig
 SRC_URI = "git://github.com/EionRobb/icyque;branch=master;protocol=https"
 SRCREV = "513fc162d5d1a201c2b044e2b42941436d1069d5"
 
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 do_compile() {

--- a/meta-oe/recipes-support/reboot-mode/reboot-mode_git.bb
+++ b/meta-oe/recipes-support/reboot-mode/reboot-mode_git.bb
@@ -8,6 +8,9 @@ SRCREV = "84831b20512abd9033414ca5f5a023f333525335"
 
 S = "${WORKDIR}/git"
 
+# Upstream repo has not made releases/tags after 1.0.0
+UPSTREAM_CHECK_COMMITS = "1"
+
 do_compile() {
     ${CC} ${CFLAGS} ${LDFLAGS} ${S}/reboot-mode.c -o ${B}/reboot-mode
 }

--- a/meta-oe/recipes-test/fbtest/fb-test_1.1.0.bb
+++ b/meta-oe/recipes-test/fbtest/fb-test_1.1.0.bb
@@ -6,6 +6,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=eb723b61539feef013de476e68b5c50a"
 SRCREV = "063ec650960c2d79ac51f5c5f026cb05343a33e2"
 SRC_URI = "git://github.com//ponty/fb-test-app.git;branch=master;protocol=https"
 
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 do_install() {

--- a/meta-oe/recipes-test/linux-serial-test/linux-serial-test_git.bb
+++ b/meta-oe/recipes-test/linux-serial-test/linux-serial-test_git.bb
@@ -8,6 +8,9 @@ SRC_URI = "git://github.com/cbrake/linux-serial-test.git;protocol=https;branch=m
 PV = "0+git"
 SRCREV = "2ee61484167eab846f7b7c565284d7c350d738d3"
 
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 inherit cmake

--- a/meta-oe/recipes-test/syzkaller/syzkaller_git.bb
+++ b/meta-oe/recipes-test/syzkaller/syzkaller_git.bb
@@ -13,6 +13,9 @@ SRC_URI = "git://${GO_IMPORT};protocol=https;destsuffix=${BPN}-${PV}/src/${GO_IM
            "
 SRCREV = "25905f5d0a2a7883bd33491997556193582c6059"
 
+# Upstream repo does not tag
+UPSTREAM_CHECK_COMMITS = "1"
+
 export GOPROXY = "https://proxy.golang.org,direct"
 # Workaround for network access issue during compile step.
 # This needs to be fixed in the recipes buildsystem so that


### PR DESCRIPTION
When performing devtool check-upgrade-status, UNKNOWN_BROKEN status appears.
On the upstream source repository, releases are not identified by tags. So,
UPSTREAM_CHECK_COMMITS is set to 1, to find the latest upstream update.

cc: @ycongal-smile 