### PR TITLE
pipewire: Install missing ALSA config files

### DIFF
--- a/meta-multimedia/recipes-multimedia/pipewire/pipewire_1.4.0.bb
+++ b/meta-multimedia/recipes-multimedia/pipewire/pipewire_1.4.0.bb
@@ -160,6 +160,14 @@ remove_unused_installed_files() {
     rm -f "${D}${datadir}/pipewire/minimal.conf"
 }
 
+do_install:append() {
+    # The pipewire-alsa plugin needs the following files in /etc/alsa/conf.d/ to
+    # be picked up by alsa.
+    install -d ${D}${sysconfdir}/alsa/conf.d
+    ln -sf ${datadir}/alsa/alsa.conf.d/50-pipewire.conf ${D}${sysconfdir}/alsa/conf.d/50-pipewire.conf
+    ln -sf ${datadir}/alsa/alsa.conf.d/99-pipewire-default.conf ${D}${sysconfdir}/alsa/conf.d/99-pipewire-default.conf
+}
+
 do_install[postfuncs] += "remove_unused_installed_files"
 
 python split_dynamic_packages () {
@@ -333,6 +341,8 @@ RDEPENDS:${PN}-pulse += " \
 FILES:${PN}-alsa = "\
     ${libdir}/alsa-lib/* \
     ${datadir}/alsa/alsa.conf.d/* \
+    ${sysconfdir}/alsa/conf.d/50-pipewire.conf \
+    ${sysconfdir}/alsa/conf.d/99-pipewire-default.conf \
 "
 
 # JACK drop-in libraries to redirect audio to pipewire.


### PR DESCRIPTION
Link: https://github.com/openembedded/meta-openembedded/issues/704

As detailed in Pipewire documentation [0], the ALSA plugin requires config files to be symlinked as follow:

```
The plugin will be picked up by alsa when the following files are in /etc/alsa/conf.d/:

/etc/alsa/conf.d/50-pipewire.conf -> /usr/share/alsa/alsa.conf.d/50-pipewire.conf
/etc/alsa/conf.d/99-pipewire-default.conf
```

The above symlinks are missing, thus the pipewire device is not properly detected.

Fix this by creating the required symlinks and installing them in the pipewire-alsa package.

[0] https://github.com/PipeWire/pipewire/blob/master/INSTALL.md#alsa-plugin