### PR TITLE
python3-{canmatrix,canopen}: Add recipes

### DIFF
--- a/meta-python/recipes-devtools/python/python3-canmatrix_1.2.bb
+++ b/meta-python/recipes-devtools/python/python3-canmatrix_1.2.bb
@@ -1,0 +1,13 @@
+SUMMARY = "Converting Can (Controller Area Network) Database Formats"
+HOMEPAGE = "https://github.com/ebroecker/canmatrix"
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=bb3bdbe015537f08812c87d93670ea1b"
+
+SRC_URI[sha256sum] = "19d5ba3fd69974bd41985b90198503bfde6ae3639dfc8ce6a2f7a0338787dbf7"
+
+inherit setuptools3 pypi
+
+RDEPENDS:${PN} += "\
+  python3-attrs \
+  python3-click \
+"

--- a/meta-python/recipes-devtools/python/python3-canopen_2.4.1.bb
+++ b/meta-python/recipes-devtools/python/python3-canopen_2.4.1.bb
@@ -1,0 +1,15 @@
+SUMMARY = "A Python implementation of the CANopen standard"
+HOMEPAGE = "https://github.com/canopen-python/canopen"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=97f135a6ee6f800c377b5512122c7a8d"
+
+SRC_URI[sha256sum] = "20a84bc498b34dadd79cece467d3bbe19591c1c02a8f39331bcc6065c4d8b2eb"
+
+inherit setuptools3 pypi
+
+RDEPENDS:${PN} += "\
+  python3-can \
+"
+
+PACKAGECONFIG ?= ""
+PACKAGECONFIG[canmatrix] = ",,,python3-canmatrix"


### PR DESCRIPTION
Add recipes for the python3 `canmatrix` and `canopen` packages.
Both packages are useful when interacting with CAN.

`canopen` optionally depends on `canmatrix`, which is why I send those
patches together.
