### PR TITLE
ipmitool: srcrev bump ab5ce5baff..bf774149ae

### DIFF
--- a/meta-oe/recipes-kernel/ipmitool/ipmitool_1.8.19.bb
+++ b/meta-oe/recipes-kernel/ipmitool/ipmitool_1.8.19.bb
@@ -21,7 +21,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=9aa91e13d644326bf281924212862184"
 
 DEPENDS = "openssl readline ncurses"
-SRCREV = "ab5ce5baff097ebb6e2a17a171858be213ee68d3"
+SRCREV = "bf774149ae7f74c12164a5b021b23520c5ca4016" 
 SRC_URI = "git://codeberg.org/ipmitool/ipmitool;protocol=https;branch=master \
            ${IANA_ENTERPRISE_NUMBERS} \
            file://0001-csv-revision-Drop-the-git-revision-info.patch \


### PR DESCRIPTION
Added version bump to fix the ipmitool build issue.

Build failure details available as part of this commit. https://codeberg.org/IPMITool/ipmitool/commit/bf774149ae7f74c12164a5b021b23520c5ca4016

Additional commit included in this version bump are below.

Alexander Amelkin (1):
      man: Remove duplicate description for -b and -B

Alexander Filippov (3):
      Remove trailing spaces
      replace HAS_PRAGMA_PACK macros
      imb: refix structure packing

Howitzer105mm (4):
      Establish a uniform structure packing syntax
      ipmievd: Eliminate a possible command line overrun (#27)
      open: Eliminate buffer overrun (#24)
      lan: Clean compile time warning from LAN authentication (#22)

István Donkó (1):
      doc: fix a small typo in `print_user_usage`

Johnathan Mantey (1):
      fru: Fix a typo causing compilation to fail (#37)

Miao Wang (1):
      lan: fix lan print fails on unsupported parameters

bbradley (1):
      chassis:  Partial revert of 6e037d6bfbb (#19)