### PR TITLE
sysprof: Upgrade to 47.1

### DIFF
--- a/meta-gnome/recipes-gnome/libdex/libdex_0.8.1.bb
+++ b/meta-gnome/recipes-gnome/libdex/libdex_0.8.1.bb
@@ -1,0 +1,16 @@
+LICENSE = "LGPL-2.1-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
+
+GNOMEBASEBUILDCLASS = "meson"
+inherit gnomebase upstream-version-is-even gobject-introspection
+
+DEPENDS += " \
+    glib-2.0 \
+"
+
+SRC_URI[archive.sha256sum] = "955475ad3e43aabd6f6f70435264b5ee77bd265bd95545211fee026b08d378a0"
+
+PACKAGECONFIG ?= ""
+EXTRA_OEMESON += "-Dintrospection=enabled -Dvapi=false"
+
+REQUIRED_DISTRO_FEATURES = "gobject-introspection-data"

--- a/meta-gnome/recipes-gnome/libpanel/libpanel_1.8.1.bb
+++ b/meta-gnome/recipes-gnome/libpanel/libpanel_1.8.1.bb
@@ -1,0 +1,22 @@
+# your responsibility to verify that the values are complete and correct.
+LICENSE = "LGPL-2.1-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=3000208d539ec061b899bce1d9ce9404"
+
+GNOMEBASEBUILDCLASS = "meson"
+inherit gnomebase upstream-version-is-even gobject-introspection gtk-icon-cache
+
+DEPENDS += " \
+    glib-2.0 \
+    gtk4 \
+    libadwaita \
+"
+
+SRC_URI[archive.sha256sum] = "b87b8fa9b79768cc704243793f0158a040a1e46d37b9889188545a7f7dcaa6fb"
+
+PACKAGECONFIG ?= ""
+#EXTRA_OEMESON += "-Ddocs=disabled"
+#GTKDOC_MESON_DISABLE_FLAG = "disabled"
+
+EXTRA_OEMESON += "-Ddocs=disabled  -Dintrospection=enabled -Dvapi=false"
+
+REQUIRED_DISTRO_FEATURES = "gobject-introspection-data"

--- a/meta-gnome/recipes-gnome/sysprof/sysprof/0001-meson-Check-for-libunwind-instead-of-libunwind-gener.patch
+++ b/meta-gnome/recipes-gnome/sysprof/sysprof/0001-meson-Check-for-libunwind-instead-of-libunwind-gener.patch
@@ -1,30 +1,32 @@
-From 19188367bee87b0084ab34869455155da5cb1731 Mon Sep 17 00:00:00 2001
-From: Khem Raj <raj.khem@gmail.com>
-Date: Wed, 13 Apr 2022 08:47:39 -0700
+From 779bbfebcd414a2cb4ab73ff1c4eb987cfdab456 Mon Sep 17 00:00:00 2001
+From: Pablo Saavedra <psaavedra@igalia.com>
+Date: Mon, 11 Nov 2024 13:05:15 +0100
 Subject: [PATCH] meson: Check for libunwind instead of libunwind-generic
 
 This helps it to use llvm unwinder since libunwind-generic is specific
 to nongnu libunwind.
 
 Upstream-Status: Submitted [https://gitlab.gnome.org/GNOME/sysprof/-/merge_requests/95]
+
+Original-by: Khem Raj <raj.khem@gmail.com>
+Modified-by: Pablo Saavedra <psaavedra@igalia.com>
+
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Pablo Saavedra <psaavedra@igalia.com>
 ---
  meson.build | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/meson.build b/meson.build
-index 3d3d8b5..4a1963d 100644
+index 96c1d09..86b9df4 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -96,7 +96,7 @@ config_h.set10('HAVE_POLKIT', polkit_dep.found())
- if get_option('libunwind')
-   # Force libunwind usage if it's specified to avoid back compiles
-   # and backtrace() showing up in builds
+@@ -107,7 +107,7 @@ polkit_dep = dependency('polkit-gobject-1', version: polkit_req_version, require
+ config_h.set10('HAVE_POLKIT', polkit_dep.found())
+ 
+ if need_libsysprof
 -  libunwind_dep = dependency('libunwind-generic', required: true)
 +  libunwind_dep = dependency('libunwind', required: true)
    config_h.set('ENABLE_LIBUNWIND', libunwind_dep.found())
-   config_h.set('HAVE_UNW_SET_CACHE_SIZE', libunwind_dep.found() and cc.has_header_symbol('libunwind.h', 'unw_set_cache_size', dependencies: [libunwind_dep]))
- endif
--- 
-2.35.2
-
+   config_h.set('HAVE_UNW_SET_CACHE_SIZE',
+                cc.has_header_symbol('libunwind.h',

--- a/meta-gnome/recipes-gnome/sysprof/sysprof/0002-meson-Do-not-invoke-the-commands-to-update-the-icon-.patch
+++ b/meta-gnome/recipes-gnome/sysprof/sysprof/0002-meson-Do-not-invoke-the-commands-to-update-the-icon-.patch
@@ -1,4 +1,4 @@
-From 9ad120283f4b61b97da67f18a95bb3b4f1e8a3b9 Mon Sep 17 00:00:00 2001
+From cc0c0b518d46bf82ad34eeea8d40496c9ad971dd Mon Sep 17 00:00:00 2001
 From: Carlos Alberto Lopez Perez <clopez@igalia.com>
 Date: Wed, 24 Jul 2024 15:51:05 +0100
 Subject: [PATCH] meson: Do not invoke the commands to update the icon caches
@@ -15,10 +15,10 @@ Signed-off-by: Carlos Alberto Lopez Perez <clopez@igalia.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/meson.build b/meson.build
-index 3d3d8b5..da622f1 100644
+index 86b9df4..fe75ef9 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -250,7 +250,7 @@ configure_file(
+@@ -269,7 +269,7 @@ configure_file(
    configuration: config_h
  )
  
@@ -27,6 +27,3 @@ index 3d3d8b5..da622f1 100644
    gnome.post_install(
        gtk_update_icon_cache: true,
      update_desktop_database: true
--- 
-2.39.2
-

--- a/meta-gnome/recipes-gnome/sysprof/sysprof/0003-libsysprof-Check-for-unw_set_caching_policy-before-u.patch
+++ b/meta-gnome/recipes-gnome/sysprof/sysprof/0003-libsysprof-Check-for-unw_set_caching_policy-before-u.patch
@@ -1,4 +1,4 @@
-From a3316e607db2a64e030df8551455c5700b5ddfcf Mon Sep 17 00:00:00 2001
+From 68425b541e88f9f03a418cfda052b46b2a185e4e Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Thu, 25 Jul 2024 20:18:17 -0700
 Subject: [PATCH] libsysprof: Check for unw_set_caching_policy before using
@@ -6,22 +6,27 @@ Subject: [PATCH] libsysprof: Check for unw_set_caching_policy before using
 llvm libunwind does not implement unw_cache_* functions yet
 
 Upstream-Status: Submitted [https://gitlab.gnome.org/GNOME/sysprof/-/merge_requests/95]
+
+Original-by: Khem Raj <raj.khem@gmail.com>
+Modified-by: Pablo Saavedra <psaavedra@igalia.com>
+
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Pablo Saavedra <psaavedra@igalia.com>
 ---
- src/libsysprof/preload/backtrace-helper.h | 2 ++
+ src/preload/backtrace-helper.h | 2 ++
  1 file changed, 2 insertions(+)
 
-diff --git a/src/libsysprof/preload/backtrace-helper.h b/src/libsysprof/preload/backtrace-helper.h
-index 88dc194..5c23ad3 100644
---- a/src/libsysprof/preload/backtrace-helper.h
-+++ b/src/libsysprof/preload/backtrace-helper.h
-@@ -32,7 +32,9 @@ static void
+diff --git a/src/preload/backtrace-helper.h b/src/preload/backtrace-helper.h
+index ac4f8e9..e60032d 100644
+--- a/src/preload/backtrace-helper.h
++++ b/src/preload/backtrace-helper.h
+@@ -26,7 +26,9 @@
+ static void
  backtrace_init (void)
  {
- #ifdef ENABLE_LIBUNWIND
 +# ifdef UNW_CACHE_PER_THREAD
    unw_set_caching_policy (unw_local_addr_space, UNW_CACHE_PER_THREAD);
-+# endif
- # ifdef HAVE_UNW_SET_CACHE_SIZE
++#endif
+ #ifdef HAVE_UNW_SET_CACHE_SIZE
    unw_set_cache_size (unw_local_addr_space, 1024, 0);
  #endif

--- a/meta-gnome/recipes-gnome/sysprof/sysprof_47.1.bb
+++ b/meta-gnome/recipes-gnome/sysprof/sysprof_47.1.bb
@@ -4,50 +4,47 @@ LICENSE = "GPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504 \
                     file://src/sysprof/sysprof-application.c;endline=17;md5=a3de8df3b0f8876dd01e1388d2d4b607"
 
-inherit gnomebase gnome-help gettext systemd upstream-version-is-even gsettings mime mime-xdg features_check
+inherit gnomebase gnome-help gettext systemd gsettings gtk-icon-cache mime mime-xdg features_check
 
 DEPENDS += " \
-    glib-2.0-native \
-    yelp-tools-native \
-    libxml2-native \
+    desktop-file-utils-native \
     glib-2.0 \
+    glib-2.0-native \
     json-glib \
+    libdex \
+    libunwind \
+    libxml2-native \
+    yelp-tools-native \
 "
 
 SRC_URI += "file://0001-meson-Check-for-libunwind-instead-of-libunwind-gener.patch \
             file://0002-meson-Do-not-invoke-the-commands-to-update-the-icon-.patch \
-            file://0001-libsysprof-Check-for-unw_set_caching_policy-before-u.patch \
-            "
-SRC_URI[archive.sha256sum] = "07d9081a66cf2fb52753f48ff2b85ada75c60ff1bc1af1bd14d8aeb627972168"
+            file://0003-libsysprof-Check-for-unw_set_caching_policy-before-u.patch \
+           "
+SRC_URI[archive.sha256sum] = "d3baba814be0cdaef28704c8004ff3110e99525422060f2a993a22a47b9334eb"
 
 # reason: gtk4 requires opengl distro feature
 REQUIRED_DISTRO_FEATURES = "${@bb.utils.contains('PACKAGECONFIG', 'gtk', 'opengl', '', d)}"
 
-PACKAGECONFIG ?= "${@bb.utils.contains('DISTRO_FEATURES', 'polkit', 'sysprofd', '', d)} \
+PACKAGECONFIG ?= "${@bb.utils.contains('DISTRO_FEATURES', 'polkit', 'sysprofd libsysprof', '', d)} \
                   ${@bb.utils.contains_any('DISTRO_FEATURES', '${GTK3DISTROFEATURES}', 'gtk', '', d)} \
-                  agent \
-                  libsysprof \
-                  libunwind \
-                  "
-# nongnu libunwind needs porting to RV32
-PACKAGECONFIG:remove:riscv32 = "libunwind"
+                 "
 
-PACKAGECONFIG[gtk] = "-Dgtk=true,-Dgtk=false,gtk4 libadwaita"
+PACKAGECONFIG[gtk] = "-Dgtk=true,-Dgtk=false,gtk4 libpanel"
 PACKAGECONFIG[sysprofd] = "-Dsysprofd=bundled,-Dsysprofd=none,polkit"
-PACKAGECONFIG[libsysprof] = "-Dlibsysprof=true,-Dlibsysprof=false,json-glib"
-PACKAGECONFIG[libunwind] = "-Dlibunwind=true,-Dlibunwind=false,libunwind"
-PACKAGECONFIG[agent] = "-Dagent=true,-Dagent=false,"
+PACKAGECONFIG[libsysprof] = "-Dlibsysprof=true,-Dlibsysprof=false,polkit"
 
 EXTRA_OEMESON += "-Dsystemdunitdir=${systemd_unitdir}/system"
 
 SOLIBS = ".so"
-FILES_SOLIBSDEV = ""
+FILES_SOLIBSDEV = "${libdir}/libsysprof-6.so"
 
-SYSTEMD_SERVICE:${PN} = "${@bb.utils.contains('PACKAGECONFIG', 'sysprofd', 'sysprof2.service sysprof3.service', '', d)}"
+SYSTEMD_SERVICE:${PN} = "${@bb.utils.contains('PACKAGECONFIG', 'sysprofd', 'sysprof3.service', '', d)}"
 
 FILES:${PN} += " \
     ${datadir}/dbus-1/system-services \
     ${datadir}/dbus-1/system.d \
     ${datadir}/dbus-1/interfaces \
     ${datadir}/metainfo \
+    ${libdir}/libsysprof-6*.so.* \
 "


### PR DESCRIPTION
Update sysprof to 47.1
    
The versioning scheme was changed to align to GNOME releases. This version resolves stack frames properly, as opposed to 3.48.
    
Depends on libdex/libpanel recipes to be able to build the sysprof UI, besides the sysprof-cli executable.

This PR also adds the recipes for new required dependencies:

* libpanel: initial add 1.8.1
* libdex: initial add 0.8.1

Co-Authored-By: Nikolas Zimmermann <nzimmermann@igalia.com>
Signed-off-by: Pablo Saavedra <psaavedra@igalia.com>
