### PR TITLE
selinux-policy/adbd: resolve SELinux denials for adb file operations and shell interactions

### DIFF
--- a/meta-oe/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0001-Added-sepolicy-for-adb-service.patch
+++ b/meta-oe/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0001-Added-sepolicy-for-adb-service.patch
@@ -64,12 +64,12 @@ index 000000000..f7e8ac7d0
 +# Minimal Rules Required for adbd service
 +allow adbd_t self:capability sys_resource;
 +
++domain_interactive_fd(adbd_t)
 +dev_rw_usbfs(adbd_t)
 +files_read_etc_files(adbd_t)
++files_rw_etc_runtime_files(adbd_t)
 +term_use_ptmx(adbd_t)
 +term_use_generic_ptys(adbd_t)
-+
-+
 +
 -- 
 2.43.0


### PR DESCRIPTION
Problem : 
---------
This change addresses several SELinux denials encountered when using adb for file transfers (push/pull) and interactive shell sessions.

avc: denied { read open getattr } for pid=1089 comm=73796E6320737663203138 path="/denials.txt"   
scontext=system_u:system_r:adbd_t:s0 
tcontext=system_u:object_r:etc_runtime_t:s0 
tclass=file

avc: denied { write } for pid=1089 comm=73796E6320737663203138 name="denials.txt" 
scontext=system_u:system_r:adbd_t:s0 
tcontext=system_u:object_r:etc_runtime_t:s0 
tclass=file


avc: denied { use } for pid=3062 comm="semodule" path="/dev/pts/0" dev="devpts" 
scontext=system_u:system_r:semanage_t:s0 
tcontext=system_u:system_r:adbd_t:s0 
tclass=fd

Fix :
----
1. Fix adb pull/push operations: The `adbd` daemon (running as `adbd_t`) requires read, write, open, and getattr permissions to handle files labeled as `etc_runtime_t`. 

2. Fix interactive shell execution (adb shell): When executing commands like `semodule` via `adb shell`, the `semanage_t` domain attempts to use the pseudo-terminal (PTY) file descriptors (`/dev/pts/0`) created by `adbd_t`.

    