### PR TITLE
mctp: srcrev bump 9042704131d..dd944cf5b5a

### DIFF
--- a/meta-networking/recipes-support/mctp/mctp_2.1.bb
+++ b/meta-networking/recipes-support/mctp/mctp_2.1.bb
@@ -5,7 +5,7 @@ LICENSE = "GPL-2.0-only"
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=4cc91856b08b094b4f406a29dc61db21"
 
-SRCREV = "9042704131d270e713fc267d3cc84273bc995315"
+SRCREV = "dd944cf5b5a8b834f3685bcb2017190258dbcd0b"
 
 SRC_URI = "git://github.com/CodeConstruct/mctp;branch=main;protocol=https"
 


### PR DESCRIPTION
Additional commit included in this version bump are below.

Jeremy Kerr (9):
  + tests: Add tests for dbus Network1 interface
  + tests: add System.del_address
  + tests: notify netlink socket on system link/neighbour/address/route changes
  + tests: Add NLSocket._create_msg
  + tests: rename NLSocket._send_resp to _send_msg
  + mctpd: fix error message and code for missing linkmap entry case
  + mctpd: remove unnecessary debug output
  + CHANGELOG: Add mctp-bench change

Thu Nguyen (1):
  + Support `LocalEIDs` property in `au.com.codeconstruct.MCTP.Network1`

Timon Liu (1):
  + mctp-bench: Add a utility tool to send/receive messages and display throughput