### PR TITLE
fbida: fix make fbpdf build optional

### DIFF
--- a/meta-oe/recipes-graphics/fbida/fbida_2.14.bb
+++ b/meta-oe/recipes-graphics/fbida/fbida_2.14.bb
@@ -16,6 +16,7 @@ SRC_URI = "https://www.kraxel.org/releases/fbida/fbida-${PV}.tar.gz \
            file://support-jpeg-turbo.patch \
            file://cairo-weak-detect.patch \
            file://fbida-gcc10.patch \
+           file://0007-make-fbpdf-build-optional.patch \
 	   "
 SRC_URI[sha256sum] = "95b7c01556cb6ef9819f358b314ddfeb8a4cbe862b521a3ed62f03d163154438"
 
@@ -34,6 +35,7 @@ PACKAGECONFIG[tiff] = ",,tiff"
 PACKAGECONFIG[motif] = ",,libx11 libxext libxpm libxt openmotif"
 PACKAGECONFIG[webp] = ",,libwebp"
 PACKAGECONFIG[lirc] = ",,lirc"
+PACKAGECONFIG[pdf] = ",,poppler libepoxy"
 # This can only be enabled when cairo has egl enabled in its packageconfig support too
 PACKAGECONFIG[egl] = ",,"
 
@@ -68,6 +70,9 @@ do_compile() {
     fi
     if [ -z "${@bb.utils.filter('PACKAGECONFIG', 'lirc', d)}" ]; then
         sed -i -e '/^HAVE_LIBLIRC/s/:=.*$/:= no/' ${S}/GNUmakefile
+    fi
+    if [ -z "${@bb.utils.filter('PACKAGECONFIG', 'pdf', d)}" ]; then
+        sed -i -e '/^HAVE_LIBPDF/s/:=.*$/:= no/' ${S}/GNUmakefile
     fi
 
     oe_runmake

--- a/meta-oe/recipes-graphics/fbida/files/0007-make-fbpdf-build-optional.patch
+++ b/meta-oe/recipes-graphics/fbida/files/0007-make-fbpdf-build-optional.patch
@@ -1,0 +1,88 @@
+--- a/GNUmakefile	2025-10-03 15:20:42.926132622 +0000
++++ b/GNUmakefile	2025-10-03 15:22:39.018131109 +0000
+@@ -29,7 +29,7 @@ deps:
+ 	@echo "  fbi   needs:  $(PKGS_FBI)"
+ 	@echo "  fbpdf needs:  $(PKGS_FBPDF)"
+ 	@echo "Please install.  Try 'make yum', 'make dnf' or 'make apt-get' (needs sudo)."
+-	@false
++	@echo "Warning: missing some deps, build may fail due to missing packages"
+ 
+ yum dnf:
+ 	sudo $@ install $(patsubst %,"pkgconfig(%)",$(PKGS_FBI) $(PKGS_FBPDF))
+@@ -46,11 +46,14 @@ all: build
+ # what to build
+ TARGETS := exiftran thumbnail.cgi
+ ifeq ($(HAVE_LINUX_FB_H),yes)
+-  TARGETS += fbi fbpdf kbdtest
++  TARGETS += fbi kbdtest
+ endif
+ ifeq ($(HAVE_MOTIF),yes)
+   TARGETS += ida
+ endif
++ifeq ($(HAVE_LIBPDF), yes)
++  TARGETS += fbpdf 
++endif
+ 
+ 
+ #################################################################
+@@ -73,6 +76,7 @@ HAVE_LIBGIF	:= $(call ac_lib,DGifOpenFileName,gif)
+ HAVE_LIBWEBP	:= $(call ac_pkg_config,libwebp)
+ HAVE_MOTIF	:= $(call ac_lib,XmStringGenerate,Xm,-L/usr/X11R6/$(LIB) -lXpm -lXt -lXext -lX11)
+ JPEG_VER        := $(call ac_jpeg_ver)
++HAVE_LIBPDF := yes
+ # deprecated
+ #HAVE_GLIBC	:= $(call ac_func,fopencookie)
+ #HAVE_LIBSANE	:= $(call ac_lib,sane_init,sane)
+@@ -215,17 +219,18 @@ fbi: $(OBJS_FBI) $(OBJS_READER)
+ ########################################################################
+ # rules for fbpdf
+ 
+-# object files
+-OBJS_FBPDF := \
+-	fbpdf.o vt.o kbd.o fbtools.o drmtools.o drmtools-egl.o \
+-	fbiconfig.o parseconfig.o
+-
+-# font + drm + jpeg/exif libs
+-fbpdf : CFLAGS += $(shell $(PKG_CONFIG) --cflags $(PKGS_FBPDF))
+-fbpdf : LDLIBS += $(shell $(PKG_CONFIG) --libs   $(PKGS_FBPDF))
+-
+-fbpdf: $(OBJS_FBPDF)
+-
++ifeq ($(HAVE_LIBPDF),yes) 
++  # object files
++  OBJS_FBPDF := \
++  	fbpdf.o vt.o kbd.o fbtools.o drmtools.o drmtools-egl.o \
++  	fbiconfig.o parseconfig.o
++  
++  # font + drm + jpeg/exif libs
++  fbpdf : CFLAGS += $(shell $(PKG_CONFIG) --cflags $(PKGS_FBPDF))
++  fbpdf : LDLIBS += $(shell $(PKG_CONFIG) --libs   $(PKGS_FBPDF))
++  
++  fbpdf: $(OBJS_FBPDF)
++endif
+ 
+ ########################################################################
+ # rules for kbdtest
+@@ -249,10 +254,7 @@ install: build
+ 	$(INSTALL_DATA) $(srcdir)/man/exiftran.1 $(mandir)/man1
+ ifeq ($(HAVE_LINUX_FB_H),yes)
+ 	$(INSTALL_BINARY) fbi $(bindir)
+-	$(INSTALL_SCRIPT) fbgs $(bindir)
+-	$(INSTALL_SCRIPT) fbpdf $(bindir)
+ 	$(INSTALL_DATA) $(srcdir)/man/fbi.1 $(mandir)/man1
+-	$(INSTALL_DATA) $(srcdir)/man/fbgs.1 $(mandir)/man1
+ endif
+ ifeq ($(HAVE_MOTIF),yes)
+ 	$(INSTALL_BINARY) ida $(bindir)
+@@ -260,6 +262,11 @@ ifeq ($(HAVE_MOTIF),yes)
+ 	$(INSTALL_DIR) $(resdir)/app-defaults
+ 	$(INSTALL_DATA) $(srcdir)/Ida.ad $(resdir)/app-defaults/Ida
+ endif
++ifeq ($(HAVE_LIBPDF),yes)
++	$(INSTALL_SCRIPT) fbpdf $(bindir)
++	$(INSTALL_SCRIPT) fbgs $(bindir)
++	$(INSTALL_DATA) $(srcdir)/man/fbgs.1 $(mandir)/man1
++endif
+ 
+ clean:
+ 	-rm -f *.o jpeg/$(JPEG_VER)/*.o rd/*.o wr/*.o $(depfiles) core core.*


### PR DESCRIPTION
this is a backport-like from scarthgap branch: fbida_git.bb and patch 0001-meson.build-make-fbpdf-build-optional.patch