### PR TITLE
gflags: update SRC_URI to use main branch

### DIFF
--- a/meta-oe/recipes-support/gflags/gflags_2.2.2.bb
+++ b/meta-oe/recipes-support/gflags/gflags_2.2.2.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/gflags/gflags"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING.txt;md5=c80d1a3b623f72bb85a4c75b556551df"
 
-SRC_URI = "git://github.com/gflags/gflags.git;branch=master;protocol=https \
+SRC_URI = "git://github.com/gflags/gflags.git;branch=main;protocol=https \
         file://0001-allow-build-with-cmake-4.patch"
 SRCREV = "e171aa2d15ed9eb17054558e0b3a6a413bb01067"
 


### PR DESCRIPTION
Upstream gflags has renamed the default branch from 'master' to 'main'. Update the recipe accordingly to ensure the source can be fetched correctly.

Here is gflags upstream repository: [https://github.com/gflags/gflags](https://github.com/gflags/gflags)