### PR TITLE
fsverity-utils: fix SRC_URI

### DIFF
--- a/meta-oe/recipes-crypto/fsverity-utils/fsverity-utils_1.5.bb
+++ b/meta-oe/recipes-crypto/fsverity-utils/fsverity-utils_1.5.bb
@@ -10,7 +10,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=bc974d217b525ea216a336adb73e1220"
 
 SRCREV = "20e87c13075a8e5660a8d69fd6c93d4f7c5f01a5"
-SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/ebiggers/fsverity-utils.git;branch=master"
+SRC_URI = "git://git.kernel.org/pub/scm/fs/fsverity/fsverity-utils.git;branch=master"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This URL does not exist any more, and do_fetch works only because a mirrored file is available at
http://downloads.yoctoproject.org/mirror/sources/git2_git.kernel.org.pub.scm.linux.kernel.git.ebiggers.fsverity-utils.git.tar.gz