### PR TITLE
refpolicy-targeted: Added policy to allow adb push, pull and semanage through adb shell

### DIFF
--- a/meta-oe/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0001-Added-sepolicy-for-adb-service.patch
+++ b/meta-oe/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0001-Added-sepolicy-for-adb-service.patch
@@ -1,6 +1,6 @@
-From c110d893be565ade574ee2933c6e89197f833006 Mon Sep 17 00:00:00 2001
+From d1c726eb1da3718d05a694222fa0a6a0e944f381 Mon Sep 17 00:00:00 2001
 From: Gargi Misra <gmisra@qti.qualcomm.com>
-Date: Thu, 5 Mar 2026 12:39:42 +0530
+Date: Tue, 31 Mar 2026 23:39:22 +0530
 Subject: [PATCH] refpolicy-targeted: Added sepolicy for adb service
 
     - Labeled adb binary
@@ -12,15 +12,15 @@ Signed-off-by: Gargi Misra <gmisra@qti.qualcomm.com>
 ---
  policy/modules/services/adbd.fc |  5 +++++
  policy/modules/services/adbd.if |  5 +++++
- policy/modules/services/adbd.te | 25 +++++++++++++++++++++++++
- 3 files changed, 35 insertions(+)
+ policy/modules/services/adbd.te | 39 +++++++++++++++++++++++++++++++++
+ 3 files changed, 49 insertions(+)
  create mode 100644 policy/modules/services/adbd.fc
  create mode 100644 policy/modules/services/adbd.if
  create mode 100644 policy/modules/services/adbd.te
 
 diff --git a/policy/modules/services/adbd.fc b/policy/modules/services/adbd.fc
 new file mode 100644
-index 000000000..6f5bb9269
+index 000000000..57d4c1d45
 --- /dev/null
 +++ b/policy/modules/services/adbd.fc
 @@ -0,0 +1,5 @@
@@ -31,7 +31,7 @@ index 000000000..6f5bb9269
 +
 diff --git a/policy/modules/services/adbd.if b/policy/modules/services/adbd.if
 new file mode 100644
-index 000000000..612fc0106
+index 000000000..d71ab1374
 --- /dev/null
 +++ b/policy/modules/services/adbd.if
 @@ -0,0 +1,5 @@
@@ -42,10 +42,10 @@ index 000000000..612fc0106
 +
 diff --git a/policy/modules/services/adbd.te b/policy/modules/services/adbd.te
 new file mode 100644
-index 000000000..f7e8ac7d0
+index 000000000..a58c61c9e
 --- /dev/null
 +++ b/policy/modules/services/adbd.te
-@@ -0,0 +1,25 @@
+@@ -0,0 +1,39 @@
 +policy_module(adbd)
 +
 +########################################
@@ -64,12 +64,26 @@ index 000000000..f7e8ac7d0
 +# Minimal Rules Required for adbd service
 +allow adbd_t self:capability sys_resource;
 +
-+domain_interactive_fd(adbd_t)
 +dev_rw_usbfs(adbd_t)
-+files_read_etc_files(adbd_t)
-+files_rw_etc_runtime_files(adbd_t)
++
++# Required for semanage on adb shell
++domain_interactive_fd(adbd_t)
++
++# Required for adb pull
++files_read_all_symlinks(adbd_t)
++files_read_all_files(adbd_t)
++
++# Required for adb push on /tmp
++files_list_tmp(adbd_t)
++files_manage_generic_tmp_files(adbd_t)
++
 +term_use_ptmx(adbd_t)
 +term_use_generic_ptys(adbd_t)
++
++
++
++
++
 +
 -- 
 2.43.0


### PR DESCRIPTION
This change updates the targeted SELinux policy to address permission denials encountered when using `adb push`, `adb pull`, and `semanage` commands from an ADB shell.

Specifically, the policy additions:

*   Allow read access to required files to support `adb pull` operations (for example, when accessing logs).
*   Permit management of files under `/tmp` to enable `adb push` for test and validation workflows.
*   Resolve observed AVC denials triggered while running `semanage` commands over an ADB shell.

These changes are based on observed runtime behavior and are intended to enable legitimate debugging and development use cases while operating in SELinux enforcing mode.