### PR TITLE
nng: Rename default branch of github.com:nanomsg/nng.git

### DIFF
--- a/meta-networking/recipes-connectivity/nanomsg/nng_1.7.3.bb
+++ b/meta-networking/recipes-connectivity/nanomsg/nng_1.7.3.bb
@@ -5,7 +5,7 @@ SECTION = "libs/networking"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=a41e579bb4326c21c774f8e51e41d8a3"
 
-SRC_URI = "git://github.com/nanomsg/nng.git;branch=master;protocol=https"
+SRC_URI = "git://github.com/nanomsg/nng.git;branch=main;protocol=https"
 SRCREV = "85fbe7f9e4642b554d0d97f2e3ff2aa12978691a"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Default branch is renamed from `master` to `main`.

Commit shas are the same.

Commit [85fbe7f9e4642b554d0d97f2e3ff2aa12978691a](https://github.com/nanomsg/nng/commit/85fbe7f9e4642b554d0d97f2e3ff2aa12978691a) still is available.

cc @kraj