### PR TITLE
Fix uhubctl_2.6.0.bb, add missing inherit

### DIFF
--- a/meta-oe/recipes-support/uhubctl/uhubctl_2.6.0.bb
+++ b/meta-oe/recipes-support/uhubctl/uhubctl_2.6.0.bb
@@ -10,6 +10,8 @@ SRCREV = "352f5878e999c0a9d5a453b34110479b2056d7e7"
 SRC_URI = "git://github.com/mvp/${BPN};branch=master;protocol=https"
 S = "${WORKDIR}/git"
 
+inherit pkgconfig
+
 # uhubctl gets its program version from "git describe". As we use the source
 # archive do reduce download size replace the call with our hardcoded version.
 do_configure:append() {


### PR DESCRIPTION
Fix error while building of uhubctl.

```
| The correct version of pkg-config is not being used!
| Make sure the recipe inherits 'pkgconfig'.
```

uhubctl depends on pkg-config in its [Makefile](https://github.com/mvp/uhubctl/blob/fbe812bd83fcd2801131a8ea2479104e0d2b2352/Makefile#L29).