### PR TITLE
Move efitools & sbsigntool recipes from meta-secure-core

### DIFF
--- a/meta-oe/classes/user-key-store.bbclass
+++ b/meta-oe/classes/user-key-store.bbclass
@@ -1,0 +1,546 @@
+DEPENDS:append:class-target = " \
+    ${@bb.utils.contains("DISTRO_FEATURES", "efi-secure-boot", "sbsigntool-native", "", d)} \
+    ${@bb.utils.contains("DISTRO_FEATURES", "efi-secure-boot", "libsign-native", "", d)} \
+    openssl-native \
+    ${@bb.utils.contains("DISTRO_FEATURES", "efi-secure-boot", "efitools-native gnupg-native", "", d)} \
+"
+
+PSEUDO_IGNORE_PATHS .= ",${GPG_PATH}"
+USER_KEY_SHOW_VERBOSE = "1"
+
+UEFI_SB = '${@bb.utils.contains("DISTRO_FEATURES", "efi-secure-boot", "1", "0", d)}'
+MOK_SB ?= '${@bb.utils.contains("DISTRO_FEATURES", "efi-secure-boot", "1", "0", d)}'
+MODSIGN = '${@bb.utils.contains("DISTRO_FEATURES", "modsign", "1", "0", d)}'
+IMA = '${@bb.utils.contains("DISTRO_FEATURES", "ima", "1", "0", d)}'
+SYSTEM_TRUSTED = '${@"1" if d.getVar("IMA") == "1" or d.getVar("MODSIGN") == "1" else "0"}'
+SECONDARY_TRUSTED = '${@"1" if d.getVar("SYSTEM_TRUSTED") == "1" else "0"}'
+RPM ?= '1'
+
+def vprint(str, d):
+    if d.getVar('USER_KEY_SHOW_VERBOSE') == '1':
+        bb.note(str)
+
+def uks_signing_model(d):
+    return d.getVar('SIGNING_MODEL')
+
+def uks_system_trusted_keys_dir(d):
+    set_keys_dir('SYSTEM_TRUSTED', d)
+    return d.getVar('SYSTEM_TRUSTED_KEYS_DIR') + '/'
+
+def uks_secondary_trusted_keys_dir(d):
+    set_keys_dir('SECONDARY_TRUSTED', d)
+    return d.getVar('SECONDARY_TRUSTED_KEYS_DIR') + '/'
+
+def uks_modsign_keys_dir(d):
+    set_keys_dir('MODSIGN', d)
+    return d.getVar('MODSIGN_KEYS_DIR') + '/'
+
+def uks_ima_keys_dir(d):
+    set_keys_dir('IMA', d)
+    return d.getVar('IMA_KEYS_DIR') + '/'
+
+def uks_rpm_keys_dir(d):
+    set_keys_dir('RPM', d)
+    return d.getVar('RPM_KEYS_DIR') + '/'
+
+def uks_boot_keys_dir(d):
+    set_keys_dir('BOOT', d)
+    return d.getVar('BOOT_KEYS_DIR') + '/'
+
+def sign_efi_image(key, cert, input, output, d):
+    import bb.process
+
+    cmd = (' '.join((d.getVar('STAGING_BINDIR_NATIVE') + '/sbsign',
+                     '--key', key, '--cert', cert,
+                     '--output', output, input)))
+    vprint("Signing %s with the key %s ..." % (input, key), d)
+    vprint("Running: %s" % cmd, d)
+    try:
+        result, _ = bb.process.run(cmd)
+    except bb.process.ExecutionError:
+        bb.fatal('Unable to sign %s' % input)
+
+def uefi_sb_keys_dir(d):
+    set_keys_dir('UEFI_SB', d)
+    return d.getVar('UEFI_SB_KEYS_DIR') + '/'
+
+def check_uefi_sb_user_keys(d):
+    dir = uefi_sb_keys_dir(d)
+
+    for _ in ('PK', 'KEK', 'DB'):
+        if not os.path.exists(dir + _ + '.key'):
+            vprint("%s.key is unavailable" % _, d)
+            return False
+
+        if not os.path.exists(dir + _ + '.crt'):
+            vprint("%s.crt is unavailable" % _, d)
+            return False
+
+def uefi_sb_sign(input, output, d):
+    if d.getVar('UEFI_SB') != '1':
+        return
+
+    _ = uefi_sb_keys_dir(d)
+    sign_efi_image(_ + 'DB.key', _ + 'DB.crt', input, output, d)
+
+def mok_sb_keys_dir(d):
+    if d.getVar('MOK_SB') != '1':
+        return
+
+    set_keys_dir('MOK_SB', d)
+    return d.getVar('MOK_SB_KEYS_DIR') + '/'
+
+def sb_sign(input, output, d):
+    if d.getVar('UEFI_SB') != '1':
+        return
+
+    if uks_signing_model(d) in ('sample', 'user'):
+        # Deal with MOK_SB firstly, as MOK_SB implies UEFI_SB == 1.
+        # On this scenario, bootloader is verified by shim_cert.crt
+        if d.getVar('MOK_SB') == '1':
+            mok_sb_sign(input, output, d)
+        # UEFI_SB is defined, but MOK_SB is not defined
+        # On this scenario, shim is not used, and DB.crt is used to
+        # verify bootloader directly.
+        else:
+            uefi_sb_sign(input, output, d)
+
+def check_mok_sb_user_keys(d):
+    dir = mok_sb_keys_dir(d)
+
+    for _ in ('shim_cert', 'vendor_cert'):
+        if not os.path.exists(dir + _ + '.key'):
+            vprint("%s.key is unavailable" % _, d)
+            return False
+
+        if not os.path.exists(dir + _ + '.crt'):
+            vprint("%s.crt is unavailable" % _, d)
+            return False
+
+def mok_sb_sign(input, output, d):
+    if d.getVar('MOK_SB') != '1':
+        return
+
+    _ = mok_sb_keys_dir(d)
+    sign_efi_image(_ + 'vendor_cert.key', _ + 'vendor_cert.crt', input, output, d)
+
+def sel_sign(key, cert, input, d):
+    import bb.process
+
+    cmd = (' '.join(('LD_LIBRARY_PATH=' + d.getVar('STAGING_LIBDIR_NATIVE') +
+           ':$LD_LIBRARY_PATH', d.getVar('STAGING_BINDIR_NATIVE') + '/selsign',
+           '--key', key, '--cert', cert, input)))
+    vprint("Signing %s with the key %s ..." % (input, key), d)
+    vprint("Running cmd: %s" % cmd, d)
+    try:
+        result, _ = bb.process.run(cmd)
+    except bb.process.ExecutionError:
+        bb.fatal('Unable to sign %s' % input)
+
+def uks_sel_sign(input, d):
+    if d.getVar('UEFI_SB') != '1':
+        return
+
+    if d.getVar('MOK_SB') == '1':
+        _ = mok_sb_keys_dir(d)
+        key = _ + 'vendor_cert.key'
+        cert = _ + 'vendor_cert.crt'
+    else:
+        _ = uefi_sb_keys_dir(d)
+        key = _ + 'DB.key'
+        cert = _ + 'DB.crt'
+
+    sel_sign(key, cert, input, d)
+
+def check_ima_user_keys(d):
+    dir = uks_ima_keys_dir(d)
+
+    for _ in ('key', 'der'):
+        if not os.path.exists(dir + 'x509_ima.' + _):
+            vprint("%s.crt is unavailable" % _, d)
+            return False
+
+def check_system_trusted_keys(d):
+    dir = uks_system_trusted_keys_dir(d)
+
+    _ = 'system_trusted_key'
+    if not os.path.exists(dir + _ + '.key'):
+        vprint("%s.key is unavailable" % _, d)
+        return False
+
+    if not os.path.exists(dir + _ + '.crt'):
+        vprint("%s.crt is unavailable" % _, d)
+        return False
+
+def check_secondary_trusted_keys(d):
+    dir = uks_secondary_trusted_keys_dir(d)
+
+    _ = 'secondary_trusted_key'
+    if not os.path.exists(dir + _ + '.key'):
+        vprint("%s.key is unavailable" % _, d)
+        return False
+
+    if not os.path.exists(dir + _ + '.crt'):
+        vprint("%s.crt is unavailable" % _, d)
+        return False
+
+def check_modsign_keys(d):
+    dir = uks_modsign_keys_dir(d)
+
+    _ = 'modsign_key'
+    if not os.path.exists(dir + _ + '.key'):
+        vprint("%s.key is unavailable" % _, d)
+        return False
+
+    if not os.path.exists(dir + _ + '.crt'):
+        vprint("%s.crt is unavailable" % _, d)
+        return False
+
+def check_rpm_keys(d):
+    dir = uks_rpm_keys_dir(d)
+
+    _ = dir + 'RPM-GPG-PRIVKEY-' + d.getVar('RPM_GPG_NAME')
+    if not os.path.exists(_):
+        vprint("%s is unavailable" % _, d)
+        return False
+
+    _ = dir + 'RPM-GPG-KEY-' + d.getVar('RPM_GPG_NAME')
+    if not os.path.exists(_):
+        vprint("%s is unavailable" % _, d)
+        return False
+
+# Convert the PEM to DER format.
+def pem2der(input, output, d):
+    import bb.process
+
+    cmd = (' '.join((d.getVar('STAGING_BINDIR_NATIVE') + '/openssl',
+           'x509', '-inform', 'PEM', '-outform', 'DER', 
+           '-in', input, '-out', output)))
+    try:
+        result, _ = bb.process.run(cmd)
+    except bb.process.ExecutionError:
+        bb.fatal('Unable to convert %s to %s' % (input, output))
+
+# Convert the certificate (PEM formatted) to ESL.
+__pem2esl() {
+    "${STAGING_BINDIR_NATIVE}/cert-to-efi-sig-list" \
+        -g ${UEFI_SIG_OWNER_GUID} "$1" "$2"
+}
+
+# Blacklist the sample DB, shim_cert, vendor_cert by default.
+__create_default_mok_sb_blacklist() {
+    __pem2esl "${SAMPLE_MOK_SB_KEYS_DIR}/shim_cert.crt" \
+        "${TMPDIR}/sample_shim_cert.esl"
+
+    __pem2esl "${SAMPLE_MOK_SB_KEYS_DIR}/vendor_cert.crt" \
+        "${TMPDIR}/sample_vendor_cert.esl"
+
+    # Cascade the sample DB, shim_cert and vendor_cert to
+    # the default vendor_dbx.
+    cat "${TMPDIR}/sample_shim_cert.esl" \
+        "${TMPDIR}/sample_vendor_cert.esl" >> "${TMPDIR}/blacklist.esl"
+}
+
+__create_default_uefi_sb_blacklist() {
+    __pem2esl "${SAMPLE_UEFI_SB_KEYS_DIR}/DB.crt" \
+        "${TMPDIR}/sample_DB.esl"
+
+    cat "${TMPDIR}/sample_DB.esl" > "${TMPDIR}/blacklist.esl"
+}
+
+# Cascade the default blacklist and user specified blacklist if any.
+def __create_blacklist(d):
+    tmp_dir = d.getVar('TMPDIR')
+
+    vprint('Preparing to create the default blacklist %s' % tmp_dir + '/blacklist.esl', d)
+
+    bb.build.exec_func('__create_default_uefi_sb_blacklist', d)
+    if d.getVar('MOK_SB') == '1':
+        bb.build.exec_func('__create_default_mok_sb_blacklist', d) 
+
+    def __pem2esl_dir (dir):
+        if not os.path.isdir(dir):
+            return
+
+        dst = open(tmp_dir + '/blacklist.esl', 'wb+')
+
+        for _ in os.listdir(dir):
+            fn = os.path.join(dir, _)
+            if not os.path.isfile(fn):
+                continue
+
+            cmd = (' '.join((d.getVar('STAGING_BINDIR_NATIVE') + '/cert-to-efi-sig-list',
+                   '-g', d.getVar('UEFI_SIG_OWNER_GUID'), fn,
+                   tmp_dir + '/' + _ + '.esl')))
+            try:
+                result, _ = bb.process.run(cmd)
+            except bb.process.ExecutionError:
+                vprint('Unable to convert %s' % fn)
+                continue
+
+            with open(fn, 'rb') as src:
+                import shutil
+                shutil.copyfileobj(src, dst)
+                src.close()
+
+        dst.close()
+
+    # Cascade the user specified blacklists.
+    __pem2esl_dir(uefi_sb_keys_dir(d) + 'DBX')
+
+    if d.getVar('MOK_SB') == '1':
+        __pem2esl_dir(mok_sb_keys_dir(d) + 'vendor_dbx')
+
+# To ensure a image signed by the sample key cannot be loaded by a image
+# signed by the user key, e.g, preventing the shim signed by the user key
+# from loading the grub signed by the sample key, certain sample keys are
+# added to the blacklist.
+def create_mok_vendor_dbx(d):
+    if d.getVar('MOK_SB') != '1' or d.getVar('SIGNING_MODEL') != 'user':
+        return None
+
+    src = d.getVar('TMPDIR') + '/blacklist.esl'
+    import os
+    if os.path.exists(src):
+        os.remove(src)
+
+    __create_blacklist(d)
+
+    dst = d.getVar('WORKDIR') + '/vendor_dbx.esl'
+    import shutil
+    shutil.copyfile(src, dst)
+
+    return dst
+
+def create_uefi_dbx(d):
+    if d.getVar('UEFI_SB') != '1' or d.getVar('SIGNING_MODEL') != 'user':
+        return None
+
+    src = d.getVar('TMPDIR') + '/blacklist.esl'
+    import os
+    if os.path.exists(src):
+        os.remove(src)
+
+    __create_blacklist(d)
+
+    dst = d.getVar('WORKDIR') + '/DBX.esl'
+    import shutil
+    shutil.copyfile(src, dst)
+
+    return dst
+
+deploy_uefi_sb_keys() {
+    local deploy_dir="${DEPLOY_KEYS_DIR}/uefi_sb_keys"
+
+    if [ x"${UEFI_SB_KEYS_DIR}" != x"$deploy_dir" ]; then
+        install -d "$deploy_dir"
+
+        cp -af "${UEFI_SB_KEYS_DIR}"/* "$deploy_dir"
+        for KEY in DB KEK PK; do
+             openssl x509 -in "${UEFI_SB_KEYS_DIR}"/${KEY}.crt \
+                 -out "$deploy_dir"/${KEY}.cer -outform DER;
+        done
+    fi
+}
+
+deploy_mok_sb_keys() {
+    local deploy_dir="${DEPLOY_KEYS_DIR}/mok_sb_keys"
+
+    if [ x"${MOK_SB_KEYS_DIR}" != x"$deploy_dir" ]; then
+        install -d "$deploy_dir"
+
+        cp -af "${MOK_SB_KEYS_DIR}"/* "$deploy_dir"
+    fi
+}
+
+deploy_ima_keys() {
+    local deploy_dir="${DEPLOY_KEYS_DIR}/ima_keys"
+
+    if [ x"${IMA_KEYS_DIR}" != x"$deploy_dir" ]; then
+        install -d "$deploy_dir"
+
+        cp -af "${IMA_KEYS_DIR}"/* "$deploy_dir"
+    fi
+}
+
+deploy_rpm_keys() {
+    local deploy_dir="${DEPLOY_KEYS_DIR}/rpm_keys"
+
+    if [ x"${RPM_KEYS_DIR}" != x"$deploy_dir" ]; then
+        install -d "$deploy_dir"
+
+        cp -af "${RPM_KEYS_DIR}"/* "$deploy_dir"
+    fi
+}
+
+deploy_system_trusted_keys() {
+    local deploy_dir="${DEPLOY_KEYS_DIR}/system_trusted_keys"
+
+    if [ x"${SYSTEM_TRUSTED_KEYS_DIR}" != x"$deploy_dir" ]; then
+        install -d "$deploy_dir"
+
+        cp -af "${SYSTEM_TRUSTED_KEYS_DIR}"/* "$deploy_dir"
+    fi
+}
+
+deploy_secondary_trusted_keys() {
+    local deploy_dir="${DEPLOY_KEYS_DIR}/secondary_trusted_keys"
+
+    if [ x"${SECONDARY_TRUSTED_KEYS_DIR}" != x"$deploy_dir" ]; then
+        install -d "$deploy_dir"
+
+        cp -af "${SECONDARY_TRUSTED_KEYS_DIR}"/* "$deploy_dir"
+    fi
+}
+
+deploy_modsign_keys() {
+    local deploy_dir="${DEPLOY_KEYS_DIR}/modsign_keys"
+
+    if [ x"${MODSIGN_KEYS_DIR}" != x"$deploy_dir" ]; then
+        install -d "$deploy_dir"
+
+        cp -af "${MODSIGN_KEYS_DIR}"/* "$deploy_dir"
+    fi
+}
+
+def deploy_keys(name, d):
+    d.setVar('DEPLOY_KEYS_DIR', d.getVar('DEPLOY_DIR_IMAGE') + '/' + \
+             d.getVar('SIGNING_MODEL') + '-keys')
+    bb.build.exec_func('deploy_' + name.lower() + '_keys', d)
+
+def sanity_check_user_keys(name, may_exit, d):
+    if d.getVar('UEFI_SELOADER') == '1' and d.getVar('GRUB_SIGN_VERIFY') == '1':
+        bb.fatal("UEFI_SELOADER and GRUB_SIGN_VERIFY cannot both be set to '1'")
+
+    if name == 'UEFI_SB':
+        _ = check_uefi_sb_user_keys(d)
+    elif name == 'MOK_SB':
+        _ = check_mok_sb_user_keys(d)
+    elif name == 'IMA':
+        _ = check_ima_user_keys(d)
+    elif name == 'SYSTEM_TRUSTED':
+        _ = check_system_trusted_keys(d)
+    elif name == 'SECONDARY_TRUSTED':
+        _ = check_secondary_trusted_keys(d)
+    elif name == 'MODSIGN':
+        _ = check_modsign_keys(d)
+    elif name == 'RPM':
+        _ = check_rpm_keys(d)
+    else:
+        _ = False
+        may_exit = True
+
+    if _ == False:
+        if may_exit:
+            bb.fatal('Unable to find user key for %s ...' % name)
+
+        vprint('Failed to check the user keys for %s ...' % name, d)
+
+    return _
+
+# *_KEYS_DIR need to be updated whenever reading them.
+def set_keys_dir(name, d):
+    if (d.getVar(name) != "1") or (d.getVar('SIGNING_MODEL') != "user"):
+        return
+
+    if d.getVar(name + '_KEYS_DIR') == d.getVar('SAMPLE_' + name + '_KEYS_DIR'):
+        d.setVar(name + '_KEYS_DIR', d.getVar('DEPLOY_DIR_IMAGE') + '/user-keys/' + name.lower() + '_keys')
+
+python check_deploy_keys() {
+    for _ in ('UEFI_SB', 'MOK_SB', 'IMA', 'SYSTEM_TRUSTED', 'SECONDARY_TRUSTED', 'MODSIGN', 'RPM'):
+        if d.getVar(_) != "1":
+            continue
+
+        # Intend to use user key?
+        if not d.getVar('SIGNING_MODEL') in ("sample", "user"):
+            continue
+
+        # Raise error if not specifying the location of the
+        # user keys.
+        sanity_check_user_keys(_, True, d)
+
+        deploy_keys(_, d)
+}
+
+check_deploy_keys[lockfiles] = "${TMPDIR}/check_deploy_keys.lock"
+
+def check_gpg_key(basekeyname, keydirfunc, d):
+    gpg_path = d.getVar('GPG_PATH')
+    if not gpg_path:
+        gpg_path = d.getVar('TMPDIR') + '/.gnupg'
+        d.setVar('GPG_PATH', gpg_path)
+    if not os.path.exists(gpg_path):
+        status, output = oe.utils.getstatusoutput('mkdir -m 0700 -p %s' % gpg_path)
+        if status:
+            bb.fatal('Failed to create gpg keying %s: %s' % (gpg_path, output))
+
+    gpg_conf = os.path.join(gpg_path, 'gpg-agent.conf')
+    if not os.path.exists(gpg_conf):
+        f = open(gpg_conf, 'w')
+        f.write('allow-loopback-pinentry\n')
+        f.write('auto-expand-secmem\n')
+        f.close()
+
+    if len(gpg_path) > 80:
+        bn = d.getVar('BUILDNAME')
+        suffixlist = ["yocto-native", "browser", "ssh", "extra"]
+        for suffix in suffixlist:
+            socket = os.path.join(gpg_path, 'S.gpg-agent.' + suffix)
+            if not os.path.exists(socket):
+                f = open(socket, 'w')
+                f.write('%Assuan%\n')
+                f.write('socket=/tmp/S.gpg-agent.%s-%s\n' % (suffix, bn))
+                f.close()
+
+    gpg_bin = d.getVar('GPG_BIN') or \
+              bb.utils.which(os.getenv('PATH'), 'gpg')
+    gpg_keyid = d.getVar(basekeyname + '_GPG_NAME')
+
+    # Check for keyid
+    cmd = "%s --homedir %s --list-keys %s" % \
+            (gpg_bin, gpg_path, gpg_keyid)
+    status, output = oe.utils.getstatusoutput(cmd)
+    if not status:
+        return
+
+    # Import gpg key if not found
+    gpg_key = keydirfunc(d) + basekeyname + '-GPG-PRIVKEY-' + gpg_keyid
+    cmd = '%s --batch --homedir %s --passphrase %s --import %s' % \
+            (gpg_bin, gpg_path, d.getVar(basekeyname + '_GPG_PASSPHRASE'), gpg_key)
+    status, output = oe.utils.getstatusoutput(cmd)
+    if status:
+        bb.fatal('Failed to import gpg key (%s): %s' % (gpg_key, output))
+
+check_gpg_key[vardepsexclude] = "BUILDNAME"
+
+python check_boot_public_key () {
+    check_gpg_key('BOOT', uks_boot_keys_dir, d)
+}
+
+check_boot_public_key[lockfiles] = "${TMPDIR}/gpg_key.lock"
+
+def boot_sign(input, d):
+    import bb.process
+
+    gpg_path = d.getVar('GPG_PATH')
+    gpg_keyid = d.getVar('BOOT_GPG_NAME')
+    gpg_pass = d.getVar('BOOT_GPG_PASSPHRASE')
+    gpg_bin = d.getVar('GPG_BIN') or \
+              bb.utils.which(os.getenv('PATH'), 'gpg')
+    if os.path.exists(input + '.sig'):
+        os.unlink(input + '.sig')
+    cmd = 'echo "%s" | %s  --pinentry-mode loopback --batch --homedir %s -u "%s" --detach-sign --passphrase-fd 0 "%s"' % \
+            (gpg_pass, gpg_bin, gpg_path, gpg_keyid, input)
+    vprint("Running: %s" % cmd, d)
+    status, output = oe.utils.getstatusoutput(cmd)
+    if status:
+        bb.fatal('Failed to sign: %s' % (input))
+
+def uks_boot_sign(input, d):
+    boot_sign(input, d)
+
+def uks_bl_sign(input, d):
+    if d.getVar('UEFI_SELOADER') == '1':
+        uks_sel_sign(input, d)
+    if d.getVar('GRUB_SIGN_VERIFY') == '1':
+        boot_sign(input, d)

--- a/meta-oe/recipes-bsp/efitools/efitools-native_1.9.2.bb
+++ b/meta-oe/recipes-bsp/efitools/efitools-native_1.9.2.bb
@@ -1,0 +1,10 @@
+require efitools.inc
+
+inherit native
+
+DEPENDS:append = " gnu-efi-native"
+
+EXTRA_OEMAKE:append = " \
+    INCDIR_PREFIX='${STAGING_DIR_NATIVE}' \
+    CRTPATH_PREFIX='${STAGING_DIR_NATIVE}' \
+"

--- a/meta-oe/recipes-bsp/efitools/efitools.inc
+++ b/meta-oe/recipes-bsp/efitools/efitools.inc
@@ -1,0 +1,86 @@
+SUMMARY = "Tools to support reading and manipulating the UEFI signature database"
+DESCRIPTION = "\
+From the EFI Tools package in the Linux user-space, it's now possible \
+to read and manipulate the UEFI signatures database via the new \
+efi-readvar and efi-updatevar commands. Aside from needing efitools \
+1.4, the EFIVARFS file-system is also needed, which was only introduced \
+in the Linux 3.8 kernel. \
+"
+
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=e28f66b16cb46be47b20a4cdfe6e99a1"
+
+SRC_URI = "\
+    git://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git;branch=master \
+    file://0001-Fix-for-the-cross-compilation.patch \
+    file://0002-Make.rules-define-_GNU_SOURCE-for-a-declaration-of-f.patch \
+    file://0003-Fix-the-wrong-dependency-for-blacklist.esl.patch \
+    file://0004-LockDown-run-system-warm-reset-after-the-key-provisi.patch \
+    file://0005-Allow-to-override-tools-for-target-build.patch \
+    file://0006-Makefile-remove-help2man-dependency.patch \
+    file://0007-Add-static-keyword-for-IsValidVariableHeader.patch \
+    file://0008-Dynamically-load-openssl.cnf-for-openssl-1.0.x-1.1.x.patch \
+    file://0009-console.c-Fix-compilation-against-latest-usr-include.patch \
+    file://0010-LockDown-enable-the-enrollment-for-DBX.patch \
+    file://0011-LockDown-show-the-error-message-with-3-sec-timeout.patch \
+    file://0012-Makefile-do-not-build-signed-efi-image.patch \
+    file://0013-Build-DBX-by-default.patch \
+    file://0014-LockDown-disable-the-entrance-into-BIOS-setup-to-re-.patch \
+    file://0015-fix-segfault-for-efitools-commands.patch \
+    file://0016-Make.rules-Pass-CFLAGS-to-Makefile.patch \
+    file://0017-Make.rules-fix-efi-files-for-gnu-efi-3.0.18.patch \
+"
+SRCREV = "392836a46ce3c92b55dc88a1aebbcfdfc5dcddce"
+
+DEPENDS = "openssl-native sbsigntool-native \
+           libfile-slurp-perl-native \
+          "
+
+PARALLEL_MAKE = ""
+
+COMPATIBLE_HOST = '(i.86|x86_64|aarch64).*-linux'
+
+S = "${WORKDIR}/git"
+
+inherit perlnative
+
+EXTRA_OEMAKE = "\
+    OPENSSL='${STAGING_BINDIR_NATIVE}/openssl' \
+    SBSIGN='${STAGING_BINDIR_NATIVE}/sbsign' \
+    NM='${NM}' AR='${AR}' \
+    OPENSSL_LIB='${STAGING_LIBDIR_NATIVE}' \
+    EXTRA_LDFLAGS='${LDFLAGS}' \
+    CFLAGS='${CFLAGS}' \
+    OBJCOPY='${OBJCOPY}' \
+"
+EXTRA_OEMAKE:append:x86 = " ARCH=ia32"
+EXTRA_OEMAKE:append:x86-64 = " ARCH=x86_64"
+EXTRA_OEMAKE:append:aarch64 = " ARCH=aarch64"
+
+EFI_BOOT_PATH = "/boot/efi/EFI/BOOT"
+
+do_compile:prepend() {
+    sed -i -e "1s:#!.*:#!/usr/bin/env nativeperl:" xxdi.pl 
+}
+
+do_install() {
+    oe_runmake install DESTDIR='${D}${base_prefix}'
+}
+
+fakeroot python do_sign:class-target() {
+    if d.getVar('GRUB_SIGN_VERIFY') != '1':
+        return
+
+    image_dir = d.getVar('D')
+    efi_boot_path = d.getVar('EFI_BOOT_PATH')
+    uks_boot_sign(os.path.join(image_dir + efi_boot_path, 'LockDown.efi'), d)
+}
+addtask sign after do_install before do_deploy do_package
+do_sign[prefuncs] += "${@'check_boot_public_key' if d.getVar('GRUB_SIGN_VERIFY') == '1' else ''}"
+
+fakeroot python do_sign() {
+}
+
+FILES:${PN} += "${EFI_BOOT_PATH}"
+
+SSTATE_ALLOW_OVERLAP_FILES += "${DEPLOY_DIR_IMAGE}/LockDown.efi"

--- a/meta-oe/recipes-bsp/efitools/efitools/0001-Fix-for-the-cross-compilation.patch
+++ b/meta-oe/recipes-bsp/efitools/efitools/0001-Fix-for-the-cross-compilation.patch
@@ -1,0 +1,184 @@
+From 2e42e857584bd06541daf3fa79db84af30d11de4 Mon Sep 17 00:00:00 2001
+From: Lans Zhang <jia.zhang@windriver.com>
+Date: Tue, 15 Mar 2016 21:28:33 +0800
+Subject: [PATCH] Fix for the cross compilation
+
+Upstream-Status: Inappropriate [embedded specific]
+
+Signed-off-by: Lans Zhang <jia.zhang@windriver.com>
+---
+ Make.rules | 48 ++++++++++++++++++++++++++----------------------
+ Makefile   | 18 +++++++++---------
+ 2 files changed, 35 insertions(+), 31 deletions(-)
+
+diff --git a/Make.rules b/Make.rules
+index 903a5a4..65a634c 100644
+--- a/Make.rules
++++ b/Make.rules
+@@ -13,21 +13,25 @@ ARCH3264 =
+ else
+ $(error unknown architecture $(ARCH))
+ endif
+-INCDIR	   = -I$(TOPDIR)include/ -I/usr/include/efi -I/usr/include/efi/$(ARCH) -I/usr/include/efi/protocol
+-CPPFLAGS   = -DCONFIG_$(ARCH)
+-CFLAGS	   = -O2 -g $(ARCH3264) -fpic -Wall -fshort-wchar -fno-strict-aliasing -fno-merge-constants -fno-stack-protector -ffreestanding -fno-stack-check
+-LDFLAGS	   = -nostdlib
++INCDIR	   = -I$(TOPDIR)include/ -I$(INCDIR_PREFIX)/usr/include -I$(INCDIR_PREFIX)/usr/include/efi -I$(INCDIR_PREFIX)/usr/include/efi/$(ARCH) -I$(INCDIR_PREFIX)/usr/include/efi/protocol
++cppflags   = -DCONFIG_$(ARCH)
++cflags	   = -O2 -g $(ARCH3264) -fpic -Wall -fshort-wchar -fno-strict-aliasing -fno-merge-constants -fno-stack-protector -ffreestanding -fno-stack-check
++ldflags	   = -nostdlib
+ CRTOBJ		= crt0-efi-$(ARCH).o
+ CRTPATHS	= /lib /lib64 /lib/efi /lib64/efi /usr/lib /usr/lib64 /usr/lib/efi /usr/lib64/efi /usr/lib/gnuefi /usr/lib64/gnuefi
+-CRTPATH		= $(shell for f in $(CRTPATHS); do if [ -e $$f/$(CRTOBJ) ]; then echo $$f; break; fi; done)
++CRTPATH		= $(shell for f in $(CRTPATHS); do if [ -e $(CRTPATH_PREFIX)/$$f/$(CRTOBJ) ]; then echo $(CRTPATH_PREFIX)/$$f; break; fi; done)
+ CRTOBJS		= $(CRTPATH)/$(CRTOBJ)
+ # there's a bug in the gnu tools ... the .reloc section has to be
+ # aligned otherwise the file alignment gets screwed up
+ LDSCRIPT	= elf_$(ARCH)_efi.lds
+-LDFLAGS		+= -shared -Bsymbolic $(CRTOBJS) -L $(CRTPATH) -L /usr/lib -L /usr/lib64 -T $(LDSCRIPT)
++ldflags		+= -shared -Bsymbolic $(CRTOBJS) -L $(CRTPATH) -T $(LDSCRIPT)
+ LOADLIBES	= -lefi -lgnuefi $(shell $(CC) $(ARCH3264) -print-libgcc-file-name)
+ FORMAT		= --target=efi-app-$(ARCH)
+ OBJCOPY		= objcopy
++NM		= nm
++AR		= ar
++OPENSSL		= openssl
++SBSIGN		= sbsign
+ MYGUID		= 11111111-2222-3333-4444-123456789abc
+ INSTALL		= install
+ BINDIR		= $(DESTDIR)/usr/bin
+@@ -36,23 +40,23 @@ EFIDIR		= $(DESTDIR)/usr/share/efitools/efi
+ DOCDIR		= $(DESTDIR)/usr/share/efitools
+ 
+ # globally use EFI calling conventions (requires gcc >= 4.7)
+-CFLAGS += -DGNU_EFI_USE_MS_ABI
++cflags += -DGNU_EFI_USE_MS_ABI
+ 
+ ifeq ($(ARCH),x86_64)
+-  CFLAGS += -DEFI_FUNCTION_WRAPPER -mno-red-zone
++  cflags += -DEFI_FUNCTION_WRAPPER -mno-red-zone
+ endif
+ 
+ ifeq ($(ARCH),ia32)
+-  CFLAGS += -mno-red-zone
++  cflags += -mno-red-zone
+ endif
+ 
+ ifeq ($(ARCH),arm)
+-  LDFLAGS += --defsym=EFI_SUBSYSTEM=0x0a
++  ldflags += --defsym=EFI_SUBSYSTEM=0x0a
+   FORMAT = -O binary
+ endif
+ 
+ ifeq ($(ARCH),aarch64)
+-  LDFLAGS += --defsym=EFI_SUBSYSTEM=0x0a
++  ldflags += --defsym=EFI_SUBSYSTEM=0x0a
+   FORMAT = -O binary
+ endif
+ 
+@@ -61,9 +65,9 @@ endif
+ 		   -j .rel -j .rela -j .rel.* -j .rela.* -j .rel* -j .rela* \
+ 		   -j .reloc $(FORMAT) $*.so $@
+ %.so: %.o
+-	$(LD) $(LDFLAGS) $^ -o $@ $(LOADLIBES)
++	$(LD) $(ldflags) $^ -o $@ $(LOADLIBES)
+ 	# check we have no undefined symbols
+-	nm -D $@ | grep ' U ' && exit 1 || exit 0
++	${NM} -D $@ | grep ' U ' && exit 1 || exit 0
+ 
+ %.h: %.auth
+ 	./xxdi.pl $< > $@
+@@ -99,28 +103,28 @@ getvar = $(shell if [ "$(1)" = "PK" -o "$(1)" = "KEK" ]; then echo $(1); else ec
+ 	./sign-efi-sig-list -a -c PK.crt -k PK.key dbx $< $@
+ 
+ %.o: %.c
+-	$(CC) $(INCDIR) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
++	$(CC) $(INCDIR) $(cflags) $(cppflags) -c $< -o $@
+ 
+ %.efi.o: %.c
+-	$(CC) $(INCDIR) $(CFLAGS) $(CPPFLAGS) -fno-toplevel-reorder -DBUILD_EFI -c $< -o $@
++	$(CC) $(INCDIR) $(cflags) $(cppflags) -fno-toplevel-reorder -DBUILD_EFI -c $< -o $@
+ 
+ %.efi.s: %.c
+-	$(CC) -S $(INCDIR) $(CFLAGS) $(CPPFLAGS) -fno-toplevel-reorder -DBUILD_EFI -c $< -o $@
++	$(CC) -S $(INCDIR) $(cflags) $(cppflags) -fno-toplevel-reorder -DBUILD_EFI -c $< -o $@
+ 
+ %.crt:
+-	openssl req -new -x509 -newkey rsa:2048 -subj "/CN=$*/" -keyout $*.key -out $@ -days 3650 -nodes -sha256
++	$(OPENSSL) req -new -x509 -newkey rsa:2048 -subj "/CN=$*/" -keyout $*.key -out $@ -days 3650 -nodes -sha256
+ 
+ %.cer: %.crt
+-	openssl x509 -in $< -out $@ -outform DER
++	$(OPENSSL) x509 -in $< -out $@ -outform DER
+ 
+ %-subkey.csr:
+-	openssl req -new -newkey rsa:2048 -keyout $*-subkey.key -subj "/CN=Subkey $* of KEK/" -out $@ -nodes
++	$(OPENSSL) req -new -newkey rsa:2048 -keyout $*-subkey.key -subj "/CN=Subkey $* of KEK/" -out $@ -nodes
+ 
+ %-subkey.crt: %-subkey.csr KEK.crt
+-	openssl x509 -req -in $< -CA DB.crt -CAkey DB.key -set_serial 1 -out $@ -days 365
++	$(OPENSSL) x509 -req -in $< -CA DB.crt -CAkey DB.key -set_serial 1 -out $@ -days 365
+ 
+ %-signed.efi: %.efi DB.crt
+-	sbsign --key DB.key --cert DB.crt --output $@ $<
++	$(SBSIGN) --key DB.key --cert DB.crt --output $@ $<
+ 
+ ##
+ # No need for KEK signing
+@@ -129,7 +133,7 @@ getvar = $(shell if [ "$(1)" = "PK" -o "$(1)" = "KEK" ]; then echo $(1); else ec
+ #	sbsign --key KEK.key --cert KEK.crt --output $@ $<
+ 
+ %.a:
+-	ar rcv $@ $^
++	$(AR) rcv $@ $^
+ 
+ doc/%.1: doc/%.1.in %
+ 	$(HELP2MAN) --no-info -i $< -o $@ ./$*
+diff --git a/Makefile b/Makefile
+index 7d471da..124c2aa 100644
+--- a/Makefile
++++ b/Makefile
+@@ -88,31 +88,31 @@ HelloWorld.so: lib/lib-efi.a
+ ShimReplace.so: lib/lib-efi.a
+ 
+ cert-to-efi-sig-list: cert-to-efi-sig-list.o lib/lib.a
+-	$(CC) $(ARCH3264) -o $@ $< lib/lib.a -lcrypto
++	$(CC) $(ARCH3264) -o $@ $< $(EXTRA_LDFLAGS) lib/lib.a -lcrypto
+ 
+ sig-list-to-certs: sig-list-to-certs.o lib/lib.a
+-	$(CC) $(ARCH3264) -o $@ $< lib/lib.a -lcrypto
++	$(CC) $(ARCH3264) -o $@ $< $(EXTRA_LDFLAGS) lib/lib.a -lcrypto
+ 
+ sign-efi-sig-list: sign-efi-sig-list.o lib/lib.a
+-	$(CC) $(ARCH3264) -o $@ $< lib/lib.a -lcrypto
++	$(CC) $(ARCH3264) -o $@ $< $(EXTRA_LDFLAGS) lib/lib.a -lcrypto
+ 
+ hash-to-efi-sig-list: hash-to-efi-sig-list.o lib/lib.a
+-	$(CC) $(ARCH3264) -o $@ $< lib/lib.a
++	$(CC) $(ARCH3264) -o $@ $< $(EXTRA_LDFLAGS) lib/lib.a
+ 
+ cert-to-efi-hash-list: cert-to-efi-hash-list.o lib/lib.a
+-	$(CC) $(ARCH3264) -o $@ $< lib/lib.a -lcrypto
++	$(CC) $(ARCH3264) -o $@ $< $(EXTRA_LDFLAGS) lib/lib.a -lcrypto
+ 
+ efi-keytool: efi-keytool.o lib/lib.a
+-	$(CC) $(ARCH3264) -o $@ $< lib/lib.a
++	$(CC) $(ARCH3264) -o $@ $< $(EXTRA_LDFLAGS) lib/lib.a
+ 
+ efi-readvar: efi-readvar.o lib/lib.a
+-	$(CC) $(ARCH3264) -o $@ $< lib/lib.a -lcrypto
++	$(CC) $(ARCH3264) -o $@ $< $(EXTRA_LDFLAGS) lib/lib.a -lcrypto
+ 
+ efi-updatevar: efi-updatevar.o lib/lib.a
+-	$(CC) $(ARCH3264) -o $@ $< lib/lib.a -lcrypto
++	$(CC) $(ARCH3264) -o $@ $< $(EXTRA_LDFLAGS) lib/lib.a -lcrypto
+ 
+ flash-var: flash-var.o lib/lib.a
+-	$(CC) $(ARCH3264) -o $@ $< lib/lib.a
++	$(CC) $(ARCH3264) -o $@ $< $(EXTRA_LDFLAGS) lib/lib.a
+ 
+ clean:
+ 	rm -f PK.* KEK.* DB.* $(EFIFILES) $(EFISIGNED) $(BINARIES) *.o *.so
+-- 
+2.25.1
+

--- a/meta-oe/recipes-bsp/efitools/efitools/0002-Make.rules-define-_GNU_SOURCE-for-a-declaration-of-f.patch
+++ b/meta-oe/recipes-bsp/efitools/efitools/0002-Make.rules-define-_GNU_SOURCE-for-a-declaration-of-f.patch
@@ -1,0 +1,28 @@
+From 410e12bf3f917581d1da54cdc760e4618f7589cf Mon Sep 17 00:00:00 2001
+From: Yi Zhao <yi.zhao@windriver.com>
+Date: Sat, 24 Jun 2023 14:58:14 +0800
+Subject: [PATCH] Make.rules: define _GNU_SOURCE for a declaration of function
+
+Upstream-Status: Pending
+
+Signed-off-by: Yi Zhao <yi.zhao@windriver.com>
+---
+ Make.rules | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Make.rules b/Make.rules
+index 65a634c..66d63f0 100644
+--- a/Make.rules
++++ b/Make.rules
+@@ -14,7 +14,7 @@ else
+ $(error unknown architecture $(ARCH))
+ endif
+ INCDIR	   = -I$(TOPDIR)include/ -I$(INCDIR_PREFIX)/usr/include -I$(INCDIR_PREFIX)/usr/include/efi -I$(INCDIR_PREFIX)/usr/include/efi/$(ARCH) -I$(INCDIR_PREFIX)/usr/include/efi/protocol
+-cppflags   = -DCONFIG_$(ARCH)
++cppflags   = -DCONFIG_$(ARCH) -D_GNU_SOURCE
+ cflags	   = -O2 -g $(ARCH3264) -fpic -Wall -fshort-wchar -fno-strict-aliasing -fno-merge-constants -fno-stack-protector -ffreestanding -fno-stack-check
+ ldflags	   = -nostdlib
+ CRTOBJ		= crt0-efi-$(ARCH).o
+-- 
+2.25.1
+

--- a/meta-oe/recipes-bsp/efitools/efitools/0003-Fix-the-wrong-dependency-for-blacklist.esl.patch
+++ b/meta-oe/recipes-bsp/efitools/efitools/0003-Fix-the-wrong-dependency-for-blacklist.esl.patch
@@ -1,0 +1,28 @@
+From 2d9f8f766278c092426c9c0f1db5a5fd77dfed8c Mon Sep 17 00:00:00 2001
+From: Lans Zhang <jia.zhang@windriver.com>
+Date: Tue, 15 Mar 2016 21:07:31 +0800
+Subject: [PATCH] Fix the wrong dependency for %-blacklist.esl
+
+Upstream-Status: Pending
+
+Signed-off-by: Lans Zhang <jia.zhang@windriver.com>
+---
+ Make.rules | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Make.rules b/Make.rules
+index 66d63f0..fed93b9 100644
+--- a/Make.rules
++++ b/Make.rules
+@@ -75,7 +75,7 @@ endif
+ %.hash: %.efi hash-to-efi-sig-list
+ 	./hash-to-efi-sig-list $< $@
+ 
+-%-blacklist.esl: %.crt cert-to-efi-hash-list
++%-blacklist.esl: %.crt cert-to-efi-sig-list
+ 	./cert-to-efi-sig-list $< $@
+ 
+ %-hash-blacklist.esl: %.crt cert-to-efi-hash-list
+-- 
+2.25.1
+

--- a/meta-oe/recipes-bsp/efitools/efitools/0004-LockDown-run-system-warm-reset-after-the-key-provisi.patch
+++ b/meta-oe/recipes-bsp/efitools/efitools/0004-LockDown-run-system-warm-reset-after-the-key-provisi.patch
@@ -1,0 +1,44 @@
+From 59e05fa48aa32cbe044e597d3d3e6707c1ad6ee9 Mon Sep 17 00:00:00 2001
+From: Lans Zhang <jia.zhang@windriver.com>
+Date: Fri, 25 Mar 2016 10:52:34 +0800
+Subject: [PATCH] LockDown: run system warm reset after the key provision
+ success
+
+In addition, BIOS would stop at its setup screen. The end user can thus
+enable UEFI secure boot immediately.
+
+Upstream-Status: Inappropriate [embedded specific]
+
+Signed-off-by: Lans Zhang <jia.zhang@windriver.com>
+---
+ LockDown.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/LockDown.c b/LockDown.c
+index 29df9de..821985c 100644
+--- a/LockDown.c
++++ b/LockDown.c
+@@ -99,5 +99,20 @@ efi_main (EFI_HANDLE image, EFI_SYSTEM_TABLE *systab)
+ 	}
+ 	Print(L"Platform %s set to boot securely\n", SecureBoot ? L"is" : L"is not");
+ 
++	/* Reset system to go back the real UEFI secure boot flow.
++	 * If SecureBoot is still false, the user needs to turn on
++	 * UEFI secure boot in BIOS setup.
++	 */
++	Print(L"Prepare to execute system warm reset after 3 seconds ...\n");
++	if (!SecureBoot)
++	        Print(L"After warm reset, enter to BIOS setup to enable UEFI Secure Boot.\n");
++
++	BS->Stall(3000000);
++
++	if (!SecureBoot)
++	        SETOSIndicationsAndReboot(EFI_OS_INDICATIONS_BOOT_TO_FW_UI);
++	else
++	        RT->ResetSystem(EfiResetWarm, EFI_SUCCESS, 0, NULL);
++
+ 	return EFI_SUCCESS;
+ }
+-- 
+2.25.1
+

--- a/meta-oe/recipes-bsp/efitools/efitools/0005-Allow-to-override-tools-for-target-build.patch
+++ b/meta-oe/recipes-bsp/efitools/efitools/0005-Allow-to-override-tools-for-target-build.patch
@@ -1,0 +1,94 @@
+From eff910ccbca8e8205f84af1093c8e4557758705c Mon Sep 17 00:00:00 2001
+From: Lans Zhang <jia.zhang@windriver.com>
+Date: Wed, 23 Mar 2016 19:05:29 +0800
+Subject: [PATCH] Allow to override tools for target build
+
+These tools should use the ones from native build.
+
+Upstream-Status: Inappropriate [embedded specific]
+
+Signed-off-by: Lans Zhang <jia.zhang@windriver.com>
+---
+ Make.rules | 22 +++++++++++++---------
+ Makefile   |  4 ++--
+ 2 files changed, 15 insertions(+), 11 deletions(-)
+
+diff --git a/Make.rules b/Make.rules
+index fed93b9..1c50114 100644
+--- a/Make.rules
++++ b/Make.rules
+@@ -32,6 +32,10 @@ NM		= nm
+ AR		= ar
+ OPENSSL		= openssl
+ SBSIGN		= sbsign
++SIGN_EFI_SIG_LIST ?= ./sign-efi-sig-list
++CERT_TO_EFI_SIG_LIST ?= ./cert-to-efi-sig-list
++CERT_TO_EFI_HASH_LIST ?= ./cert-to-efi-hash-list
++HASH_TO_EFI_SIG_LIST ?= ./hash-to-efi-sig-list
+ MYGUID		= 11111111-2222-3333-4444-123456789abc
+ INSTALL		= install
+ BINDIR		= $(DESTDIR)/usr/bin
+@@ -73,34 +77,34 @@ endif
+ 	./xxdi.pl $< > $@
+ 
+ %.hash: %.efi hash-to-efi-sig-list
+-	./hash-to-efi-sig-list $< $@
++	$(HASH_TO_EFI_SIG_LIST) $< $@
+ 
+ %-blacklist.esl: %.crt cert-to-efi-sig-list
+-	./cert-to-efi-sig-list $< $@
++	$(CERT_TO_EFI_SIG_LIST) $< $@
+ 
+ %-hash-blacklist.esl: %.crt cert-to-efi-hash-list
+-	./cert-to-efi-hash-list $< $@
++	$(CERT_TO_EFI_HASH_LIST) $< $@
+ 
+ %.esl: %.crt cert-to-efi-sig-list
+-	./cert-to-efi-sig-list -g $(MYGUID) $< $@
++	$(CERT_TO_EFI_SIG_LIST) -g $(MYGUID) $< $@
+ 
+ getcert = $(shell if [ "$(1)" = "PK" -o "$(1)" = "KEK" ]; then echo "-c PK.crt -k PK.key"; else echo "-c KEK.crt -k KEK.key"; fi)
+ getvar = $(shell if [ "$(1)" = "PK" -o "$(1)" = "KEK" ]; then echo $(1); else echo db; fi)
+ 
+ %.auth: %.esl PK.crt KEK.crt sign-efi-sig-list
+-	./sign-efi-sig-list $(call getcert,$*) $(call getvar,$*) $< $@
++	$(SIGN_EFI_SIG_LIST) $(call getcert,$*) $(call getvar,$*) $< $@
+ 
+ %-update.auth: %.esl PK.crt KEK.crt sign-efi-sig-list
+-	./sign-efi-sig-list -a $(call getcert,$*) $(call getvar,$*) $< $@
++	$(SIGN_EFI_SIG_LIST) -a $(call getcert,$*) $(call getvar,$*) $< $@
+ 
+ %-pkupdate.auth: %.esl PK.crt sign-efi-sig-list
+-	./sign-efi-sig-list -a -c PK.crt -k PK.key $(call getvar,$*) $< $@
++	$(SIGN_EFI_SIG_LIST) -a -c PK.crt -k PK.key $(call getvar,$*) $< $@
+ 
+ %-blacklist.auth: %-blacklist.esl KEK.crt sign-efi-sig-list
+-	./sign-efi-sig-list -a -c KEK.crt -k KEK.key dbx $< $@
++	$(SIGN_EFI_SIG_LIST) -a -c KEK.crt -k KEK.key dbx $< $@
+ 
+ %-pkblacklist.auth: %-blacklist.esl PK.crt sign-efi-sig-list
+-	./sign-efi-sig-list -a -c PK.crt -k PK.key dbx $< $@
++	$(SIGN_EFI_SIG_LIST) -a -c PK.crt -k PK.key dbx $< $@
+ 
+ %.o: %.c
+ 	$(CC) $(INCDIR) $(cflags) $(cppflags) -c $< -o $@
+diff --git a/Makefile b/Makefile
+index 124c2aa..0343224 100644
+--- a/Makefile
++++ b/Makefile
+@@ -66,10 +66,10 @@ noPK.esl:
+ 	> noPK.esl
+ 
+ noPK.auth: noPK.esl PK.crt sign-efi-sig-list
+-	./sign-efi-sig-list -t "$(shell date --date='1 second' +'%Y-%m-%d %H:%M:%S')" -c PK.crt -k PK.key PK $< $@
++	$(SIGN_EFI_SIG_LIST) -t "$(shell date --date='1 second' +'%Y-%m-%d %H:%M:%S')" -c PK.crt -k PK.key PK $< $@
+ 
+ ms-%.esl: ms-%.crt cert-to-efi-sig-list
+-	./cert-to-efi-sig-list -g $(MSGUID) $< $@
++	$(CERT_TO_EFI_SIG_LIST) -g $(MSGUID) $< $@
+ 
+ hashlist.h: HashTool.hash
+ 	cat $^ > /tmp/tmp.hash
+-- 
+2.25.1
+

--- a/meta-oe/recipes-bsp/efitools/efitools/0006-Makefile-remove-help2man-dependency.patch
+++ b/meta-oe/recipes-bsp/efitools/efitools/0006-Makefile-remove-help2man-dependency.patch
@@ -1,0 +1,34 @@
+From 738d48e46cbebfa22cbfc400ce2a7ab320f07359 Mon Sep 17 00:00:00 2001
+From: Yi Zhao <yi.zhao@windriver.com>
+Date: Sat, 24 Jun 2023 15:26:27 +0800
+Subject: [PATCH] Makefile: remove help2man dependency
+
+Upstream-Status: Inappropriate [embedded specific]
+
+Signed-off-by: Yi Zhao <yi.zhao@windriver.com>
+---
+ Makefile | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 0343224..f493778 100644
+--- a/Makefile
++++ b/Makefile
+@@ -27,13 +27,11 @@ include Make.rules
+ 
+ EFISIGNED = $(patsubst %.efi,%-signed.efi,$(EFIFILES))
+ 
+-all: $(EFISIGNED) $(BINARIES) $(MANPAGES) noPK.auth $(KEYAUTH) \
++all: $(EFISIGNED) $(BINARIES) noPK.auth $(KEYAUTH) \
+ 	$(KEYUPDATEAUTH) $(KEYBLACKLISTAUTH) $(KEYHASHBLACKLISTAUTH)
+ 
+ 
+ install: all
+-	$(INSTALL) -m 755 -d $(MANDIR)
+-	$(INSTALL) -m 644 $(MANPAGES) $(MANDIR)
+ 	$(INSTALL) -m 755 -d $(EFIDIR)
+ 	$(INSTALL) -m 755 $(EFIFILES) $(EFIDIR)
+ 	$(INSTALL) -m 755 -d $(BINDIR)
+-- 
+2.25.1
+

--- a/meta-oe/recipes-bsp/efitools/efitools/0007-Add-static-keyword-for-IsValidVariableHeader.patch
+++ b/meta-oe/recipes-bsp/efitools/efitools/0007-Add-static-keyword-for-IsValidVariableHeader.patch
@@ -1,0 +1,38 @@
+From 717ea53c803a1cd7ae24589fb10bf794e422d38f Mon Sep 17 00:00:00 2001
+From: Lans Zhang <jia.zhang@windriver.com>
+Date: Sun, 12 Jun 2016 13:45:54 +0800
+Subject: [PATCH] Add static keyword for IsValidVariableHeader()
+
+GCC does not inline any functions when not optimizing (-O0 specified) unless
+you specify "always_inline" attribute for the function.
+
+By default, GCC complies with C89 standard for c code, which means
+"inline" equals to "extern inline" and thus the definition is used only for
+inlining with the assembly code actually generated.
+
+Therefore, "static inline" is used for both purposes. If -O0 is specified,
+GCC will generate the assembly code as long as the function is referred.
+
+Upstream-Status: Inappropriate [embedded specific]
+
+Signed-off-by: Lans Zhang <jia.zhang@windriver.com>
+---
+ include/variableformat.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/variableformat.h b/include/variableformat.h
+index 32cde05..45d0ebb 100644
+--- a/include/variableformat.h
++++ b/include/variableformat.h
+@@ -109,7 +109,7 @@ typedef struct {
+ 
+ #pragma pack()
+ 
+-inline BOOLEAN
++static inline BOOLEAN
+ IsValidVariableHeader (VARIABLE_HEADER   *vh) {
+ 	if (vh == NULL || vh->StartId != VARIABLE_DATA)
+ 		return FALSE;
+-- 
+2.25.1
+

--- a/meta-oe/recipes-bsp/efitools/efitools/0008-Dynamically-load-openssl.cnf-for-openssl-1.0.x-1.1.x.patch
+++ b/meta-oe/recipes-bsp/efitools/efitools/0008-Dynamically-load-openssl.cnf-for-openssl-1.0.x-1.1.x.patch
@@ -1,0 +1,50 @@
+From ddb4a7634ebedc6a0812b1afb70072c7621555f5 Mon Sep 17 00:00:00 2001
+From: Lans Zhang <jia.zhang@windriver.com>
+Date: Wed, 16 Aug 2017 22:59:12 +0800
+Subject: [PATCH] Dynamically load openssl.cnf for openssl-1.0.x/1.1.x/3.0
+
+Upstream-Status: Inappropriate [embedded specific]
+
+Signed-off-by: Lans Zhang <jia.zhang@windriver.com>
+Signed-off-by: Yi Zhao <yi.zhao@windriver.com>
+---
+ Make.rules | 18 ++++++++++++++++--
+ 1 file changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/Make.rules b/Make.rules
+index 1c50114..0316ce5 100644
+--- a/Make.rules
++++ b/Make.rules
+@@ -116,13 +116,27 @@ getvar = $(shell if [ "$(1)" = "PK" -o "$(1)" = "KEK" ]; then echo $(1); else ec
+ 	$(CC) -S $(INCDIR) $(cflags) $(cppflags) -fno-toplevel-reorder -DBUILD_EFI -c $< -o $@
+ 
+ %.crt:
+-	$(OPENSSL) req -new -x509 -newkey rsa:2048 -subj "/CN=$*/" -keyout $*.key -out $@ -days 3650 -nodes -sha256
++	@if [ -s "$(OPENSSL_LIB)/ssl-3/openssl.cnf" ]; then \
++	    cfg="$(OPENSSL_LIB)/ssl-3/openssl.cnf"; \
++	elif [ -s "$(OPENSSL_LIB)/ssl-1.1/openssl.cnf" ]; then \
++	    cfg="$(OPENSSL_LIB)/ssl-1.1/openssl.cnf"; \
++	else \
++	    cfg="$(OPENSSL_LIB)/ssl/openssl.cnf"; \
++	fi; \
++	$(OPENSSL) req -config $$cfg -new -x509 -newkey rsa:2048 -subj "/CN=$*/" -keyout $*.key -out $@ -days 3650 -nodes -sha256
+ 
+ %.cer: %.crt
+ 	$(OPENSSL) x509 -in $< -out $@ -outform DER
+ 
+ %-subkey.csr:
+-	$(OPENSSL) req -new -newkey rsa:2048 -keyout $*-subkey.key -subj "/CN=Subkey $* of KEK/" -out $@ -nodes
++	@if [ -s "$(OPENSSL_LIB)/ssl-3/openssl.cnf" ]; then \
++	    cfg="$(OPENSSL_LIB)/ssl-3/openssl.cnf"; \
++	elif [ -s "$(OPENSSL_LIB)/ssl-1.1/openssl.cnf" ]; then \
++	    cfg="$(OPENSSL_LIB)/ssl-1.1/openssl.cnf"; \
++	else \
++	    cfg="$(OPENSSL_LIB)/ssl/openssl.cnf"; \
++	fi; \
++	$(OPENSSL) req -config $$cfg -new -newkey rsa:2048 -keyout $*-subkey.key -subj "/CN=Subkey $* of KEK/" -out $@ -nodes
+ 
+ %-subkey.crt: %-subkey.csr KEK.crt
+ 	$(OPENSSL) x509 -req -in $< -CA DB.crt -CAkey DB.key -set_serial 1 -out $@ -days 365
+-- 
+2.25.1
+

--- a/meta-oe/recipes-bsp/efitools/efitools/0009-console.c-Fix-compilation-against-latest-usr-include.patch
+++ b/meta-oe/recipes-bsp/efitools/efitools/0009-console.c-Fix-compilation-against-latest-usr-include.patch
@@ -1,0 +1,39 @@
+From b10bb68613eb98ecf00bfc90df66740bb538589d Mon Sep 17 00:00:00 2001
+From: Jason Wessel <jason.wessel@windriver.com>
+Date: Mon, 4 Nov 2019 12:42:49 -0800
+Subject: [PATCH] console.c: Fix compilation against latest /usr/include/efi
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+| gcc  -I/opt/tmp/work/x86_64-linux/efitools-native/1.9.2+gitAUTOINC+392836a46c-r0/git/include/ -I/opt/tmp/work/x86_64-linux/efitools-native/1.9.2+gitAUTOINC+392836a46c-r0/recipe-sysroot-native/usr/include -I/opt/tmp/work/x86_64-linux/efitools-native/1.9.2+gitAUTOINC+392836a46c-r0/recipe-sysroot-native/usr/include/efi -I/opt/tmp/work/x86_64-linux/efitools-native/1.9.2+gitAUTOINC+392836a46c-r0/recipe-sysroot-native/usr/include/efi/x86_64 -I/opt/tmp/work/x86_64-linux/efitools-native/1.9.2+gitAUTOINC+392836a46c-r0/recipe-sysroot-native/usr/include/efi/protocol -O2 -g  -fpic -Wall -fshort-wchar -fno-strict-aliasing -fno-merge-constants -fno-stack-protector -ffreestanding -fno-stack-check -DGNU_EFI_USE_MS_ABI -DEFI_FUNCTION_WRAPPER -mno-red-zone -DCONFIG_x86_64 -fno-toplevel-reorder -DBUILD_EFI -c console.c -o console.efi.o
+| console.c:360:5: error: ‘EFI_WARN_UNKOWN_GLYPH’ undeclared here (not in a function); did you mean ‘EFI_WARN_UNKNOWN_GLYPH’?
+|   {  EFI_WARN_UNKOWN_GLYPH,      L"Warning Unknown Glyph"},
+|      ^~~~~~~~~~~~~~~~~~~~~
+|      EFI_WARN_UNKNOWN_GLYPH
+| ../Make.rules:113: recipe for target 'console.efi.o' failed
+|
+
+Upstream-Status: Pending
+
+Signed-off-by: Jason Wessel <jason.wessel@windriver.com>
+---
+ lib/console.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/console.c b/lib/console.c
+index 9c10560..b932a44 100644
+--- a/lib/console.c
++++ b/lib/console.c
+@@ -357,7 +357,7 @@ static struct {
+ 	{  EFI_SECURITY_VIOLATION,     L"Security Violation"},
+ 
+ 	// warnings
+-	{  EFI_WARN_UNKOWN_GLYPH,      L"Warning Unknown Glyph"},
++	{  EFI_WARN_UNKNOWN_GLYPH,     L"Warning Unknown Glyph"},
+ 	{  EFI_WARN_DELETE_FAILURE,    L"Warning Delete Failure"},
+ 	{  EFI_WARN_WRITE_FAILURE,     L"Warning Write Failure"},
+ 	{  EFI_WARN_BUFFER_TOO_SMALL,  L"Warning Buffer Too Small"},
+-- 
+2.25.1
+

--- a/meta-oe/recipes-bsp/efitools/efitools/0010-LockDown-enable-the-enrollment-for-DBX.patch
+++ b/meta-oe/recipes-bsp/efitools/efitools/0010-LockDown-enable-the-enrollment-for-DBX.patch
@@ -1,0 +1,85 @@
+From 359729908d7b3f1cee2fcad5218b3112ca694780 Mon Sep 17 00:00:00 2001
+From: Lans Zhang <jia.zhang@windriver.com>
+Date: Fri, 22 Apr 2016 16:28:05 +0800
+Subject: [PATCH] LockDown: enable the enrollment for DBX
+
+DBX acting as blacklist now is able to be enrolled.
+
+Upstream-Status: Inappropriate [embedded specific]
+
+Signed-off-by: Lans Zhang <jia.zhang@windriver.com>
+---
+ LockDown.c | 16 +++++++++++-----
+ Makefile   |  4 +++-
+ 2 files changed, 14 insertions(+), 6 deletions(-)
+
+diff --git a/LockDown.c b/LockDown.c
+index 821985c..fec2e79 100644
+--- a/LockDown.c
++++ b/LockDown.c
+@@ -12,6 +12,7 @@
+ #include "PK.h"
+ #include "KEK.h"
+ #include "DB.h"
++#include "DBX.h"
+ 
+ EFI_STATUS
+ efi_main (EFI_HANDLE image, EFI_SYSTEM_TABLE *systab)
+@@ -47,6 +48,7 @@ efi_main (EFI_HANDLE image, EFI_SYSTEM_TABLE *systab)
+ 		return efi_status;
+ 	}
+ 	Print(L"Created KEK Cert\n");
++
+ 	efi_status = RT->SetVariable(L"db", &SIG_DB,
+ 				     EFI_VARIABLE_NON_VOLATILE
+ 				     | EFI_VARIABLE_RUNTIME_ACCESS 
+@@ -58,15 +60,19 @@ efi_main (EFI_HANDLE image, EFI_SYSTEM_TABLE *systab)
+ 		return efi_status;
+ 	}
+ 	Print(L"Created db Cert\n");
+-#if 0
+-	/* testing revocation ... this will revoke the certificate
+-	 * we just enrolled in db */
+-	efi_status = SetSecureVariable(L"dbx", DB_cer, DB_cer_len, SIG_DB, 0);
++
++	efi_status = RT->SetVariable(L"dbx", &SIG_DB,
++				     EFI_VARIABLE_NON_VOLATILE
++				     | EFI_VARIABLE_RUNTIME_ACCESS
++				     | EFI_VARIABLE_BOOTSERVICE_ACCESS
++				     | EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS,
++				     DBX_auth_len, DBX_auth);
+ 	if (efi_status != EFI_SUCCESS) {
+ 		Print(L"Failed to enroll dbx: %d\n", efi_status);
+ 		return efi_status;
+ 	}
+-#endif
++	Print(L"Created dbx Cert\n");
++
+ 	/* PK must be updated with a signed copy of itself */
+ 	efi_status = RT->SetVariable(L"PK", &GV_GUID,
+ 				     EFI_VARIABLE_NON_VOLATILE
+diff --git a/Makefile b/Makefile
+index f493778..da209f6 100644
+--- a/Makefile
++++ b/Makefile
+@@ -51,7 +51,7 @@ lib/asn1/libasn1.a lib/asn1/libasn1-efi.a: FORCE
+ .KEEP: PK.crt KEK.crt DB.crt PK.key KEK.key DB.key PK.esl DB.esl KEK.esl \
+ 	$(EFIFILES)
+ 
+-LockDown.o: PK.h KEK.h DB.h
++LockDown.o: PK.h KEK.h DB.h DBX.h
+ PreLoader.o: hashlist.h
+ 
+ PK.h: PK.auth
+@@ -60,6 +60,8 @@ KEK.h: KEK.auth
+ 
+ DB.h: DB.auth
+ 
++DBX.h: DBX.auth
++
+ noPK.esl:
+ 	> noPK.esl
+ 
+-- 
+2.25.1
+

--- a/meta-oe/recipes-bsp/efitools/efitools/0011-LockDown-show-the-error-message-with-3-sec-timeout.patch
+++ b/meta-oe/recipes-bsp/efitools/efitools/0011-LockDown-show-the-error-message-with-3-sec-timeout.patch
@@ -1,0 +1,96 @@
+From 1bd8db07ed8ee1e256f31a39fed7113372779ce8 Mon Sep 17 00:00:00 2001
+From: Lans Zhang <jia.zhang@windriver.com>
+Date: Tue, 17 Jan 2017 12:48:27 +0800
+Subject: [PATCH] LockDown: show the error message with 3-sec timeout
+
+Upstream-Status: Inappropriate [embedded specific]
+
+Signed-off-by: Lans Zhang <jia.zhang@windriver.com>
+---
+ LockDown.c | 20 ++++++++++++--------
+ 1 file changed, 12 insertions(+), 8 deletions(-)
+
+diff --git a/LockDown.c b/LockDown.c
+index fec2e79..13c626f 100644
+--- a/LockDown.c
++++ b/LockDown.c
+@@ -27,12 +27,12 @@ efi_main (EFI_HANDLE image, EFI_SYSTEM_TABLE *systab)
+ 
+ 	if (efi_status != EFI_SUCCESS) {
+ 		Print(L"No SetupMode variable ... is platform secure boot enabled?\n");
+-		return EFI_SUCCESS;
++		goto out;
+ 	}
+ 
+ 	if (!SetupMode) {
+ 		Print(L"Platform is not in Setup Mode, cannot install Keys\n");
+-		return EFI_SUCCESS;
++		goto out;
+ 	}
+ 
+ 	Print(L"Platform is in Setup Mode\n");
+@@ -45,7 +45,7 @@ efi_main (EFI_HANDLE image, EFI_SYSTEM_TABLE *systab)
+ 				     KEK_auth_len, KEK_auth);
+ 	if (efi_status != EFI_SUCCESS) {
+ 		Print(L"Failed to enroll KEK: %d\n", efi_status);
+-		return efi_status;
++		goto out;
+ 	}
+ 	Print(L"Created KEK Cert\n");
+ 
+@@ -57,7 +57,7 @@ efi_main (EFI_HANDLE image, EFI_SYSTEM_TABLE *systab)
+ 				     DB_auth_len, DB_auth);
+ 	if (efi_status != EFI_SUCCESS) {
+ 		Print(L"Failed to enroll db: %d\n", efi_status);
+-		return efi_status;
++		goto out;
+ 	}
+ 	Print(L"Created db Cert\n");
+ 
+@@ -69,7 +69,7 @@ efi_main (EFI_HANDLE image, EFI_SYSTEM_TABLE *systab)
+ 				     DBX_auth_len, DBX_auth);
+ 	if (efi_status != EFI_SUCCESS) {
+ 		Print(L"Failed to enroll dbx: %d\n", efi_status);
+-		return efi_status;
++		goto out;
+ 	}
+ 	Print(L"Created dbx Cert\n");
+ 
+@@ -84,14 +84,14 @@ efi_main (EFI_HANDLE image, EFI_SYSTEM_TABLE *systab)
+ 	
+ 	if (efi_status != EFI_SUCCESS) {
+ 		Print(L"Failed to enroll PK: %d\n", efi_status);
+-		return efi_status;
++		goto out;
+ 	}
+ 	Print(L"Created PK Cert\n");
+ 	/* enrolling the PK should put us in SetupMode; check this */
+ 	efi_status = RT->GetVariable(L"SetupMode", &GV_GUID, NULL, &DataSize, &SetupMode);
+ 	if (efi_status != EFI_SUCCESS) {
+ 		Print(L"Failed to get SetupMode variable: %d\n", efi_status);
+-		return efi_status;
++		goto out;
+ 	}
+ 	Print(L"Platform is in %s Mode\n", SetupMode ? L"Setup" : L"User");
+ 
+@@ -101,7 +101,7 @@ efi_main (EFI_HANDLE image, EFI_SYSTEM_TABLE *systab)
+ 
+ 	if (efi_status != EFI_SUCCESS) {
+ 		Print(L"Failed to get SecureBoot variable: %d\n", efi_status);
+-		return efi_status;
++		goto out;
+ 	}
+ 	Print(L"Platform %s set to boot securely\n", SecureBoot ? L"is" : L"is not");
+ 
+@@ -121,4 +121,8 @@ efi_main (EFI_HANDLE image, EFI_SYSTEM_TABLE *systab)
+ 	        RT->ResetSystem(EfiResetWarm, EFI_SUCCESS, 0, NULL);
+ 
+ 	return EFI_SUCCESS;
++
++out:
++	BS->Stall(3000000);
++	return efi_status;
+ }
+-- 
+2.25.1
+

--- a/meta-oe/recipes-bsp/efitools/efitools/0012-Makefile-do-not-build-signed-efi-image.patch
+++ b/meta-oe/recipes-bsp/efitools/efitools/0012-Makefile-do-not-build-signed-efi-image.patch
@@ -1,0 +1,42 @@
+From e0ee24698be52fdb9bb7b62d70f052044d4de62f Mon Sep 17 00:00:00 2001
+From: Yunguo Wei <yunguo.wei@windriver.com>
+Date: Tue, 17 Jan 2017 17:24:51 +0800
+Subject: [PATCH] Makefile: do not build signed efi image
+
+Upstream-Status: Inappropriate [embedded specific]
+
+Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>
+---
+ Makefile | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index da209f6..df8c1e8 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,11 +1,10 @@
+-EFIFILES = HelloWorld.efi LockDown.efi Loader.efi ReadVars.efi UpdateVars.efi \
+-	KeyTool.efi HashTool.efi SetNull.efi ShimReplace.efi
++EFIFILES = LockDown.efi
+ BINARIES = cert-to-efi-sig-list sig-list-to-certs sign-efi-sig-list \
+ 	hash-to-efi-sig-list efi-readvar efi-updatevar cert-to-efi-hash-list \
+ 	flash-var
+ 
+ ifeq ($(ARCH),x86_64)
+-EFIFILES += PreLoader.efi
++#EFIFILES += PreLoader.efi
+ endif
+ 
+ MSGUID = 77FA9ABD-0359-4D32-BD60-28F4E78F784B
+@@ -27,7 +26,7 @@ include Make.rules
+ 
+ EFISIGNED = $(patsubst %.efi,%-signed.efi,$(EFIFILES))
+ 
+-all: $(EFISIGNED) $(BINARIES) noPK.auth $(KEYAUTH) \
++all: $(EFIFILES) $(BINARIES) noPK.auth $(KEYAUTH) \
+ 	$(KEYUPDATEAUTH) $(KEYBLACKLISTAUTH) $(KEYHASHBLACKLISTAUTH)
+ 
+ 
+-- 
+2.25.1
+

--- a/meta-oe/recipes-bsp/efitools/efitools/0013-Build-DBX-by-default.patch
+++ b/meta-oe/recipes-bsp/efitools/efitools/0013-Build-DBX-by-default.patch
@@ -1,0 +1,46 @@
+From 77beb93b2d78fa715b9f094fd8fd6e8f2816eb37 Mon Sep 17 00:00:00 2001
+From: Lans Zhang <jia.zhang@windriver.com>
+Date: Sat, 28 Jan 2017 13:42:28 +0800
+Subject: [PATCH] Build DBX by default
+
+Upstream-Status: Inappropriate [embedded specific]
+
+Signed-off-by: Lans Zhang <jia.zhang@windriver.com>
+---
+ Makefile | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index df8c1e8..66f5d2e 100644
+--- a/Makefile
++++ b/Makefile
+@@ -26,7 +26,7 @@ include Make.rules
+ 
+ EFISIGNED = $(patsubst %.efi,%-signed.efi,$(EFIFILES))
+ 
+-all: $(EFIFILES) $(BINARIES) noPK.auth $(KEYAUTH) \
++all: $(EFIFILES) $(BINARIES) noPK.auth $(KEYAUTH) DBX.auth \
+ 	$(KEYUPDATEAUTH) $(KEYBLACKLISTAUTH) $(KEYHASHBLACKLISTAUTH)
+ 
+ 
+@@ -47,7 +47,7 @@ lib/asn1/libasn1.a lib/asn1/libasn1-efi.a: FORCE
+ 
+ .SUFFIXES: .crt
+ 
+-.KEEP: PK.crt KEK.crt DB.crt PK.key KEK.key DB.key PK.esl DB.esl KEK.esl \
++.KEEP: PK.crt KEK.crt DB.crt DBX.crt PK.key KEK.key DB.key PK.esl DB.esl KEK.esl DBX.esl \
+ 	$(EFIFILES)
+ 
+ LockDown.o: PK.h KEK.h DB.h DBX.h
+@@ -114,7 +114,7 @@ flash-var: flash-var.o lib/lib.a
+ 	$(CC) $(ARCH3264) -o $@ $< $(EXTRA_LDFLAGS) lib/lib.a
+ 
+ clean:
+-	rm -f PK.* KEK.* DB.* $(EFIFILES) $(EFISIGNED) $(BINARIES) *.o *.so
++	rm -f PK.* KEK.* DB.* DBX.* $(EFIFILES) $(EFISIGNED) $(BINARIES) *.o *.so
+ 	rm -f noPK.*
+ 	rm -f doc/*.1
+ 	$(MAKE) -C lib clean
+-- 
+2.25.1
+

--- a/meta-oe/recipes-bsp/efitools/efitools/0014-LockDown-disable-the-entrance-into-BIOS-setup-to-re-.patch
+++ b/meta-oe/recipes-bsp/efitools/efitools/0014-LockDown-disable-the-entrance-into-BIOS-setup-to-re-.patch
@@ -1,0 +1,49 @@
+From ff50beb84628c9f852445696f06c8843b2d75c98 Mon Sep 17 00:00:00 2001
+From: Lans Zhang <jia.zhang@windriver.com>
+Date: Wed, 15 Feb 2017 14:52:07 +0800
+Subject: [PATCH] LockDown: disable the entrance into BIOS setup to re-enable
+ secure boot
+
+In most cases, this step is not necessary.
+
+Upstream-Status: Inappropriate [embedded specific]
+
+Signed-off-by: Lans Zhang <jia.zhang@windriver.com>
+---
+ LockDown.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/LockDown.c b/LockDown.c
+index 13c626f..fbde3f2 100644
+--- a/LockDown.c
++++ b/LockDown.c
+@@ -20,6 +20,11 @@ efi_main (EFI_HANDLE image, EFI_SYSTEM_TABLE *systab)
+ 	EFI_STATUS efi_status;
+ 	UINT8 SecureBoot, SetupMode;
+ 	UINTN DataSize = sizeof(SetupMode);
++	/* This controls whether it is required to enter into BIOS setup in
++	 * order to re-enable UEFI secure boot. This operation is unnecessary
++	 * in most cases.
++	 */
++	UINTN NeedSetAttempt = 0;
+ 
+ 	InitializeLib(image, systab);
+ 
+@@ -110,12 +115,12 @@ efi_main (EFI_HANDLE image, EFI_SYSTEM_TABLE *systab)
+ 	 * UEFI secure boot in BIOS setup.
+ 	 */
+ 	Print(L"Prepare to execute system warm reset after 3 seconds ...\n");
+-	if (!SecureBoot)
++	if (NeedSetAttempt && !SecureBoot)
+ 	        Print(L"After warm reset, enter to BIOS setup to enable UEFI Secure Boot.\n");
+ 
+ 	BS->Stall(3000000);
+ 
+-	if (!SecureBoot)
++	if (NeedSetAttempt && !SecureBoot)
+ 	        SETOSIndicationsAndReboot(EFI_OS_INDICATIONS_BOOT_TO_FW_UI);
+ 	else
+ 	        RT->ResetSystem(EfiResetWarm, EFI_SUCCESS, 0, NULL);
+-- 
+2.25.1
+

--- a/meta-oe/recipes-bsp/efitools/efitools/0015-fix-segfault-for-efitools-commands.patch
+++ b/meta-oe/recipes-bsp/efitools/efitools/0015-fix-segfault-for-efitools-commands.patch
@@ -1,0 +1,219 @@
+From 6818d5f0514a4e34bf3a8a52e41a20778d5cd3b9 Mon Sep 17 00:00:00 2001
+From: Yi Zhao <yi.zhao@windriver.com>
+Date: Thu, 20 Jul 2023 12:36:14 +0800
+Subject: [PATCH] fix segfault for efitools commands
+
+Segfault occurs when missing argument in some options.
+
+e.g.
+$ sign-efi-sig-list -g
+Segmentation fault
+
+$ cert-to-efi-hash-list -s
+Segmentation fault
+
+$ efi-readvar -s
+Segmentation fault
+
+$ efi-updatevar -d
+Segmentation fault
+
+This is because argv[2] is not checked for NULL before using it. Add
+check to avoid the segfault.
+
+Upstream-Status: Pending
+
+Signed-off-by: Yi Zhao <yi.zhao@windriver.com>
+---
+ cert-to-efi-hash-list.c | 22 ++++++++++++++++------
+ cert-to-efi-sig-list.c  | 11 ++++++++---
+ efi-readvar.c           | 11 ++++++++---
+ efi-updatevar.c         | 26 ++++++++++++++++++--------
+ flash-var.c             | 15 ++++++++++-----
+ sign-efi-sig-list.c     | 11 ++++++++---
+ 6 files changed, 68 insertions(+), 28 deletions(-)
+
+diff --git a/cert-to-efi-hash-list.c b/cert-to-efi-hash-list.c
+index 8a5468a..ead82f1 100644
+--- a/cert-to-efi-hash-list.c
++++ b/cert-to-efi-hash-list.c
+@@ -76,13 +76,23 @@ main(int argc, char *argv[])
+ 			help(progname);
+ 			exit(0);
+ 		} else if (strcmp("-g", argv[1]) == 0) {
+-			str_to_guid(argv[2], &owner);
+-			argv += 2;
+-			argc -= 2;
++			if (argv[2]) {
++				str_to_guid(argv[2], &owner);
++				argv += 2;
++				argc -= 2;
++			} else {
++				usage(progname);
++				exit(1);
++			}
+ 		} else if (strcmp("-s", argv[1]) == 0) {
+-			sha = atoi(argv[2]);
+-			argv += 2;
+-			argc -= 2;
++			if (argv[2]) {
++				sha = atoi(argv[2]);
++				argv += 2;
++				argc -= 2;
++			} else {
++				usage(progname);
++				exit(1);
++			}
+ 		} else if (strcmp("-t", argv[1]) == 0) {
+ 			timestampstr = argv[2];
+ 			argv += 2;
+diff --git a/cert-to-efi-sig-list.c b/cert-to-efi-sig-list.c
+index fe65e15..d06cac9 100644
+--- a/cert-to-efi-sig-list.c
++++ b/cert-to-efi-sig-list.c
+@@ -61,9 +61,14 @@ main(int argc, char *argv[])
+ 			help(progname);
+ 			exit(0);
+ 		} else if (strcmp("-g", argv[1]) == 0) {
+-			str_to_guid(argv[2], &owner);
+-			argv += 2;
+-			argc -= 2;
++			if (argv[2]) {
++				str_to_guid(argv[2], &owner);
++				argv += 2;
++				argc -= 2;
++			} else {
++				usage(progname);
++				exit(1);
++			}
+ 		} else {
+ 			break;
+ 		}
+diff --git a/efi-readvar.c b/efi-readvar.c
+index 816b306..2f6584a 100644
+--- a/efi-readvar.c
++++ b/efi-readvar.c
+@@ -132,9 +132,14 @@ main(int argc, char *argv[])
+ 			argv += 2;
+ 			argc -= 2;
+ 		} else if (strcmp(argv[1], "-s") == 0) {
+-			sscanf(argv[2], "%d-%d", &sig, &entry);
+-			argv += 2;
+-			argc -= 2;
++			if (argv[2]) {
++				sscanf(argv[2], "%d-%d", &sig, &entry);
++				argv += 2;
++				argc -= 2;
++			} else {
++				usage(progname);
++				exit(1);
++			}
+ 		} else if (strcmp(argv[1], "-o") == 0) {
+ 			file = argv[2];
+ 			argv += 2;
+diff --git a/efi-updatevar.c b/efi-updatevar.c
+index 4247105..5f626be 100644
+--- a/efi-updatevar.c
++++ b/efi-updatevar.c
+@@ -85,7 +85,7 @@ main(int argc, char *argv[])
+ 			attributes |= EFI_VARIABLE_APPEND_WRITE;
+ 			argv += 1;
+ 			argc -= 1;
+-		} if (strcmp(argv[1], "-e") == 0) {
++		} else if (strcmp(argv[1], "-e") == 0) {
+ 			esl_mode = 1;
+ 			argv += 1;
+ 			argc -= 1;
+@@ -98,12 +98,17 @@ main(int argc, char *argv[])
+ 			argv += 2;
+ 			argc -= 2;
+ 		} else if (strcmp(argv[1], "-g") == 0) {
+-			if (str_to_guid(argv[2], &guid)) {
+-				fprintf(stderr, "Invalid GUID %s\n", argv[2]);
++			if (argv[2]) {
++				if (str_to_guid(argv[2], &guid)) {
++					fprintf(stderr, "Invalid GUID %s\n", argv[2]);
++					exit(1);
++				}
++				argv += 2;
++				argc -= 2;
++			} else {
++				usage(progname);
+ 				exit(1);
+ 			}
+-			argv += 2;
+-			argc -= 2;
+ 		} else if (strcmp(argv[1], "-c") == 0) {
+ 			crt_file = argv[2];
+ 			argv += 2;
+@@ -113,9 +118,14 @@ main(int argc, char *argv[])
+ 			argv += 2;
+ 			argc -= 2;
+ 		} else if (strcmp(argv[1], "-d") == 0) {
+-			sscanf(argv[2], "%d-%d", &delsig, &delentry);
+-			argv += 2;
+-			argc -= 2;
++			if (argv[2]) {
++				sscanf(argv[2], "%d-%d", &delsig, &delentry);
++				argv += 2;
++				argc -= 2;
++			} else {
++				usage(progname);
++				exit(1);
++			}
+ 		} else if (strcmp(argv[1], "--engine") == 0) {
+ 			engine = argv[2];
+ 			argv += 2;
+diff --git a/flash-var.c b/flash-var.c
+index aa10ae6..7c31cf1 100644
+--- a/flash-var.c
++++ b/flash-var.c
+@@ -59,13 +59,18 @@ main(int argc, char *argv[])
+ 			help(progname);
+ 			exit(0);
+ 		} else if (strcmp(argv[1], "-g") == 0) {
+-			if (str_to_guid(argv[2], &guid)) {
+-				fprintf(stderr, "Invalid GUID %s\n", argv[2]);
++			if (argv[2]) {
++				if (str_to_guid(argv[2], &guid)) {
++					fprintf(stderr, "Invalid GUID %s\n", argv[2]);
++					exit(1);
++				}
++				owner = &guid;
++				argv += 2;
++				argc -= 2;
++			} else {
++				usage(progname);
+ 				exit(1);
+ 			}
+-			owner = &guid;
+-			argv += 2;
+-			argc -= 2;
+ 		} else if (strcmp("-t", argv[1]) == 0) {
+ 			timestampstr = argv[2];
+ 			argv += 2;
+diff --git a/sign-efi-sig-list.c b/sign-efi-sig-list.c
+index 94bd7d4..147fcfb 100644
+--- a/sign-efi-sig-list.c
++++ b/sign-efi-sig-list.c
+@@ -88,9 +88,14 @@ main(int argc, char *argv[])
+ 			help(progname);
+ 			exit(0);
+ 		} else if (strcmp("-g", argv[1]) == 0) {
+-			str_to_guid(argv[2], &vendor_guid);
+-			argv += 2;
+-			argc -= 2;
++			if (argv[2]) {
++				str_to_guid(argv[2], &vendor_guid);
++				argv += 2;
++				argc -= 2;
++			} else {
++				usage(progname);
++				exit(1);
++			}
+ 		} else if (strcmp("-r", argv[1]) == 0) {
+ 			rsasig = 1;
+ 			argv += 1;
+-- 
+2.25.1
+

--- a/meta-oe/recipes-bsp/efitools/efitools/0016-Make.rules-Pass-CFLAGS-to-Makefile.patch
+++ b/meta-oe/recipes-bsp/efitools/efitools/0016-Make.rules-Pass-CFLAGS-to-Makefile.patch
@@ -1,0 +1,31 @@
+From 39f96d9b98a21618f4a36e5bb8d4bb6c4da6497f Mon Sep 17 00:00:00 2001
+From: Mingli Yu <mingli.yu@windriver.com>
+Date: Thu, 17 Aug 2023 15:11:25 +0800
+Subject: [PATCH] Make.rules: Pass CFLAGS to Makefile
+
+Make sure the right debug directory remapping options are passed to
+the compiler.
+
+Upstream-Status: Pending
+
+Signed-off-by: Mingli Yu <mingli.yu@windriver.com>
+---
+ Make.rules | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Make.rules b/Make.rules
+index 0316ce5..1aa4465 100644
+--- a/Make.rules
++++ b/Make.rules
+@@ -15,7 +15,7 @@ $(error unknown architecture $(ARCH))
+ endif
+ INCDIR	   = -I$(TOPDIR)include/ -I$(INCDIR_PREFIX)/usr/include -I$(INCDIR_PREFIX)/usr/include/efi -I$(INCDIR_PREFIX)/usr/include/efi/$(ARCH) -I$(INCDIR_PREFIX)/usr/include/efi/protocol
+ cppflags   = -DCONFIG_$(ARCH) -D_GNU_SOURCE
+-cflags	   = -O2 -g $(ARCH3264) -fpic -Wall -fshort-wchar -fno-strict-aliasing -fno-merge-constants -fno-stack-protector -ffreestanding -fno-stack-check
++cflags	   = $(CFLAGS) -O2 -g $(ARCH3264) -fpic -Wall -fshort-wchar -fno-strict-aliasing -fno-merge-constants -fno-stack-protector -ffreestanding -fno-stack-check
+ ldflags	   = -nostdlib
+ CRTOBJ		= crt0-efi-$(ARCH).o
+ CRTPATHS	= /lib /lib64 /lib/efi /lib64/efi /usr/lib /usr/lib64 /usr/lib/efi /usr/lib64/efi /usr/lib/gnuefi /usr/lib64/gnuefi
+-- 
+2.25.1
+

--- a/meta-oe/recipes-bsp/efitools/efitools/0017-Make.rules-fix-efi-files-for-gnu-efi-3.0.18.patch
+++ b/meta-oe/recipes-bsp/efitools/efitools/0017-Make.rules-fix-efi-files-for-gnu-efi-3.0.18.patch
@@ -1,0 +1,37 @@
+From 5b60e0d67332354bd873754627c3994ce1bf26bb Mon Sep 17 00:00:00 2001
+From: Yi Zhao <yi.zhao@windriver.com>
+Date: Thu, 6 Jun 2024 22:16:52 +0800
+Subject: [PATCH] Make.rules: fix efi files for gnu-efi 3.0.18
+
+With commit [1] and [2] in gnu-efi 3.0.18, For efi files, the .dynsym
+section was dropped and the .rodata section was splitted out from lds
+files. These changes make LockDown.efi no longer work. Referring to
+gnu-efi 3.0.18, copy .rodata section and remove .dynsym section to efi
+files.
+
+[1] https://sourceforge.net/p/gnu-efi/code/ci/1be024100e80885cfbc840e322673cb850b57316
+[2] https://sourceforge.net/p/gnu-efi/code/ci/b3e80c38bcab002bef2b9e66b7037fbb1980e173
+
+Upstream-Status: Pending
+
+Signed-off-by: Yi Zhao <yi.zhao@windriver.com>
+---
+ Make.rules | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Make.rules b/Make.rules
+index 90f444a..2c08e48 100644
+--- a/Make.rules
++++ b/Make.rules
+@@ -65,7 +65,7 @@ ifeq ($(ARCH),aarch64)
+ endif
+ 
+ %.efi: %.so
+-	$(OBJCOPY) -j .text -j .sdata -j .data -j .dynamic -j .dynsym \
++	$(OBJCOPY) -j .text -j .sdata -j .data -j .dynamic -j .rodata \
+ 		   -j .rel -j .rela -j .rel.* -j .rela.* -j .rel* -j .rela* \
+ 		   -j .reloc $(FORMAT) $*.so $@
+ %.so: %.o
+-- 
+2.25.1
+

--- a/meta-oe/recipes-bsp/efitools/efitools_1.9.2.bb
+++ b/meta-oe/recipes-bsp/efitools/efitools_1.9.2.bb
@@ -1,0 +1,79 @@
+require efitools.inc
+
+# The generated native binaries are used during target build
+DEPENDS += "efitools-native gnu-efi openssl"
+
+inherit user-key-store deploy
+
+EXTRA_OEMAKE:append = " \
+    INCDIR_PREFIX='${STAGING_DIR_TARGET}' \
+    CRTPATH_PREFIX='${STAGING_DIR_TARGET}' \
+    SIGN_EFI_SIG_LIST='${STAGING_BINDIR_NATIVE}/sign-efi-sig-list' \
+    CERT_TO_EFI_SIG_LIST='${STAGING_BINDIR_NATIVE}/cert-to-efi-sig-list' \
+    CERT_TO_EFI_HASH_LIST='${STAGING_BINDIR_NATIVE}/cert-to-efi-hash-list' \
+    HASH_TO_EFI_SIG_LIST='${STAGING_BINDIR_NATIVE}/hash-to-efi-sig-list' \
+    MYGUID='${UEFI_SIG_OWNER_GUID}' \
+"
+
+python do_prepare_signing_keys() {
+    if d.expand('${UEFI_SB}') != '1':
+        return
+
+    # Prepare PK, KEK and DB for LockDown.efi.
+    if uks_signing_model(d) in ('sample', 'user'):
+        dir = uefi_sb_keys_dir(d)
+    else:
+        dir = d.expand('${SAMPLE_UEFI_SB_KEYS_DIR}/')
+
+    import shutil
+
+    for _ in ('PK', 'KEK', 'DB'):
+        shutil.copyfile(dir + _ + '.crt', d.expand('${S}/') + _ + '.crt')
+        shutil.copyfile(dir + _ + '.key', d.expand('${S}/') + _ + '.key')
+
+    # Make sure LockDown.efi contains the DB and KEK from Microsoft.
+    if "${@bb.utils.contains('DISTRO_FEATURES', 'msft', '1', '0', d)}" == '1':
+        shutil.copyfile(d.expand('${MSFT_DB_CERT}'), d.expand('${S}/DB.crt'))
+        shutil.copyfile(d.expand('${MSFT_KEK_CERT}'), d.expand('${S}/KEK.crt'))
+
+    path = create_uefi_dbx(d)
+    if path:
+        with open(d.expand('${S}/DBX.crt'), 'w') as f:
+            pass
+
+        shutil.copyfile(path, d.expand('${S}/DBX.esl'))
+
+        # Cheat the Makefile to avoid running this rule:
+        # %.esl: %.crt cert-to-efi-sig-list
+        #        $(CERT_TO_EFI_SIG_LIST) -g $(MYGUID) $< $@
+        import time, os
+        tm = time.strptime('2038-01-01 00:00:00', \
+                           '%Y-%m-%d %H:%M:%S')
+        time_stamp = time.mktime(tm)
+        os.utime(d.expand('${S}/DBX.esl'), (time_stamp, time_stamp))
+}
+addtask prepare_signing_keys after do_configure before do_compile
+do_prepare_signing_keys[prefuncs] += "check_deploy_keys"
+
+do_install:append() {
+    if [ x"${UEFI_SB}" = x"1" ]; then
+        install -d ${D}${EFI_BOOT_PATH}
+        install -m 0755 ${D}${datadir}/efitools/efi/LockDown.efi ${D}${EFI_BOOT_PATH}
+    fi
+}
+
+do_deploy() {
+    install -d ${DEPLOYDIR}
+
+    if [ -e ${D}${EFI_BOOT_PATH}/LockDown.efi ] ; then
+        install -m 0600 ${D}${EFI_BOOT_PATH}/LockDown.efi "${DEPLOYDIR}"
+    fi
+    if [ -e ${D}${EFI_BOOT_PATH}/LockDown.efi.sig ] ; then
+        install -m 0600 ${D}${EFI_BOOT_PATH}/LockDown.efi.sig "${DEPLOYDIR}"
+    fi
+}
+addtask deploy after do_install before do_build
+
+RDEPENDS:${PN} = " \
+    parted mtools coreutils util-linux openssl libcrypto \
+"

--- a/meta-oe/recipes-devtools/sbsigntool/sbsigntool/0001-configure-Dont-t-check-for-gnu-efi.patch
+++ b/meta-oe/recipes-devtools/sbsigntool/sbsigntool/0001-configure-Dont-t-check-for-gnu-efi.patch
@@ -1,0 +1,54 @@
+From c946d67ec9c4c8f7f078afc7d4f352ba3e288213 Mon Sep 17 00:00:00 2001
+From: Ilias Apalodimas <ilias.apalodimas@linaro.org>
+Date: Wed, 10 Mar 2021 15:51:49 +0200
+Subject: [PATCH] configure: Dont't check for gnu-efi
+
+The configure.ac is searching the gnu-efi libs in hardcoded paths making
+the configure fail.
+We explictly include the paths in our .bb recipe, so let's get rid of
+the check
+
+Upstream-Status: Inappropriate [embedded specific]
+
+Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
+---
+ configure.ac | 15 +++++++--------
+ 1 file changed, 7 insertions(+), 8 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 8a5340a..f6536da 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -17,9 +17,9 @@ AC_PROG_MKDIR_P
+ AC_CHECK_TOOL(OBJCOPY, [objcopy])
+ AC_CHECK_TOOL(STRIP, [strip])
+ 
+- AC_CHECK_HEADER([bfd.h], [],
+-  AC_MSG_ERROR([bfd.h not found.]
+-[bfd.h is usually distributed in a binutils development package.]))
++ #AC_CHECK_HEADER([bfd.h], [],
++  #AC_MSG_ERROR([bfd.h not found.]
++#[bfd.h is usually distributed in a binutils development package.]))
+ 
+ if test $cross_compiling = no; then
+   AM_MISSING_PROG(HELP2MAN, help2man)
+@@ -78,12 +78,11 @@ for path in /lib /lib64 /usr/lib /usr/lib64 /usr/lib32 /lib/efi /lib64/efi /usr/
+        CRTPATH=$path
+     fi
+ done
+-if test -z "$CRTPATH"; then
+-   AC_MSG_ERROR([cannot find the gnu-efi crt path])
+-fi
++#if test -z "$CRTPATH"; then
++   #AC_MSG_ERROR([cannot find the gnu-efi crt path])
++#fi
+ 
+-EFI_CPPFLAGS="-I/usr/include/efi -I/usr/include/efi/$EFI_ARCH \
+- -DEFI_FUNCTION_WRAPPER"
++EFI_CPPFLAGS="-DEFI_FUNCTION_WRAPPER"
+ CPPFLAGS_save="$CPPFLAGS"
+ CPPFLAGS="$CPPFLAGS $EFI_CPPFLAGS"
+ AC_CHECK_HEADERS([efi.h], [], [], $EFI_INCLUDES)
+-- 
+2.25.1
+

--- a/meta-oe/recipes-devtools/sbsigntool/sbsigntool/0002-docs-Don-t-build-man-pages.patch
+++ b/meta-oe/recipes-devtools/sbsigntool/sbsigntool/0002-docs-Don-t-build-man-pages.patch
@@ -1,0 +1,31 @@
+From 27abd536c0e2f2ee0b4fa373e636076e58ed4510 Mon Sep 17 00:00:00 2001
+From: Ilias Apalodimas <ilias.apalodimas@linaro.org>
+Date: Wed, 10 Mar 2021 15:52:52 +0200
+Subject: [PATCH] docs: Don't build man pages
+
+Man pages not needed on embedded targets
+
+Upstream-Status: Inappropriate [embedded specific]
+
+Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
+---
+ docs/Makefile.am | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/docs/Makefile.am b/docs/Makefile.am
+index 89ed110..6918dd8 100644
+--- a/docs/Makefile.am
++++ b/docs/Makefile.am
+@@ -1,9 +1,4 @@
+ 
+-man1_MANS = sbsign.1 sbverify.1 sbattach.1 sbvarsign.1 sbsiglist.1 \
+-		sbkeysync.1
+-
+-EXTRA_DIST = sbsign.1.in sbverify.1.in sbattach.1.in \
+-		sbvarsign.1.in sbsiglist.1.in sbkeysync.1.in
+ CLEANFILES = $(man1_MANS)
+ 
+ $(builddir)/%.1: $(srcdir)/%.1.in $(top_builddir)/src/%
+-- 
+2.25.1
+

--- a/meta-oe/recipes-devtools/sbsigntool/sbsigntool/0003-sbsign-add-x-option-to-avoid-overwrite-existing-sign.patch
+++ b/meta-oe/recipes-devtools/sbsigntool/sbsigntool/0003-sbsign-add-x-option-to-avoid-overwrite-existing-sign.patch
@@ -1,0 +1,76 @@
+From 0c9efb490040b376abad5f51773680000beac28d Mon Sep 17 00:00:00 2001
+From: Ilias Apalodimas <ilias.apalodimas@linaro.org>
+Date: Wed, 10 Mar 2021 15:53:21 +0200
+Subject: [PATCH] sbsign: add -x option to avoid overwrite existing signature
+
+Upstream-Status: Inappropriate [embedded specific]
+
+Signed-off-by: Lans Zhang <jia.zhang@windriver.com>
+Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
+---
+ src/sbsign.c | 17 +++++++++++++++--
+ 1 file changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/src/sbsign.c b/src/sbsign.c
+index 898fe66..3a5ed32 100644
+--- a/src/sbsign.c
++++ b/src/sbsign.c
+@@ -69,6 +69,7 @@ struct sign_context {
+ };
+ 
+ static struct option options[] = {
++	{ "noresign", no_argument, NULL, 'x' },
+ 	{ "output", required_argument, NULL, 'o' },
+ 	{ "cert", required_argument, NULL, 'c' },
+ 	{ "key", required_argument, NULL, 'k' },
+@@ -94,6 +95,7 @@ static void usage(void)
+ 		"\t--addcert <addcertfile> additional intermediate certificates in a file\n"
+ 		"\t--detached         write a detached signature, instead of\n"
+ 		"\t                    a signed binary\n"
++		"\t--noresign         don't re-sign the binary if signed\n"
+ 		"\t--output <file>    write signed data to <file>\n"
+ 		"\t                    (default <efi-boot-image>.signed,\n"
+ 		"\t                    or <efi-boot-image>.pk7 for detached\n"
+@@ -155,7 +157,7 @@ int main(int argc, char **argv)
+ 	const char *keyfilename, *certfilename, *addcertfilename, *engine;
+ 	struct sign_context *ctx;
+ 	uint8_t *buf, *tmp;
+-	int rc, c, sigsize;
++	int rc, c, sigsize, no_resign = 0;
+ 	EVP_PKEY *pkey;
+ 
+ 	ctx = talloc_zero(NULL, struct sign_context);
+@@ -167,11 +169,14 @@ int main(int argc, char **argv)
+ 
+ 	for (;;) {
+ 		int idx;
+-		c = getopt_long(argc, argv, "o:c:k:dvVhe:a:", options, &idx);
++		c = getopt_long(argc, argv, "xo:c:k:dvVhe:a:", options, &idx);
+ 		if (c == -1)
+ 			break;
+ 
+ 		switch (c) {
++		case 'x':
++			no_resign = 1;
++			break;
+ 		case 'o':
+ 			ctx->outfilename = talloc_strdup(ctx, optarg);
+ 			break;
+@@ -228,6 +233,14 @@ int main(int argc, char **argv)
+ 	if (!ctx->image)
+ 		return EXIT_FAILURE;
+ 
++	if (ctx->image->cert_table) {
++		if (no_resign) {
++			fprintf(stderr,
++				"Don't overwrite existing signature\n");
++			return EXIT_SUCCESS;
++		}
++	}
++
+ 	talloc_steal(ctx, ctx->image);
+ 
+ 	ERR_load_crypto_strings();
+-- 
+2.25.1
+

--- a/meta-oe/recipes-devtools/sbsigntool/sbsigntool/0004-src-Makefile.am-Add-read_write_all.c-to-common_SOURC.patch
+++ b/meta-oe/recipes-devtools/sbsigntool/sbsigntool/0004-src-Makefile.am-Add-read_write_all.c-to-common_SOURC.patch
@@ -1,0 +1,33 @@
+From 98365ce5ecf835841344bf1b6ec34f00223a4ca5 Mon Sep 17 00:00:00 2001
+From: Robert Yang <liezhi.yang@windriver.com>
+Date: Thu, 17 Jun 2021 08:05:25 +0000
+Subject: [PATCH] src/Makefile.am: Add read_write_all.c to common_SOURCES
+
+It is required by image.c.
+
+Fixed:
+src/image.c:659: undefined reference to `write_all'
+
+Upstream-Status: Pending
+
+Signed-off-by: Robert Yang <liezhi.yang@windriver.com>
+---
+ src/Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 38f93ff..b32befc 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -9,7 +9,7 @@ AM_CFLAGS += -DOPENSSL_API_COMPAT=0x10100000L
+ endif
+ 
+ common_SOURCES = idc.c idc.h image.c image.h fileio.c fileio.h \
+-	efivars.h $(coff_headers)
++	../lib/ccan.git/ccan/read_write_all/read_write_all.c efivars.h $(coff_headers)
+ common_LDADD = ../lib/ccan/libccan.a $(libcrypto_LIBS)
+ common_CFLAGS = -I$(top_srcdir)/lib/ccan/ -Werror
+ 
+-- 
+2.25.1
+

--- a/meta-oe/recipes-devtools/sbsigntool/sbsigntool/0005-fileio.c-initialize-local-variables-before-use-in-fu.patch
+++ b/meta-oe/recipes-devtools/sbsigntool/sbsigntool/0005-fileio.c-initialize-local-variables-before-use-in-fu.patch
@@ -1,0 +1,43 @@
+From 71aeaa6df86ed3b53b0a1e91125630706a15be26 Mon Sep 17 00:00:00 2001
+From: Yi Zhao <yi.zhao@windriver.com>
+Date: Tue, 22 Jun 2021 11:20:17 +0800
+Subject: [PATCH] fileio.c: initialize local variables before use in function
+ __fileio_read_file
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixes:
+fileio.c: In function ‘__fileio_read_file’:
+fileio.c:179:26: error: ‘len’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
+  179 |                 *out_len = len;
+      |                 ~~~~~~~~~^~~~~
+fileio.c:178:26: error: ‘buf’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
+  178 |                 *out_buf = buf;
+      |                 ~~~~~~~~~^~~~~
+
+Upstream-Status: Pending
+
+Signed-off-by: Yi Zhao <yi.zhao@windriver.com>
+---
+ src/fileio.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/fileio.c b/src/fileio.c
+index 032eb1e..929bb00 100644
+--- a/src/fileio.c
++++ b/src/fileio.c
+@@ -142,8 +142,8 @@ static int __fileio_read_file(void *ctx, const char *filename,
+ 		 uint8_t **out_buf, size_t *out_len, int flags)
+ {
+ 	struct stat statbuf;
+-	uint8_t *buf;
+-	size_t len;
++	uint8_t *buf = NULL;
++	size_t len = 0;
+ 	int fd, rc;
+ 
+ 	rc = -1;
+-- 
+2.25.1
+

--- a/meta-oe/recipes-devtools/sbsigntool/sbsigntool/0006-Makefile.am-do-not-use-Werror.patch
+++ b/meta-oe/recipes-devtools/sbsigntool/sbsigntool/0006-Makefile.am-do-not-use-Werror.patch
@@ -1,0 +1,31 @@
+From 8c8fc325b3146e2e6032821460690f61703daf22 Mon Sep 17 00:00:00 2001
+From: Yi Zhao <yi.zhao@windriver.com>
+Date: Wed, 20 Oct 2021 15:31:05 +0800
+Subject: [PATCH] Makefile.am: do not use -Werror
+
+Do not use -Werror to disable openssl 3.0 deprecation warnings turning
+into errors.
+
+Upstream-Status: Pending
+
+Signed-off-by: Yi Zhao <yi.zhao@windriver.com>
+---
+ src/Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Makefile.am b/src/Makefile.am
+index b32befc..16fbfe7 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -11,7 +11,7 @@ endif
+ common_SOURCES = idc.c idc.h image.c image.h fileio.c fileio.h \
+ 	../lib/ccan.git/ccan/read_write_all/read_write_all.c efivars.h $(coff_headers)
+ common_LDADD = ../lib/ccan/libccan.a $(libcrypto_LIBS)
+-common_CFLAGS = -I$(top_srcdir)/lib/ccan/ -Werror
++common_CFLAGS = -I$(top_srcdir)/lib/ccan/
+ 
+ sbsign_SOURCES = sbsign.c $(common_SOURCES)
+ sbsign_LDADD = $(common_LDADD)
+-- 
+2.25.1
+

--- a/meta-oe/recipes-devtools/sbsigntool/sbsigntool/0007-create-ccan-tree-use-native-tools.patch
+++ b/meta-oe/recipes-devtools/sbsigntool/sbsigntool/0007-create-ccan-tree-use-native-tools.patch
@@ -1,0 +1,46 @@
+From ff049c6ceb557efbaed3c4b209872d851c620f4a Mon Sep 17 00:00:00 2001
+From: Guillaume Champagne <champagne.guillaume.c@gmail.com>
+Date: Mon, 20 Feb 2023 13:48:18 -0500
+Subject: [PATCH] tools: create-ccan-tree: use native tools built by yocto
+
+If tools are built during the target build the compilation flags may be
+incompatible with the host. Thus, assume yocto pre-built the necessary
+binaries and use them as is.
+
+Upstream-Status: Inappropriate [embedded specific]
+---
+ tools/create-ccan-tree | 18 ++++++------------
+ 1 file changed, 6 insertions(+), 12 deletions(-)
+
+diff --git a/tools/create-ccan-tree b/tools/create-ccan-tree
+index 64fc36e7..46f86a81 100755
+--- a/lib/ccan.git/tools/create-ccan-tree
++++ b/lib/ccan.git/tools/create-ccan-tree
+@@ -82,18 +82,12 @@ tmpdir="$(mktemp -d)"
+ # sanity check, we don't want to be overwriting stuff in arbitrary dirs
+ [ $? -eq 0 -a -d "${tmpdir}" ] || exit 1
+ 
+-# We'll need the ccan_depends tool, but also a clean source tree. Build
+-# tools/ccan_depends, and store it in $tmpdir for later use
+-
+-echo "Building ccan_depends"
+-ccan_depends="$tmpdir/ccan_depends"
+-make -s -C "$srcdir" tools/ccan_depends
+-[ $? -eq 0 ] || exit 1
+-cp "$srcdir/tools/ccan_depends" "$ccan_depends"
+-
+-echo "Cleaning source tree"
+-make -s -C "$srcdir" clean
+-[ $? -eq 0 ] || exit 1
++# We assume ccan_depends was pre-built by yocto
++if [ ! -e ${srcdir}/tools/ccan_depends ]
++then
++	echo "tools/ccan_depends not built" >&2
++	exit 1
++fi
+ 
+ # clean up on error
+ trap 'rm -rf $tmpdir' EXIT
+-- 
+2.30.2
+

--- a/meta-oe/recipes-devtools/sbsigntool/sbsigntool_0.9.5.bb
+++ b/meta-oe/recipes-devtools/sbsigntool/sbsigntool_0.9.5.bb
@@ -1,0 +1,100 @@
+SUMMARY = "Utilities for signing UEFI binaries for use with secure boot"
+
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "\
+    file://LICENSE.GPLv3;md5=9eef91148a9b14ec7f9df333daebc746 \
+    file://COPYING;md5=a7710ac18adec371b84a9594ed04fd20 \
+"
+
+DEPENDS = "binutils openssl gnu-efi util-linux-libuuid sbsigntool-native"
+
+SRC_URI = " \
+    git://git.kernel.org/pub/scm/linux/kernel/git/jejb/sbsigntools.git;protocol=https;name=sbsigntools;branch=master \
+    git://github.com/rustyrussell/ccan.git;protocol=https;destsuffix=git/lib/ccan.git;name=ccan;branch=master \
+    file://0001-configure-Dont-t-check-for-gnu-efi.patch \
+    file://0002-docs-Don-t-build-man-pages.patch \
+    file://0003-sbsign-add-x-option-to-avoid-overwrite-existing-sign.patch  \
+    file://0004-src-Makefile.am-Add-read_write_all.c-to-common_SOURC.patch \
+    file://0005-fileio.c-initialize-local-variables-before-use-in-fu.patch \
+    file://0006-Makefile.am-do-not-use-Werror.patch \
+"
+
+SRC_URI:append:class-target = "\
+    file://0007-create-ccan-tree-use-native-tools.patch \
+"
+
+SRCREV_sbsigntools  ?= "9cfca9fe7aa7a8e29b92fe33ce8433e212c9a8ba"
+SRCREV_ccan         ?= "b1f28e17227f2320d07fe052a8a48942fe17caa5"
+SRCREV_FORMAT       =  "sbsigntools_ccan"
+
+S = "${WORKDIR}/git"
+
+COMPATIBLE_HOST = "(x86_64.*|i.86.*|aarch64.*|arm.*|riscv64.*)-linux"
+COMPATIBLE_HOST:armv4 = 'null'
+
+inherit autotools-brokensep pkgconfig
+
+def efi_arch(d):
+    import re
+    arch = d.getVar("TARGET_ARCH")
+    if re.match("i[3456789]86", arch):
+        return "ia32"
+    return arch
+
+HOST_EXTRACFLAGS += "\
+    INCLUDES+='-I${S}/lib/ccan.git/ \
+              -I${STAGING_INCDIR_NATIVE}/efi \
+              -I${STAGING_INCDIR_NATIVE} \
+"
+
+EXTRA_OEMAKE += "\
+    INCLUDES='-I${S}/lib/ccan.git' \
+    EFI_CPPFLAGS='-I${STAGING_INCDIR} -I${STAGING_INCDIR}/efi \
+                  -I${STAGING_INCDIR}/efi/${@efi_arch(d)}' \
+"
+
+configure_hook() {
+    if [ ! -e lib/ccan ]; then
+
+        # Use empty SCOREDIR because 'make scores' is not run.
+        # The default setting depends on (non-whitelisted) host tools.
+        sed -i -e 's#^\(SCOREDIR=\).*#\1#' lib/ccan.git/Makefile
+
+        TMPDIR=lib lib/ccan.git/tools/create-ccan-tree \
+            --build-type=automake lib/ccan \
+            talloc read_write_all build_assert array_size endian
+    fi
+
+    # Create generatable docs from git
+    (
+    echo "Authors of sbsigntool:"
+    echo
+    git log --format='%an' | sort -u | sed 's,^,\t,'
+    ) > AUTHORS
+
+    # Generate simple ChangeLog
+    git log --date=short --format='%ad %t %an <%ae>%n%n  * %s%n' > ChangeLog
+}
+
+do_configure:prepend:class-target() {
+    cd ${S}
+    cp ${STAGING_DIR_NATIVE}/${bindir_native}/ccan_depends ${S}/lib/ccan.git/tools/ccan_depends
+    configure_hook
+    cd ${B}
+}
+
+do_configure:prepend:class-native() {
+    cd ${S}
+    configure_hook
+    cd ${B}
+}
+
+do_compile:append:class-native() {
+    make -C ${S}/lib/ccan.git tools/ccan_depends
+}
+
+do_install:append:class-native() {
+    install -D ${S}/lib/ccan.git/tools/ccan_depends ${D}/${bindir}/ccan_depends
+}
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
`efitools` is coming from meta-secure-code. There are many cases where meta-secure-code is added just to use `efitools`, like https://github.com/Wind-River/meta-secure-core/pull/76

`efitools` has a dependency on `sbsigntool`.