### PR TITLE
mbedtls: Do not set LIB_INSTALL_DIR to an absolute path to make MbedT…

### DIFF
--- a/meta-networking/recipes-connectivity/mbedtls/mbedtls_2.28.10.bb
+++ b/meta-networking/recipes-connectivity/mbedtls/mbedtls_2.28.10.bb
@@ -40,8 +40,6 @@ PACKAGECONFIG[werror] = "-DMBEDTLS_FATAL_WARNINGS=ON,-DMBEDTLS_FATAL_WARNINGS=OF
 PACKAGECONFIG[psa] = ""
 PACKAGECONFIG[tests] = "-DENABLE_TESTING=ON,-DENABLE_TESTING=OFF"
 
-EXTRA_OECMAKE = "-DLIB_INSTALL_DIR:STRING=${libdir}"
-
 # For now the only way to enable PSA is to explicitly pass a -D via CFLAGS
 CFLAGS:append = "${@bb.utils.contains('PACKAGECONFIG', 'psa', ' -DMBEDTLS_USE_PSA_CRYPTO', '', d)}"
 

--- a/meta-networking/recipes-connectivity/mbedtls/mbedtls_3.6.5.bb
+++ b/meta-networking/recipes-connectivity/mbedtls/mbedtls_3.6.5.bb
@@ -42,8 +42,6 @@ PACKAGECONFIG[werror] = "-DMBEDTLS_FATAL_WARNINGS=ON,-DMBEDTLS_FATAL_WARNINGS=OF
 PACKAGECONFIG[psa] = ""
 PACKAGECONFIG[tests] = "-DENABLE_TESTING=ON,-DENABLE_TESTING=OFF"
 
-EXTRA_OECMAKE = "-DLIB_INSTALL_DIR:STRING=${libdir}"
-
 # For now the only way to enable PSA is to explicitly pass a -D via CFLAGS
 CFLAGS:append = "${@bb.utils.contains('PACKAGECONFIG', 'psa', ' -DMBEDTLS_USE_PSA_CRYPTO', '', d)}"
 


### PR DESCRIPTION
…LSTargets.cmake relocateable

Fix absolute paths in CMake install targets, similar to the approach taken in https://github.com/openembedded/meta-openembedded/pull/835