### PR TITLE
fmt: Updated master->main in SRC_URI.

### DIFF
--- a/meta-oe/recipes-support/fmt/fmt_8.1.1.bb
+++ b/meta-oe/recipes-support/fmt/fmt_8.1.1.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://fmt.dev"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.rst;md5=af88d758f75f3c5c48a967501f24384b"
 
-SRC_URI = "git://github.com/fmtlib/fmt;branch=master;protocol=https \
+SRC_URI = "git://github.com/fmtlib/fmt;branch=main;protocol=https \
            file://run-ptest"
 SRCREV = "b6f4ceaed0a0a24ccf575fab6c56dd50ccf6f1a9"
 


### PR DESCRIPTION
fmt github repo has sometime recently changed their master branch to main. This change is reflected in the SRC_URI.

Solves https://github.com/openembedded/meta-openembedded/issues/1041 (#1041)