### PR TITLE
Fix libdevmapper for scarthgap and kirkstone branches

### DIFF
--- a/meta-oe/recipes-support/lvm2/libdevmapper_2.03.22.bb
+++ b/meta-oe/recipes-support/lvm2/libdevmapper_2.03.22.bb
@@ -5,6 +5,8 @@ require lvm2.inc
 
 DEPENDS += "autoconf-archive-native"
 
+inherit nopackages
+
 TARGET_CC_ARCH += "${LDFLAGS}"
 
 do_install() {


### PR DESCRIPTION
Commit [8de9b8c](https://github.com/openembedded/openembedded-core/commit/8de9b8c1e199896b9a7bc5ed64967c6bfbf84bea) of OE-Core was backported [to the kirkstone branch](https://github.com/openembedded/openembedded-core/commit/6817b012763fc32cdcffe30163a304da3ed59ae1) and [the scarthgap branch](https://github.com/openembedded/openembedded-core/commit/eb94b09a9183e0b0d9cfc45287e0967ae185c099), and required commit 90f96e053ad3eefa7693d9748efdfbfa72d7dcfd as a fix in meta-openembedded.
This was originally applied to master at the time of styhead, so it should also be backported to the scarthgap branch, but also the kirkstone branch.