### PR TITLE
[protobuf] Link with libatomic on mips

### DIFF
--- a/meta-oe/recipes-devtools/protobuf/protobuf_5.29.4.bb
+++ b/meta-oe/recipes-devtools/protobuf/protobuf_5.29.4.bb
@@ -52,6 +52,7 @@ TEST_SRC_DIR = "examples"
 LANG_SUPPORT = "cpp ${@bb.utils.contains('PACKAGECONFIG', 'python', 'python', '', d)}"
 
 LDFLAGS:append:riscv32 = " -latomic"
+CXXFLAGS:append:mipsarch = " -latomic"
 
 do_compile_ptest() {
 	mkdir -p "${B}/${TEST_SRC_DIR}"


### PR DESCRIPTION
mips does not have compiler builtins for 64bit atomics

Fix:
/openpli-dreambox-oe-core/build/tmp/work/mips32el-oe-linux/protobuf/5.29.4/recipe-sysroot/usr/lib/libabsl_spinlock_wait.so.2501.0.0: undefined reference to `__atomic_store_8'