### PR TITLE
polkit: Install rules in subdir

### DIFF
--- a/meta-oe/recipes-extended/polkit/polkit-group-rule.inc
+++ b/meta-oe/recipes-extended/polkit/polkit-group-rule.inc
@@ -6,4 +6,8 @@ REQUIRED_DISTRO_FEATURES = "polkit"
 
 inherit useradd
 
+do_install:prepend() {
+        install -m 700 -d ${D}${datadir}/polkit-1/rules.d
+}
+
 FILES:${PN} += "${datadir}/polkit-1/rules.d"


### PR DESCRIPTION
https://github.com/openembedded/meta-openembedded/commit/d5e90541f8e35916abc930b2da6de037b23d51a1 moved the rules to /usr/share/ instead of /etc/. The commit also removed the install:prepend() step.
This results in the rules being installed as file /usr/share/polkit-1/rules.d instead of in that folder.

This commit adds back the install prepend step such that the rules are installed in said folder.