### PR TITLE
libuio: fix FILE descriptor leak

### DIFF
--- a/meta-oe/recipes-extended/libuio/libuio/fix-fclose-leak-in-uio_line_from_file.patch
+++ b/meta-oe/recipes-extended/libuio/libuio/fix-fclose-leak-in-uio_line_from_file.patch
@@ -1,0 +1,31 @@
+From: Jason Smith <qili00001@gmail.com>
+Subject: [PATCH] Fix FILE descriptor leak in uio_line_from_file()
+
+The function uio_line_from_file() fails to close the FILE pointer
+when fgets() returns NULL, causing a file descriptor leak.
+
+Upstream-Status: Submitted [https://sourceforge.net/p/libuio/code/merge-requests/2/]
+Signed-off-by: Jason Smith <qili00001@gmail.com>
+
+--- a/src/uio_line_from_file.c
++++ b/src/uio_line_from_file.c
+@@ -28,14 +28,17 @@
+ {
+ 	char *s;
+ 	int i;
++	int ret = 0;
+ 	memset(linebuf, 0, UIO_MAX_NAME_SIZE);
+ 	FILE* file = fopen(filename,"r");
+ 	if (!file) return -1;
+ 	s = fgets(linebuf,UIO_MAX_NAME_SIZE,file);
+-	if (!s) return -2;
++	if (!s) { ret = -2; goto out; }
+ 	for (i=0; (*s)&&(i<UIO_MAX_NAME_SIZE); i++) {
+ 		if (*s == '\n') *s = 0;
+ 		s++;
+ 	}
+-	return 0;
++out:
++	fclose(file);
++	return ret;
+ }

--- a/meta-oe/recipes-extended/libuio/libuio_0.2.1.bb
+++ b/meta-oe/recipes-extended/libuio/libuio_0.2.1.bb
@@ -6,6 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=393a5ca445f6965873eca0259a17f833"
 SRCREV = "17d96e8f9a5bce7cee5e2222855ab46a246dba51"
 
 SRC_URI = "git://git.code.sf.net/p/libuio/code;branch=master;protocol=https"
+SRC_URI += "file://fix-fclose-leak-in-uio_line_from_file.patch"
 
 PV .= "+0.2.2+git"
 


### PR DESCRIPTION
The function uio_line_from_file() fails to close the FILE pointer when fgets() returns NULL, causing a file descriptor leak.

This can be triggered when reading from /sys files that return empty content, leading to resource exhaustion over time.

Fix this by using goto-based error handling to ensure fclose() is called on all exit paths.