### PR TITLE
perfetto: fix error in qemux86-64

### DIFF
--- a/meta-oe/recipes-devtools/perfetto/perfetto.bb
+++ b/meta-oe/recipes-devtools/perfetto/perfetto.bb
@@ -81,7 +81,14 @@ do_configure () {
     CXX_BIN=`echo $CXX | awk '{print $1}'`
     STRIP_BIN=`echo $STRIP | awk '{print $1}'`
 
-    ARGS="is_debug=false "  # Tell gn to use release mode
+    ARGS="is_debug=false"  # Tell gn to use release mode
+
+    # Disable x64 CPU optimizations for qemux86-64 since QEMU doesn't support
+    # all the required CPU features (SSE4.2, BMI2, AVX2). Without this flag,
+    # the tracebox binary will fail at runtime with an error message in qemux86-64.
+    if [ "${MACHINE}" = "qemux86-64" ]; then
+        ARGS=$ARGS" enable_perfetto_x64_cpu_opt=false"
+    fi
 
     if [ -z `echo ${TOOLCHAIN} | grep clang` ]; then
         ARGS=$ARGS" is_clang=false"


### PR DESCRIPTION
This fixes this error:

```
root@qemux86-64:~# tracebox --txt -c /tmp/config.pbtxt -o /tmp/perfetto-trace.pb
This executable requires a x86_64 cpu that supports SSE4.2, BMI2 and AVX2.
Rebuild with enable_perfetto_x64_cpu_opt=false.
```