### PR TITLE
fixes for source-highlight

### DIFF
--- a/meta-oe/recipes-support/source-highlight/source-highlight_git.bb
+++ b/meta-oe/recipes-support/source-highlight/source-highlight_git.bb
@@ -14,7 +14,7 @@ inherit autotools pkgconfig
 
 DEPENDS:append = " bison-native boost"
 
-DEPENDS:append:class-target = " ${PN}-native"
+DEPENDS:append:class-target = " ${BPN}-native"
 
 EXTRA_OECONF = "--with-boost-regex=boost_regex"
 


### PR DESCRIPTION
Commit 1:
 source-highlight: remove double ';'

Commit 2:

source-highlight: fix multibuild build error
    
The multibuild build of lib32-source-highlight was failing with:
    
    ```
    ERROR: Nothing PROVIDES 'lib32-source-highlight-native' (but virtual:multilib:lib32:meta-oe/meta-oe/recipes-support/source-highlight/source-highlight_git.bb DEPENDS on or otherwise requires it). Close matches:
    lib32-source-highlight
    source-highlight
    source-highlight-native
    ```
