### PR TITLE
networkmanager: only enable the vala bindings if GObject introspection is enabled

### DIFF
--- a/meta-networking/recipes-connectivity/networkmanager/networkmanager_1.46.0.bb
+++ b/meta-networking/recipes-connectivity/networkmanager/networkmanager_1.46.0.bb
@@ -82,11 +82,12 @@ do_configure:prepend() {
     cp -f ${STAGING_LIBDIR}/girepository-1.0/GModule*typelib ${STAGING_LIBDIR_NATIVE}/girepository-1.0/
 }
 
-PACKAGECONFIG ??= "readline nss ifupdown dnsmasq nmcli vala \
+PACKAGECONFIG ??= "readline nss ifupdown dnsmasq nmcli \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', bb.utils.contains('DISTRO_FEATURES', 'x11', 'consolekit', '', d), d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'bluez5', '', d)} \
     ${@bb.utils.filter('DISTRO_FEATURES', 'wifi polkit ppp', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'selinux', 'selinux audit', '', d)} \
+    ${@bb.utils.contains('GI_DATA_ENABLED', 'True', 'vala', '', d)} \
 "
 
 inherit ${@bb.utils.contains('PACKAGECONFIG', 'vala', 'vala', '', d)}

--- a/meta-networking/recipes-connectivity/networkmanager/networkmanager_1.46.0.bb
+++ b/meta-networking/recipes-connectivity/networkmanager/networkmanager_1.46.0.bb
@@ -76,11 +76,6 @@ EXTRA_OEMESON = "\
 CFLAGS:append:libc-musl = " \
     -DRTLD_DEEPBIND=0 \
 "
-do_configure:prepend() {
-    cp -f ${STAGING_LIBDIR}/girepository-1.0/GObject*typelib ${STAGING_LIBDIR_NATIVE}/girepository-1.0/
-    cp -f ${STAGING_LIBDIR}/girepository-1.0/Gio*typelib ${STAGING_LIBDIR_NATIVE}/girepository-1.0/
-    cp -f ${STAGING_LIBDIR}/girepository-1.0/GModule*typelib ${STAGING_LIBDIR_NATIVE}/girepository-1.0/
-}
 
 PACKAGECONFIG ??= "readline nss ifupdown dnsmasq nmcli \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', bb.utils.contains('DISTRO_FEATURES', 'x11', 'consolekit', '', d), d)} \


### PR DESCRIPTION
Fixes build errors in network-manager with GI_DATA_ENABLED = "False"
