### PR TITLE
networkmanager: enable modemmanager support for 'phone' devices

### DIFF
--- a/meta-networking/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/meta-networking/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append:qcom = " ${@bb.utils.contains('MACHINE_FEATURES', 'phone', ' modemmanager ', '', d)}"


### PR DESCRIPTION
Enable ModemManager in NetworkManager when the 'phone' MACHINE_FEATURE is enabled.