### PR TITLE
gitpkgv.bbclass: Fix git revison

### DIFF
--- a/meta-oe/classes/gitpkgv.bbclass
+++ b/meta-oe/classes/gitpkgv.bbclass
@@ -70,7 +70,7 @@ def get_git_pkgv(d, use_tags):
         names = []
         for url in ud.values():
             if url.type == 'git' or url.type == 'gitsm':
-                names.extend(url.revision)
+                names.extend([url.revision[:5]])
         if len(names) > 0:
             format = '_'.join(names)
         else:


### PR DESCRIPTION
With new Bitbake  fetcher changes, url.revision is a string now. Convert to list and abbreviate revision to the first five.

Old ipk file name:
enigma2_3.13+git3_1_3_0_9_c_7_0_a_4_f_a_6_9_d_6_7_0_1_7_b_b_9_f_7_f_4_d_d_9_d_6_1_0_a_8_c_3_d_20+31309c70a4-r0_dm920.ipk

New ipk file name:
enigma2_3.13+git313090+31309c70a4-r0_dm920.ipk