### PR TITLE
python3-h5py: switch to PEP-517 build backend; don't enforce hdf5 lib version

### DIFF
--- a/meta-python/recipes-devtools/python/python3-h5py_3.13.0.bb
+++ b/meta-python/recipes-devtools/python/python3-h5py_3.13.0.bb
@@ -24,5 +24,3 @@ RDEPENDS:${PN} = "python3-numpy \
                   python3-six \
                   python3-json \
                  "
-
-export HDF5_VERSION = "1.14.0"

--- a/meta-python/recipes-devtools/python/python3-h5py_3.13.0.bb
+++ b/meta-python/recipes-devtools/python/python3-h5py_3.13.0.bb
@@ -8,7 +8,7 @@ SRC_URI[sha256sum] = "1870e46518720023da85d0895a1960ff2ce398c5671eac3b1a41ec696b
 
 SRC_URI += "file://0001-setup_build.py-avoid-absolute-path.patch"
 
-inherit pkgconfig pypi setuptools3 cython
+inherit pkgconfig pypi python_setuptools_build_meta cython
 
 BBCLASSEXTEND = "native"
 


### PR DESCRIPTION
Upstream moved to PEP-517 builds, so use the appropriate bbclass.

Also don't enforce hdf5 lib version, as it will be automatically detected.
This fixes the following runtime warning:

    >>> import h5py
    /usr/lib/python3.13/site-packages/h5py/__init__.py:36: UserWarning: h5py is running against HDF5 1.14.4 when it was built against 1.14.0, this may cause problems
    _warn(("h5py is running against HDF5 {0} when it was built against {1}, "