### PR TITLE
Bump nbdkit to the newest repo tag

### DIFF
--- a/meta-networking/recipes-support/nbdkit/nbdkit/0002-plugins-Avoid-absolute-buildpaths-in-binaries.patch
+++ b/meta-networking/recipes-support/nbdkit/nbdkit/0002-plugins-Avoid-absolute-buildpaths-in-binaries.patch
@@ -1,0 +1,38 @@
+From 1ccbd8fdbd2e367a702e48c8703b2f010d067b23 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 22 May 2023 18:16:24 -0700
+Subject: [PATCH] plugins: Avoid absolute buildpaths in binaries
+
+plugins seems to add CC to the plugins shared objects via compiler
+cmdline which ends up in real code. Therefore scrub buildpaths from CC
+and CFLAGS before passing them to plugin's build.
+
+Upstream-Status: Submitted [https://gitlab.com/nbdkit/nbdkit/-/merge_requests/30]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ plugins/cc/Makefile.am | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/plugins/cc/Makefile.am b/plugins/cc/Makefile.am
+index df8b5d15..80586a17 100644
+--- a/plugins/cc/Makefile.am
++++ b/plugins/cc/Makefile.am
+@@ -44,9 +44,12 @@ nbdkit_cc_plugin_la_SOURCES = \
+ 	$(top_srcdir)/include/nbdkit-plugin.h \
+ 	$(NULL)
+ 
++workdir := $(shell dirname $(abs_top_builddir))
++cc_no_sysroot := $(shell echo \"$(CC)\"|sed -e 's#$(workdir)#<WORKDIR>#g')
++cflags_no_sysroot := $(shell echo \"$(CFLAGS)\"|sed -e 's#$(workdir)#<WORKDIR>#g')
+ nbdkit_cc_plugin_la_CPPFLAGS = \
+-	-DCC="\"$(CC_PLUGIN_CC)\"" \
+-	-DCFLAGS="\"$(CC_PLUGIN_CFLAGS)\"" \
++	-DCC=\"$(cc_no_sysroot)\" \
++	-DCFLAGS=\"$(cflags_no_sysroot)\" \
+ 	-I$(top_srcdir)/include \
+ 	-I$(top_builddir)/include \
+ 	-I$(top_srcdir)/common/include \
+-- 
+2.40.1
+

--- a/meta-networking/recipes-support/nbdkit/nbdkit_1.40.4.bb
+++ b/meta-networking/recipes-support/nbdkit/nbdkit_1.40.4.bb
@@ -1,0 +1,33 @@
+SUMMARY = "nbdkit is a toolkit for creating NBD servers."
+DESCRIPTION = "NBD — Network Block Device — is a protocol \
+for accessing Block Devices (hard disks and disk-like things) \
+over a Network. \
+\
+nbdkit is a toolkit for creating NBD servers."
+
+HOMEPAGE = "https://gitlab.com/nbdkit/nbdkit"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=26250adec854bc317493f6fb98efe049"
+
+SRC_URI = "git://gitlab.com/nbdkit/nbdkit.git;protocol=https;branch=stable-1.40 \
+           file://0002-plugins-Avoid-absolute-buildpaths-in-binaries.patch"
+SRCREV = "0d111a31d9dbc473b9eb901fefe07f0ad392c75a"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = "curl xz e2fsprogs zlib"
+
+# autotools-brokensep is needed as nbdkit does not support build in external directory
+inherit pkgconfig python3native perlnative bash-completion autotools-brokensep
+
+# Those are required to build standalone
+EXTRA_OECONF = " --without-libvirt --without-libguestfs --disable-perl"
+
+# Disable some extended support (not desired for small embedded systems)
+#EXTRA_OECONF += " --disable-python"
+#EXTRA_OECONF += " --disable-ocaml"
+#EXTRA_OECONF += " --disable-rust"
+#EXTRA_OECONF += " --disable-ruby"
+#EXTRA_OECONF += " --disable-tcl"
+#EXTRA_OECONF += " --disable-lua"
+#EXTRA_OECONF += " --disable-vddk"


### PR DESCRIPTION
Recently, the official nbdkit repo has been changed: from https://github.com/libguestfs/nbdkit
into https://gitlab.com/nbdkit/nbdkit

Additionally, the newest tag versiion is v1.41.8.
The patch used with version 1.33.11 is also merged to v1.41.8, so it is obsolete now.

This commit bumps the used version from 1.33.11 to 1.41.8.

It was tested with one of openbmc images.