### PR TITLE
polkit: fix permissions of /usr/share/polkit-1/rules.d/ again

### DIFF
--- a/meta-oe/recipes-extended/polkit/polkit-group-rule.inc
+++ b/meta-oe/recipes-extended/polkit/polkit-group-rule.inc
@@ -7,7 +7,7 @@ REQUIRED_DISTRO_FEATURES = "polkit"
 inherit useradd
 
 do_install:prepend() {
-        install -m 700 -d ${D}${datadir}/polkit-1/rules.d
+        install -m 755 -d ${D}${datadir}/polkit-1/rules.d
 }
 
 FILES:${PN} += "${datadir}/polkit-1/rules.d"


### PR DESCRIPTION
Commit d89fc818b716d099f83a5a9a973be428e2b66806 changed the permissions back to 700, which is wrong for /usr/share, these files are intended to be world readable. Change it back.

Fixes: d89fc818b716 ("polkit: Install rules in subdir")