### PR TITLE
uutils-coreutils: fix selinux PACKAGECONFIG option

### DIFF
--- a/meta-oe/recipes-core/uutils-coreutils/uutils-coreutils_0.0.30.bb
+++ b/meta-oe/recipes-core/uutils-coreutils/uutils-coreutils_0.0.30.bb
@@ -24,7 +24,7 @@ RPROVIDES:${PN} = "coreutils"
 
 PACKAGECONFIG ?= "${@bb.utils.filter('DISTRO_FEATURES', 'selinux', d)}"
 
-PACKAGECONFIG[selinux] = "--with-selinux,--without-selinux,libselinux"
+PACKAGECONFIG[selinux] = ",,libselinux"
 
 CARGO_BUILD_FLAGS += "--features unix"
 CARGO_BUILD_FLAGS += "${@bb.utils.contains('PACKAGECONFIG', 'selinux', '--features feat_selinux', '', d)}"


### PR DESCRIPTION
This does not compile any more after https://git.openembedded.org/openembedded-core/commit/?id=16745b20452de60ae2474433cc1a2fb1ed9f6a64 which appends the contents of PACKAGECONFIG_CONFARGS to the cargo build command.