### PR TITLE
source-highlight: add recipe

### DIFF
--- a/meta-oe/recipes-support/source-highlight/source-highlight_git.bb
+++ b/meta-oe/recipes-support/source-highlight/source-highlight_git.bb
@@ -1,0 +1,36 @@
+SUMMARY = "Syntax highlight utility"
+DESCRIPTION = "Source-highlight converts source code to formatted text with syntax highlighting."
+HOMEPAGE = "https://www.gnu.org/software/src-highlite/"
+LICENSE = "GPL-3.0-only"
+SECTION = "libs"
+LIC_FILES_CHKSUM = "file://COPYING;;md5=ff95bfe019feaf92f524b73dd79e76eb"
+
+SRCREV = "894cacd0799ca60afa359a63782729dec76cbb79"
+PV = "3.1.9+git"
+SRC_URI = "git://git.savannah.gnu.org/git/src-highlite.git;protocol=https;branch=master"
+S = "${WORKDIR}/git"
+
+inherit autotools pkgconfig
+
+DEPENDS:append = " bison-native boost"
+
+DEPENDS:append:class-target = " ${PN}-native"
+
+EXTRA_OECONF="--with-boost-regex=boost_regex"
+
+BBCLASSEXTEND = "native nativesdk"
+
+PACKAGES += "${PN}-tools ${PN}-data"
+
+RDEPENDS:${PN} = "boost-regex ${PN}-data"
+RDEPENDS:${PN}-tools = "${PN} ${PN}-data bash"
+
+FILES:${PN}       = "${libdir}/*${SOLIBS}"
+FILES:${PN}-data  = "${datadir}/source-highlight"
+FILES:${PN}-tools = "${bindir} ${sysconfdir}/bash_completion.d"
+
+# source-highlight is using its own binary from the build tree to make documentation
+# let's substitute the native binary instead
+do_configure:prepend:class-target () {
+     sed -i -e 's,^SRCHILITEEXE = $(top_builddir).*,SRCHILITEEXE = source-highlight,' ${S}/doc/Makefile.am
+}


### PR DESCRIPTION
source-highlight version 3.1.8 was removed from openembedded-core in https://web.git.yoctoproject.org/poky/commit/?id=6560db9ddfd39a2715ede96430228306b00f53dd in June 2019 because the was no user left, however there is now a gdb PACKAGECONFIG option which uses it. Since the last release was in 2019, let's use the latest git version rather than the latest formal release.