### PR TITLE
RFC: openh264: Is LICENSE_FLAGS needed?

### DIFF
--- a/meta-multimedia/recipes-multimedia/openh264/openh264_2.6.0.bb
+++ b/meta-multimedia/recipes-multimedia/openh264/openh264_2.6.0.bb
@@ -4,7 +4,6 @@ decoding. It is suitable for use in real time applications such as WebRTC."
 HOMEPAGE = "http://www.openh264.org/"
 SECTION = "libs/multimedia"
 LICENSE = "BSD-2-Clause"
-LICENSE_FLAGS = "commercial"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=bb6d3771da6a07d33fd50d4d9aa73bcf"
 
 DEPENDS = " nasm-native"


### PR DESCRIPTION
Hey. 

For what I understand the BSD-2-Clause is an open source license, not a commercial one.
So I was wondering why I need to add it to LICENSE_FLAGS_ACCEPTED in order to use it in a project? 