### PR TITLE
libatasmart: fix SRC_URI protocol

### DIFF
--- a/meta-oe/recipes-support/libatasmart/libatasmart_0.19.bb
+++ b/meta-oe/recipes-support/libatasmart/libatasmart_0.19.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LGPL;md5=2d5025d4aa3495befef8f17206a5b0a1"
 DEPENDS = "udev"
 
 SRCREV = "de6258940960443038b4c1651dfda3620075e870"
-SRC_URI = "git://git.0pointer.net/libatasmart.git;protocol=https;branch=master \
+SRC_URI = "git://git.0pointer.net/libatasmart.git;protocol=http;branch=master \
            file://0001-Makefile.am-add-CFLAGS-and-LDFLAGS-definiton.patch \
 "
 


### PR DESCRIPTION
This recipe SRC_URI was defining the fetch protocol as 'https', but if we look into libatasmart's repo [1], it says it supports 'git' and 'http'.
This was resulting in the recipe being stuck forever in the 'do_fetch' task.

[1] https://git.0pointer.net/libatasmart.git