### PR TITLE
Bslawomir330 patch 1

### DIFF
--- a/meta-networking/recipes-protocols/frr/frr/0002-tools-update-frr-reload.py-path-to-usr-libexec-frr.patch
+++ b/meta-networking/recipes-protocols/frr/frr/0002-tools-update-frr-reload.py-path-to-usr-libexec-frr.patch
@@ -1,0 +1,25 @@
+From: Sławomir Błaszczyk <bslawomir330@gmail.com>
+Date: Tue, 07 Apr 2026 13:54:00 +0200
+Subject: [PATCH] tools: update frr-reload.py path to /usr/libexec/frr/
+
+Upstream-Status: Submitted [https://github.com/openembedded/meta-openembedded/pull/1044]
+---
+ tools/frr-reload | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tools/frr-reload b/tools/frr-reload
+index 75b31d0622..eb784da3d6 100755
+--- a/tools/frr-reload
++++ b/tools/frr-reload
+@@ -1,7 +1,7 @@
+ #!/bin/sh
+
+-if test -e /usr/lib/frr/frr-reload.py; then
+-   exec /usr/lib/frr/frr-reload.py --reload /etc/frr/frr.conf
++if test -e /usr/libexec/frr/frr-reload.py; then
++   exec /usr/frrexec/frr-reload.py --reload /etc/frr/frr.conf
+ fi
+ >&2 echo "Please install frr-pythontools package. Required for reload"
+ exit 1
+--
+2.41.0

--- a/meta-networking/recipes-protocols/frr/frr_9.1.3.bb
+++ b/meta-networking/recipes-protocols/frr/frr_9.1.3.bb
@@ -13,6 +13,7 @@ LIC_FILES_CHKSUM = "file://doc/licenses/GPL-2.0;md5=b234ee4d69f5fce4486a80fdaf4a
 SRC_URI = "git://github.com/FRRouting/frr.git;protocol=https;branch=stable/9.1 \
            file://frr.pam \
            file://0001-zebra-Mimic-GNU-basename-API-for-non-glibc-library-e.patch \
+           file://0002-tools-update-frr-reload.py-path-to-usr-libexec-frr.patch \
            file://CVE-2024-55553.patch \
            file://CVE-2025-61099-61100-61101-61102-61103-61104-61105-61106-61107_1.patch \
            file://CVE-2025-61099-61100-61101-61102-61103-61104-61105-61106-61107_2.patch \


### PR DESCRIPTION
# FRR frr-reload.py path update to /usr/libexec/frr/

## Summary
This pull request updates the FRR (FRRouting) recipe to use the correct path for `frr-reload.py` in `/usr/libexec/frr/` instead of `/usr/lib/frr/`.

## Changes
- Added new patch file: `0002-tools-update-frr-reload.py-path-to-usr-libexec-frr.patch`
  - Updates `tools/frr-reload` script to look for `frr-reload.py` in `/usr/libexec/frr/`
  - Ensures proper execution path for the FRR reload utility
- Updated `frr_9.1.3.bb` recipe to include the new patch in the build process

## Details
- **Recipe**: `meta-networking/recipes-protocols/frr/frr_9.1.3.bb`
- **FRR Version**: 9.1.3
- **Branch**: stable/9.1

## Testing
Please verify that:
- The FRR package builds successfully with this patch
- The `frr-reload.py` script is correctly located and executable in `/usr/libexec/frr/`
- Existing functionality is not affected