### PR TITLE
tinycompress: install compress_ops.h as public header

### DIFF
--- a/meta-multimedia/recipes-multimedia/tinycompress/tinycompress/0001-include-install-compress_ops.h-as-public-header.patch
+++ b/meta-multimedia/recipes-multimedia/tinycompress/tinycompress/0001-include-install-compress_ops.h-as-public-header.patch
@@ -1,0 +1,32 @@
+From 2db4ee4ed5e12a48b1d195dab0f57b7106ff37c4 Mon Sep 17 00:00:00 2001
+From: Pratyush Meduri <mpratyus@qti.qualcomm.com>
+Date: Tue, 20 Jan 2026 14:47:27 +0530
+Subject: [PATCH] include: install compress_ops.h as public header
+
+Move tinycompress/compress_ops.h from noinst_HEADERS to
+nobase_include_HEADERS so it gets installed for users.
+
+Signed-off-by: Pratyush Meduri <mpratyus@qti.qualcomm.com>
+Upstream-Status: Submitted [https://github.com/alsa-project/tinycompress/pull/30]
+---
+ include/Makefile.am | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/Makefile.am b/include/Makefile.am
+index b12c2c5..15058a9 100644
+--- a/include/Makefile.am
++++ b/include/Makefile.am
+@@ -1,8 +1,8 @@
+-nobase_include_HEADERS = tinycompress/tinycompress.h
++nobase_include_HEADERS = tinycompress/tinycompress.h \
++                         tinycompress/compress_ops.h
+ 
+ noinst_HEADERS = sound/compress_offload.h \
+ 		 sound/compress_params.h \
+ 		 tinycompress/version.h \
+-		 tinycompress/compress_ops.h \
+ 		 tinycompress/tinymp3.h \
+ 		 tinycompress/tinywave.h
+-- 
+2.34.1
+

--- a/meta-multimedia/recipes-multimedia/tinycompress/tinycompress_1.2.13.bb
+++ b/meta-multimedia/recipes-multimedia/tinycompress/tinycompress_1.2.13.bb
@@ -6,6 +6,7 @@ LICENSE = "LGPL-2.1-only | BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=cf9105c1a2d4405cbe04bbe3367373a0"
 
 SRCREV = "ea5c7245beb0b6aec1565cfae0454d6ba374dfdd"
-SRC_URI = "git://github.com/alsa-project/tinycompress.git;branch=master;protocol=https;tag=v${PV}"
+SRC_URI = "git://github.com/alsa-project/tinycompress.git;branch=master;protocol=https;tag=v${PV} \
+           file://0001-include-install-compress_ops.h-as-public-header.patch"
 
 inherit autotools pkgconfig


### PR DESCRIPTION
Add a patch to install compress_ops.h as a public header for tinycompress, and update the recipe to apply it.

This is required for users that need access to compress_ops from external components.

Upstream-Status: submitted