### PR TITLE
chore: add .editorconfig and .gitattributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{patch,diff}]
+end_of_line = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset
+charset = unset
+indent_style = unset
+indent_size = unset

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# BitBake recipes and configuration (the bulk of this repository)
+*.bb         text
+*.bbappend   text
+*.bbclass    text
+*.inc        text
+*.conf       text
+*.cfg        text
+
+# Other text files actually present in this repository
+*.md         text diff=markdown
+*.txt        text
+*.json       text
+*.xml        text
+
+# Binary files actually present in this repository
+*.png        binary
+*.zip        binary
+
+# Patch and diff files: keep verbatim (do NOT normalize line endings)
+*.patch      -text
+*.diff       -text


### PR DESCRIPTION
## Changes

chore: add .editorconfig and .gitattributes

Add editor configuration and line ending normalization
for consistent development across platforms.

Signed with GPG.