### PR TITLE
gitpkgv.bbclass: Fix broken git revison

### DIFF
--- a/meta-oe/classes/gitpkgv.bbclass
+++ b/meta-oe/classes/gitpkgv.bbclass
@@ -70,7 +70,7 @@ def get_git_pkgv(d, use_tags):
         names = []
         for url in ud.values():
             if url.type == 'git' or url.type == 'gitsm':
-                names.extend(url.revision)
+                names.append(url.name)
         if len(names) > 0:
             format = '_'.join(names)
         else:


### PR DESCRIPTION
The revision dictionary was built with keys from names list in Bitbake(setup_revisions()). See:
https://git.openembedded.org/bitbake/commit/?id=2515fbd10824005fa7f34e87706000c079920366

And used to build names list in gitpkgv.bbclass in the old situation, see: https://git.openembedded.org/meta-openembedded/commit/?id=2920d4909236106e1a36d56b3b20762a308ba3d4

Use name variable to build names list instead of revision variable. Use append() now name variable is a string.

Old ipk file name:
enigma2_3.13+git3_1_3_0_9_c_7_0_a_4_f_a_6_9_d_6_7_0_1_7_b_b_9_f_7_f_4_d_d_9_d_6_1_0_a_8_c_3_d_20+31309c70a4-r0_dm920.ipk

New ipk file name:
enigma2_3.13+git21834+31309c70+31309c70a4-r0_dm920.ipk