### PR TITLE
scarthgap: Update poco_1.12.5p2.bb

### DIFF
--- a/meta-oe/recipes-support/poco/poco_1.12.5p2.bb
+++ b/meta-oe/recipes-support/poco/poco_1.12.5p2.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=4267f48fc738f50380cbeeb76f95cebc"
 # These dependencies are required by Foundation
 DEPENDS = "libpcre2 zlib"
 
-SRC_URI = "git://github.com/pocoproject/poco.git;branch=master;protocol=https \
+SRC_URI = "git://github.com/pocoproject/poco.git;branch=poco-1.12.5;protocol=https \
            file://0001-Use-std-atomic-int-instead-of-std-atomic-bool.patch \
            file://0001-cppignore.lnx-Ignore-PKCS12-and-testLaunch-test.patch \
            file://run-ptest \


### PR DESCRIPTION
Fixes #938 
Update branch in SRC_URI from `master` to `poco-1.12.5` since `master` branch is not available anymore in `poco.git`. `poco-1.12.5` contains the commit `1d6fb3e1383e559cacbada5e3f861c0dafaf5d30` already.