### PR TITLE
libcanberra: Fix sound not playing on Colibri iMX8X

### DIFF
--- a/meta-oe/recipes-support/libcanberra/files/0001-Determine-audio-buffer-size-for-a-time-of-500ms.patch
+++ b/meta-oe/recipes-support/libcanberra/files/0001-Determine-audio-buffer-size-for-a-time-of-500ms.patch
@@ -1,0 +1,40 @@
+From 86488a7fc209ac08dd92c9d50a77e3330e7aedd9 Mon Sep 17 00:00:00 2001
+From: Patrick Zacharias <1475802+Fighter19@users.noreply.github.com>
+Date: Thu, 7 Nov 2024 14:03:29 +0100
+Subject: [PATCH] Determine audio buffer size for a time of 500ms
+
+On some hardware like the SGTL5000, not specifying a buffer size
+results to EINVAL being returned.
+
+This code sets the buffer time to 500ms and the period time to a fourth of that,
+or whatever is nearest to that.
+---
+ src/alsa.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/src/alsa.c b/src/alsa.c
+index bebcc4a..ac26578 100644
+--- a/src/alsa.c
++++ b/src/alsa.c
+@@ -258,6 +258,21 @@ static int open_alsa(ca_context *c, struct outstanding *out) {
+         if ((ret = snd_pcm_hw_params_set_channels(out->pcm, hwparams, ca_sound_file_get_nchannels(out->file))) < 0)
+                 goto finish;
+ 
++        unsigned int buffer_time = 0;
++        if ((ret = snd_pcm_hw_params_get_buffer_time_max(hwparams, &buffer_time, 0)) < 0)
++                goto finish;
++
++        // Cap the buffer time to 500ms
++        if (buffer_time > 500000)
++                buffer_time = 500000;
++
++        unsigned int period_time = buffer_time / 4;
++        if ((ret = snd_pcm_hw_params_set_period_time_near(out->pcm, hwparams, &period_time, 0)) < 0)
++                goto finish;
++
++        if ((ret = snd_pcm_hw_params_set_buffer_time_near(out->pcm, hwparams, &buffer_time, 0)) < 0)
++                goto finish;
++
+         if ((ret = snd_pcm_hw_params(out->pcm, hwparams)) < 0)
+                 goto finish;
+ 

--- a/meta-oe/recipes-support/libcanberra/libcanberra_0.30.bb
+++ b/meta-oe/recipes-support/libcanberra/libcanberra_0.30.bb
@@ -13,6 +13,7 @@ SRC_URI = " \
     file://0001-build-gtk-and-gtk3-version-for-canberra_gtk_play.patch \
     file://0001-gtk-Don-t-assume-all-GdkDisplays-are-GdkX11Displays-.patch \
     file://0001-remove-dropped-templates.patch \
+    file://0001-Determine-audio-buffer-size-for-a-time-of-500ms.patch \
 "
 SRC_URI[md5sum] = "34cb7e4430afaf6f447c4ebdb9b42072"
 SRC_URI[sha256sum] = "c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72"


### PR DESCRIPTION
Canberra does not specify a buffer size, which leads to ALSA rejecting the settings. By specfiying a buffer time of 500ms and a period time with a fourth of that, an appropriate buffer size should be able to be calculated for all setups.