### PR TITLE
ramspeed: Add recipe for cache and memory benchmarking tool

### DIFF
--- a/meta-oe/licenses/Alasir
+++ b/meta-oe/licenses/Alasir
@@ -1,0 +1,47 @@
+                              The Alasir Licence
+
+
+    This is a free software. It's provided as-is and carries absolutely no
+warranty or responsibility by the author and the contributors, neither in
+general nor in particular. No matter if this software is able or unable to
+cause any damage to your or third party's computer hardware, software, or any
+other asset available, neither the author nor a separate contributor may be
+found liable for any harm or its consequences resulting from either proper or
+improper use of the software, even if advised of the possibility of certain
+injury as such and so forth.
+
+    The software isn't a public domain, it's a copyrighted one. In no event
+shall the author's or a separate contributor's copyright be denied or violated
+otherwise. No copyright may be removed unless together with the code
+contributed to the software by a holder of the respective copyright. A
+copyright itself indicates the rights of ownership over the code contributed.
+Back and forth, the author is defined as the one who holds the oldest
+copyright over the software. Furthermore, the software is defined as either
+source or binary computer code, which is organised in the form of a single
+computer file usually.
+
+    The software (the whole or a part of it) is prohibited from being sold or
+leased in any form or manner with the only possible exceptions:
+
+a) money may be charged for a physical medium used to transfer the software;
+b) money may be charged for optional warranty or support services related to
+   the software.
+
+    Nevertheless, if the software (the whole or a part of it) is desired to
+become an object of sale or lease (the whole or a part of it), then a separate
+non-exclusive licence agreement must be negotiated from the author. Benefits
+accrued should be distributed between the contributors or likewise at the
+author's option.
+
+    Whenever and wherever the software is distributed, in either source or
+binary form, either in whole or in part, it must include the complete
+unchanged text of this licence agreement unless different conditions have been
+negotiated. In case of a binary-only distribution, the names of the copyright
+holders must be mentioned in the documentation supplied with the software.
+This is supposed to protect rights and freedom of those who have contributed
+their time and labour to free software development, because otherwise the
+development itself and this licence agreement are of a very little sense.
+
+    Nothing else but this licence agreement grants you rights to use, modify
+and distribute the software. Any violation of this licence agreement is
+recognised as an action prohibited by an applicable legislation.

--- a/meta-oe/recipes-benchmark/ramspeed/ramspeed_git.bb
+++ b/meta-oe/recipes-benchmark/ramspeed/ramspeed_git.bb
@@ -1,0 +1,21 @@
+SUMMARY = "Cache and memory benchmarking tool"
+DESCRIPTION = "RAMspeed is a micro-benchmark for measuring cache and memory bandwidth"
+HOMEPAGE = "https://github.com/cruvolo/ramspeed"
+
+LICENSE = "Alasir"
+LIC_FILES_CHKSUM = "file://LICENCE;md5=92cffec6695a20eab8d0e4770f4e9353"
+LICENSE_FLAGS = "commercial"
+
+SRC_URI = "git://github.com/cruvolo/ramspeed.git;protocol=https;branch=master"
+SRCREV = "f3a766dc4f89cee97b5283d5c6bdf8b8e3474813"
+
+do_compile() {
+    ${CC} ${CFLAGS} ${LDFLAGS} \
+        ramspeed.c intmem.c fltmem.c intmark.c fltmark.c \
+        -o ramspeed
+}
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ramspeed ${D}${bindir}/
+}


### PR DESCRIPTION
Add a new recipe for ramspeed, a lightweight benchmark utility that measures cache and memory bandwidth using a set of synthetic tests.