### PR TITLE
libspdm: add support for ppc64le

### DIFF
--- a/meta-oe/recipes-support/libspdm/libspdm_3.6.0.bb
+++ b/meta-oe/recipes-support/libspdm/libspdm_3.6.0.bb
@@ -37,6 +37,7 @@ def get_spdm_multiarch(bb, d):
         "aarch64": "aarch64",
         "riscv32": "riscv32",
         "riscv64": "riscv64",
+        "ppc64le": "ppc64le",
     }
 
     if target_arch in multiarch_options :


### PR DESCRIPTION
Recently picked this up over in the OpenBMC project and noticed our ppc64le based server could no longer build the code.

Verified this change allows everything to build fine on ppc64le servers now.