### PR TITLE
pipewire: backport fix for spa/plugins/alsa build with glibc-2.43

### DIFF
--- a/meta-multimedia/recipes-multimedia/pipewire/files/0001-spa-plugins-alsa-acp-compat.h-Fix-missed-Wdiscarded-.patch
+++ b/meta-multimedia/recipes-multimedia/pipewire/files/0001-spa-plugins-alsa-acp-compat.h-Fix-missed-Wdiscarded-.patch
@@ -1,0 +1,30 @@
+From c847b8162959c29b783585e0dcadbfb096e7cb73 Mon Sep 17 00:00:00 2001
+From: Ripley Tom <discofan420@protonmail.com>
+Date: Sat, 21 Feb 2026 19:33:11 +0100
+Subject: [PATCH] spa/plugins/alsa/acp/compat.h: Fix missed
+ -Wdiscarded-qualifiers warning
+
+Upstream-Status: Backport [https://github.com/PipeWire/pipewire/commit/c847b8162959c29b783585e0dcadbfb096e7cb73]
+---
+ spa/plugins/alsa/acp/compat.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/spa/plugins/alsa/acp/compat.h b/spa/plugins/alsa/acp/compat.h
+index f7592e1a6..0f7b959df 100644
+--- a/spa/plugins/alsa/acp/compat.h
++++ b/spa/plugins/alsa/acp/compat.h
+@@ -429,9 +429,9 @@ static PA_PRINTF_FUNC(1,0) inline char *pa_vsprintf_malloc(const char *fmt, va_l
+ 
+ #define pa_fopen_cloexec(f,m)	fopen(f,m"e")
+ 
+-static inline char *pa_path_get_filename(const char *p)
++static inline const char *pa_path_get_filename(const char *p)
+ {
+-    char *fn;
++    const char *fn;
+     if (!p)
+         return NULL;
+     if ((fn = strrchr(p, PA_PATH_SEP_CHAR)))
+-- 
+2.43.0
+

--- a/meta-multimedia/recipes-multimedia/pipewire/pipewire_1.6.2.bb
+++ b/meta-multimedia/recipes-multimedia/pipewire/pipewire_1.6.2.bb
@@ -15,6 +15,7 @@ DEPENDS = "dbus ncurses"
 SRCREV = "95da54a482b68475958bbc3fa572a9c20df0df74"
 BRANCH = "${@oe.utils.trim_version('${PV}', 2)}"
 SRC_URI = "git://gitlab.freedesktop.org/pipewire/pipewire.git;branch=${BRANCH};protocol=https;tag=${PV}"
+SRC_URI += "file://0001-spa-plugins-alsa-acp-compat.h-Fix-missed-Wdiscarded-.patch"
 
 inherit meson pkgconfig systemd gettext useradd
 


### PR DESCRIPTION
Fix missed -Wdiscarded-qualifiers warning:
    ../sources/pipewire-1.6.2/spa/plugins/alsa/acp/compat.h: In function 'pa_path_get_filename':
    ../sources/pipewire-1.6.2/spa/plugins/alsa/acp/compat.h:437:13: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
      437 |     if ((fn = strrchr(p, PA_PATH_SEP_CHAR)))
          |             ^