### PR TITLE
ctre: add new recipe

### DIFF
--- a/meta-oe/recipes-support/ctre/ctre_3.9.0.bb
+++ b/meta-oe/recipes-support/ctre/ctre_3.9.0.bb
@@ -1,0 +1,22 @@
+DESCRIPTION = "Fast compile-time regular expressions with support for matching/searching/capturing."
+HOMEPAGE = "https://github.com/hanickadot/compile-time-regular-expressions"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=2e982d844baa4df1c80de75470e0c5cb"
+
+SRC_URI = "git://github.com/hanickadot/compile-time-regular-expressions.git;protocol=https;branch=main"
+SRCREV = "eb9577aae3515d14e6c5564f9aeb046d2e7c1124"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[module] = "-DCTRE_MODULE=ON,-DCTRE_MODULE=OFF"
+PACKAGECONFIG[tests] = "-DCTRE_BUILD_TESTS=ON,-DCTRE_BUILD_TESTS=OFF"
+
+EXTRA_OECMAKE:append = " \
+-DCTRE_BUILD_PACKAGE=OFF \
+-DCTRE_BUILD_PACKAGE_DEB=OFF \
+-DCTRE_BUILD_PACKAGE_RPM=OFF \
+"


### PR DESCRIPTION
Hello,
I would like to add a new recipe to the meta-oe layer.
This recipe is another component required by the reflect-cpp project, which I want to add to this layer.