### PR TITLE
libjs-jquery-cookie: switch to main branch

### DIFF
--- a/meta-oe/recipes-support/libjs/libjs-jquery-cookie_3.0.1.bb
+++ b/meta-oe/recipes-support/libjs/libjs-jquery-cookie_3.0.1.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/js-cookie/js-cookie"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e16cf0e247d84f8999bf55865a9c98cf"
 
-SRC_URI = "git://github.com/js-cookie/js-cookie.git;protocol=http;branch=master;protocol=https"
+SRC_URI = "git://github.com/js-cookie/js-cookie.git;protocol=http;branch=main;protocol=https"
 
 SRCREV = "0ba77141dd215782cc7770347a457906908c66ff"
 


### PR DESCRIPTION
Branch "master" has been renamed to "main".