### PR TITLE
fix missing posix message queue support in python3-posix-ipc package

### DIFF
--- a/meta-python/recipes-devtools/python/python3-posix-ipc_1.1.1.bb
+++ b/meta-python/recipes-devtools/python/python3-posix-ipc_1.1.1.bb
@@ -10,3 +10,7 @@ UPSTREAM_CHECK_PYPI_PACKAGE = "${PYPI_PACKAGE}"
 SRC_URI[sha256sum] = "e2456ba0cfb2ee5ba14121450e8d825b3c4a1461fca0761220aab66d4111cbb7"
 
 inherit setuptools3 pypi
+
+# Ensure posix message queue support in python package for prober.py script
+DEPENDS += "glibc"
+RDEPENDS:${PN} += "glibc"


### PR DESCRIPTION
[issue](https://github.com/openembedded/meta-openembedded/issues/916)

There was a problem with this package, it compiled normally, but without message queue support, even though it was enabled due to the latest kernel usage. 

Without DEPENDS += "glibc" [probber script](https://github.com/osvenskan/posix_ipc/blob/rel1.1.1/prober.py) tends to provide wrong results, disabling message queue support. 

This hack fixes it. I'm new to open embedded, so please tell me if this approach is not the optimal one or not correct.