### PR TITLE
networkmanager: only enable the vala bindings if gobject introspection is enabled

### DIFF
--- a/meta-networking/recipes-connectivity/networkmanager/networkmanager_1.50.0.bb
+++ b/meta-networking/recipes-connectivity/networkmanager/networkmanager_1.50.0.bb
@@ -77,11 +77,12 @@ CFLAGS:append:libc-musl = " \
     -DRTLD_DEEPBIND=0 \
 "
 
-PACKAGECONFIG ??= "readline nss ifupdown dnsmasq nmcli vala \
+PACKAGECONFIG ??= "readline nss ifupdown dnsmasq nmcli \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', bb.utils.contains('DISTRO_FEATURES', 'x11', 'consolekit', '', d), d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'bluez5', '', d)} \
     ${@bb.utils.filter('DISTRO_FEATURES', 'wifi polkit ppp', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'selinux', 'selinux audit', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES_BACKFILL_CONSIDERED', 'gobject-introspection-data', '', 'vala', d)} \
 "
 
 inherit ${@bb.utils.contains('PACKAGECONFIG', 'vala', 'vala', '', d)}

--- a/meta-networking/recipes-connectivity/networkmanager/networkmanager_1.50.0.bb
+++ b/meta-networking/recipes-connectivity/networkmanager/networkmanager_1.50.0.bb
@@ -76,12 +76,6 @@ EXTRA_OEMESON = "\
 CFLAGS:append:libc-musl = " \
     -DRTLD_DEEPBIND=0 \
 "
-do_configure:prepend() {
-    cp -f ${STAGING_LIBDIR}/girepository-1.0/GLib*typelib ${STAGING_LIBDIR_NATIVE}/girepository-1.0/
-    cp -f ${STAGING_LIBDIR}/girepository-1.0/GObject*typelib ${STAGING_LIBDIR_NATIVE}/girepository-1.0/
-    cp -f ${STAGING_LIBDIR}/girepository-1.0/Gio*typelib ${STAGING_LIBDIR_NATIVE}/girepository-1.0/
-    cp -f ${STAGING_LIBDIR}/girepository-1.0/GModule*typelib ${STAGING_LIBDIR_NATIVE}/girepository-1.0/
-}
 
 PACKAGECONFIG ??= "readline nss ifupdown dnsmasq nmcli vala \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', bb.utils.contains('DISTRO_FEATURES', 'x11', 'consolekit', '', d), d)} \


### PR DESCRIPTION
Tested in a minimal environment, see below

with one of the the following options, or with none enabled:  

in local.conf:
GI_DATA_ENABLED = "False"
DISTRO_FEATURES:remove = " gobject-introspection-data"

networkmanager-%.bbappend
GI_DATA_ENABLED = "False"


```
Project: bitbake
Mount path: poky-master/sources/bitbake
Current revision: 696c2c1ef095f8b11c7d2eff36fae50f58c62e5e
Manifest revision: 2.8
Local Branches: 0
----------------------------
Project: meta-openembedded
Mount path: poky-master/sources/meta-openembedded
Current revision: 9e203efd094c0474f8fe89eb47b41ef49e3def31
Current branch: networkmanager
Manifest revision: networkmanager
Local Branches: 1 [networkmanager]
----------------------------
Project: openembedded-core
Mount path: poky-master/sources/openembedded-core
Current revision: dc2ef2cc1183a14cd3a05d388a1d0485a1bc8d20
Manifest revision: master
Local Branches: 0
----------------------------
Project: poky
Mount path: poky-master/sources/poky
Current revision: e894acce6ede8bedafc1859ea0345ee6d80e9c74
Manifest revision: master
Local Branches: 0
```