### PR TITLE
suitesparse: file parse error

### DIFF
--- a/meta-oe/recipes-devtools/suitesparse/suitesparse_5.10.1.bb
+++ b/meta-oe/recipes-devtools/suitesparse/suitesparse_5.10.1.bb
@@ -19,14 +19,14 @@ RPROVIDES:${PN} = "mongoose graphblas"
 # the command line. To get around this problem, set these variables to only the
 # program name and prepend the rest of the value onto the corresponding FLAGS
 # variable.
-CFLAGS:prepend := "${@" ".join(d.getVar('CC').split()[1:])} "
-export CC := "${@d.getVar('CC').split()[0]}"
+CFLAGS:prepend = "${@" ".join(d.getVar('CC').split()[1:])} "
+export CC = "${@d.getVar('CC').split()[0]}"
 
-CXXFLAGS:prepend := "${@" ".join(d.getVar('CXX').split()[1:])} "
-export CXX := "${@d.getVar('CXX').split()[0]}"
+CXXFLAGS:prepend = "${@" ".join(d.getVar('CXX').split()[1:])} "
+export CXX = "${@d.getVar('CXX').split()[0]}"
 
-LDFLAGS:prepend := "${@" ".join(d.getVar('LD').split()[1:])} "
-export LD := "${@d.getVar('LD').split()[0]}"
+LDFLAGS:prepend = "${@" ".join(d.getVar('LD').split()[1:])} "
+export LD = "${@d.getVar('LD').split()[0]}"
 
 export CMAKE_OPTIONS = " \
     -DCMAKE_INSTALL_PREFIX=${D}${prefix} \


### PR DESCRIPTION
This causes a bitbake parsing error with poky master ( https://git.yoctoproject.org/poky/commit/?h=master-next&id=33fd6f6e82cf2c9d20a0532d8cfe850280a83051 ).

```
ERROR: ExpansionError during parsing /home/ecordonnier/dev/poky/meta-openembedded/meta-oe/recipes-devtools/suitesparse/suitesparse_5.10.1.bb                                                                                             | ETA:  0:00:23
bb.data_smart.ExpansionError: Failure expanding variable CFLAGS:prepend[:=], expression was ${@" ".join(d.getVar('CC').split()[1:])}  which triggered exception AttributeError: 'NoneType' object has no attribute 'split'
The variable dependency chain for the failure is: CFLAGS:prepend[:=]

ERROR: Parsing halted due to errors, see error messages above
```