### PR TITLE
benchmarking: add performance measurement and evaluation tools

### DIFF
--- a/meta-oe/licenses/LicenseRef-wrk
+++ b/meta-oe/licenses/LicenseRef-wrk
@@ -1,0 +1,182 @@
+
+                          Modified Apache 2.0 License
+                         Version 2.0.1, February 2015
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      (e) If the Derivative Work includes substantial changes to features
+          or functionality of the Work, then you must remove the name of
+          the Work, and any derivation thereof, from all copies that you
+          distribute, whether in Source or Object form, except as required
+          in copyright, patent, trademark, and attribution notices.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/meta-oe/recipes-benchmark/coremark-pro/coremark-pro/0001-allow-toolchain-override.patch
+++ b/meta-oe/recipes-benchmark/coremark-pro/coremark-pro/0001-allow-toolchain-override.patch
@@ -1,0 +1,39 @@
+From: Vaibhav Jindal <vaibjind@qti.qualcomm.com>
+Date: Mon, 1 Jan 2024 00:00:00 +0000
+Subject: [PATCH] Allow toolchain components to be overridden for cross-compilation
+
+Allow toolchain components (CC, AS, AR, and LD) to be overridden by the build
+environment. This enables cross-compilation support while preserving the existing
+default behavior for native builds.
+
+Upstream-Status: Pending
+diff --git a/util/make/gcc64.mak b/util/make/gcc64.mak
+index d8d5e51..5ee9b52 100644
+--- a/util/make/gcc64.mak
++++ b/util/make/gcc64.mak
+@@ -41,7 +41,7 @@ TOOLS	= /usr
+ 
+ # Variable: CC
+ #	name of the compiler
+-CC		= $(TOOLS)/bin/gcc
++CC		?= $(TOOLS)/bin/gcc
+ # Solaris: /usr/ccs/bin/as requires space after -o passed from gcc.
+ #OBJOUT = -o \#
+ OBJOUT	= -o
+@@ -50,13 +50,13 @@ CINCD	= -I
+ CDEFN	= -D
+ OEXT = .o
+ 
+-AS		= $(TOOLS)/bin/as
++AS		?= $(TOOLS)/bin/as
+ 
+-LD		= $(TOOLS)/bin/gcc
++LD		?= $(TOOLS)/bin/gcc
+ EXEOUT	= -o
+ EXE		= .exe
+ 
+-AR		= $(TOOLS)/bin/ar
++AR		?= $(TOOLS)/bin/ar
+ LIBTYPE	= .a
+ LIBOUT	= 
+ 

--- a/meta-oe/recipes-benchmark/coremark-pro/coremark-pro_git.bb
+++ b/meta-oe/recipes-benchmark/coremark-pro/coremark-pro_git.bb
@@ -1,0 +1,42 @@
+SUMMARY = "EEMBC CoreMark-Pro CPU benchmark"
+DESCRIPTION = "CoreMark-Pro is a comprehensive CPU benchmark suite from EEMBC that evaluates processor performance using integer, floating-point, and real-world workloads."
+HOMEPAGE = "https://www.eembc.org/coremark-pro/"
+LICENSE = "Apache-2.0 & LicenseRef-EEMBC-AUA"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=c84d8f508b20d579641ad151a79a8bf3"
+
+SRC_URI = "git://github.com/eembc/coremark-pro.git;branch=main;protocol=https"
+SRCREV = "4832cc67b0926c7a80a4b7ce0ce00f4640ea6bec"
+
+# Apply patch to allow cross-compilation
+SRC_URI += "file://0001-allow-toolchain-override.patch"
+
+inherit pkgconfig
+
+# Ignore buildpaths QA check - CoreMark-Pro embeds build paths in binaries
+INSANE_SKIP:${PN} += "buildpaths"
+INSANE_SKIP:${PN}-dbg += "buildpaths"
+
+do_configure[noexec] = "1"
+
+TARGET_CC_ARCH += "${LDFLAGS}"
+
+do_compile() {
+    oe_runmake \
+    TARGET=linux64 \
+    CC="${CC}" \
+    AS="${AS}" \
+    AR="${AR}" \
+    LD="${CC}" \
+    LINKER_LAST="-lc -lm -lrt -lpthread" \
+    build
+}
+
+do_install() {
+    install -d ${D}${bindir}
+    # CoreMark-Pro generates nine workload binaries
+    for binary in cjpeg-rose7-preset core linear_alg-mid-100x100-sp loops-all-mid-10k-sp nnet_test parser-125k radix2-big-64k sha-test zip-test; do
+        if [ -f ${S}/builds/linux64/gcc64/bin/${binary}.exe ]; then
+            install -m 0755 ${S}/builds/linux64/gcc64/bin/${binary}.exe ${D}${bindir}/${binary}
+        fi
+    done
+}

--- a/meta-oe/recipes-benchmark/cyclictest/cyclictest_git.bb
+++ b/meta-oe/recipes-benchmark/cyclictest/cyclictest_git.bb
@@ -1,0 +1,24 @@
+SUMMARY = "Real-time latency measurement tool"
+DESCRIPTION = "Cyclictest is a tool for measuring real-time latency and jitter on Linux systems. It measures the latency of the kernel scheduler."
+HOMEPAGE = "https://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
+
+SRC_URI = "git://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git;protocol=https;branch=main"
+SRCREV = "7aca81171ea05a03d0e8698af4ae53c5177f5f83"
+
+DEPENDS = "numactl"
+
+# Filter out unsupported compiler flags
+CFLAGS:remove = "-fcanon-prefix-map"
+
+do_configure[noexec] = "1"
+
+do_compile() {
+    oe_runmake NUMA=1 CC="${CC}" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" cyclictest
+}
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${B}/cyclictest ${D}${bindir}/cyclictest
+}

--- a/meta-oe/recipes-benchmark/hackbench/hackbench_git.bb
+++ b/meta-oe/recipes-benchmark/hackbench/hackbench_git.bb
@@ -1,0 +1,24 @@
+SUMMARY = "Linux kernel scheduler benchmark"
+DESCRIPTION = "Hackbench is a benchmark for measuring Linux kernel scheduler performance. It creates groups of processes or threads that communicate via pipes or sockets and measures the time taken to complete the communication."
+HOMEPAGE = "https://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
+
+SRC_URI = "git://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git;protocol=https;branch=main"
+SRCREV = "d232f528fd131b7d840e79a3756d1dbdaa9b1b60"
+
+DEPENDS = "numactl"
+
+# Filter out unsupported compiler flags
+CFLAGS:remove = "-fcanon-prefix-map"
+
+do_configure[noexec] = "1"
+
+do_compile() {
+    oe_runmake NUMA=1 CC="${CC}" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" hackbench
+}
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${B}/hackbench ${D}${bindir}/hackbench
+}

--- a/meta-oe/recipes-benchmark/ramspeed-smp/ramspeed-smp_git.bb
+++ b/meta-oe/recipes-benchmark/ramspeed-smp/ramspeed-smp_git.bb
@@ -1,0 +1,19 @@
+SUMMARY = "RAMspeed/SMP cache and memory benchmarking tool"
+DESCRIPTION = "RAMspeed/SMP measures cache and memory bandwidth on multiprocessor systems."
+HOMEPAGE = "https://github.com/cruvolo/ramspeed-smp"
+LICENSE = "Alasir"
+LIC_FILES_CHKSUM = "file://LICENCE;md5=92cffec6695a20eab8d0e4770f4e9353"
+
+SRC_URI = "git://github.com/cruvolo/ramspeed-smp.git;protocol=https;branch=master"
+SRCREV = "2011a256caa6a0ccdb88cb8c6b1e69c8f782b729"
+
+do_compile() {
+    ${CC} ${CFLAGS} ${LDFLAGS} \
+        ramsmp.c intmem.c fltmem.c intmark.c fltmark.c \
+        -o ramsmp
+}
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ramsmp ${D}${bindir}/ramsmp
+}

--- a/meta-oe/recipes-benchmark/ramspeed/ramspeed_git.bb
+++ b/meta-oe/recipes-benchmark/ramspeed/ramspeed_git.bb
@@ -1,10 +1,8 @@
 SUMMARY = "Cache and memory benchmarking tool"
 DESCRIPTION = "RAMspeed is a micro-benchmark for measuring cache and memory bandwidth"
 HOMEPAGE = "https://github.com/cruvolo/ramspeed"
-
-LICENSE = "LicenseRef-Alasir"
+LICENSE = "Alasir"
 LIC_FILES_CHKSUM = "file://LICENCE;md5=92cffec6695a20eab8d0e4770f4e9353"
-LICENSE_FLAGS = "commercial"
 
 SRC_URI = "git://github.com/cruvolo/ramspeed.git;protocol=https;branch=master"
 SRCREV = "f3a766dc4f89cee97b5283d5c6bdf8b8e3474813"

--- a/meta-oe/recipes-benchmark/sockperf/sockperf_git.bb
+++ b/meta-oe/recipes-benchmark/sockperf/sockperf_git.bb
@@ -1,0 +1,11 @@
+SUMMARY = "Network benchmarking utility for measuring latency and throughput"
+DESCRIPTION = "Tool for network performance measurement written in C++"
+HOMEPAGE = "https://github.com/Mellanox/sockperf"
+SECTION = "console/network"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://copying;md5=b4563b57c98bc23c8cecbc0b6d9546e9"
+
+SRC_URI = "git://github.com/Mellanox/sockperf;branch=sockperf_v2;protocol=https"
+SRCREV = "3c65ad99cd385e18f8a2a655c19826e81a4d17e8"
+
+inherit autotools

--- a/meta-oe/recipes-benchmark/unixbench/unixbench/0001-skip-make-checks.patch
+++ b/meta-oe/recipes-benchmark/unixbench/unixbench/0001-skip-make-checks.patch
@@ -1,0 +1,32 @@
+From: Vaibhav Jindal <vaibjind@qti.qualcomm.com>
+Date: Mon, 1 Jan 2024 00:00:00 +0000
+Subject: [PATCH] Skip make checks for prebuilt Yocto package
+
+The UnixBench Run script expects a source tree and invokes
+'make check' and 'make all'. In Yocto, binaries are prebuilt
+during do_compile() and only runtime artifacts are installed.
+Skip the build verification step.
+
+Upstream-Status: Inappropriate [cross-compilation]
+
+diff --git a/UnixBench/Run b/UnixBench/Run
+index 898eb5c..fb24263 100755
+--- a/UnixBench/Run
++++ b/UnixBench/Run
+@@ -1037,16 +1037,6 @@ sub preChecks {
+     # Set the language.
+     $ENV{'LANG'} = $language;
+ 
+-    # Check that the required files are in the proper places.
+-    my $make = $ENV{MAKE} || "make";
+-    system("$make check");
+-    if ($? != 0) {
+-        system("$make all");
+-        if ($? != 0) {
+-            abortRun("\"$make all\" failed");
+-        }
+-    }
+-
+     # Create a script to kill this run.
+     system("echo \"kill -9 $$\" > \"${TMPDIR}/kill_run\"");
+     chmod(0755, $TMPDIR . "/kill_run");

--- a/meta-oe/recipes-benchmark/unixbench/unixbench_git.bb
+++ b/meta-oe/recipes-benchmark/unixbench/unixbench_git.bb
@@ -1,0 +1,65 @@
+SUMMARY = "BYTE UNIX Benchmark Suite"
+DESCRIPTION = "UnixBench is the original BYTE UNIX benchmark suite that provides a basic indicator of the performance of a Unix-like system. It includes tests for CPU, memory, I/O, and graphics performance."
+HOMEPAGE = "https://github.com/kdlucas/byte-unixbench"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+SRC_URI = " \
+    git://github.com/kdlucas/byte-unixbench.git;protocol=https;nobranch=1 \
+    file://0001-skip-make-checks.patch \
+"
+SRCREV = "e949d4402f76b4bc9b7b114418faace882f0ef12"
+
+do_configure[noexec] = "1"
+
+RDEPENDS:${PN} += " \
+    perl \
+    perl-modules \
+"
+
+INSANE_SKIP:${PN} = "ldflags"
+
+do_compile() {
+    oe_runmake -C ${S}/UnixBench \
+    CC="${CC}" \
+    AS="${AS}" \
+    AR="${AR}" \
+    LD="${CC}" \
+    UB_GCC_OPTIONS="${CFLAGS}" \
+    LDFLAGS="${LDFLAGS} -lm" \
+    all
+}
+
+do_install() {
+    # Install UnixBench under datadir to preserve directory structure
+    install -d ${D}${datadir}/unixbench/pgms
+    install -d ${D}${datadir}/unixbench/testdir
+    install -d ${D}${datadir}/unixbench/results
+    install -d ${D}${datadir}/unixbench/tmp
+    
+    # Install UnixBench binaries under pgms/ directory
+    for binary in arithoh register short int long float double hanoi syscall context1 pipe spawn execl dhry2 dhry2reg looper fstime whetstone-double; do
+        if [ -f ${S}/UnixBench/pgms/${binary} ]; then
+            install -m 0755 ${S}/UnixBench/pgms/${binary} ${D}${datadir}/unixbench/pgms/${binary}
+        fi
+    done
+    
+    # Install Run script
+    install -m 0755 ${S}/UnixBench/Run ${D}${datadir}/unixbench/Run
+    
+    # Install test scripts
+    install -m 0755 ${S}/UnixBench/pgms/multi.sh ${D}${datadir}/unixbench/pgms/
+    install -m 0755 ${S}/UnixBench/pgms/tst.sh ${D}${datadir}/unixbench/pgms/
+    install -m 0644 ${S}/UnixBench/pgms/index.base ${D}${datadir}/unixbench/pgms/
+    install -m 0644 ${S}/UnixBench/pgms/unixbench.logo ${D}${datadir}/unixbench/pgms/
+    
+    # Install test data files
+    install -m 0644 ${S}/UnixBench/testdir/sort.src ${D}${datadir}/unixbench/testdir/
+    install -m 0644 ${S}/UnixBench/testdir/cctest.c ${D}${datadir}/unixbench/testdir/
+    install -m 0644 ${S}/UnixBench/testdir/dc.dat ${D}${datadir}/unixbench/testdir/
+    install -m 0644 ${S}/UnixBench/testdir/large.txt ${D}${datadir}/unixbench/testdir/
+}
+
+FILES:${PN} += " \
+    ${datadir}/unixbench \
+"

--- a/meta-oe/recipes-benchmark/wrk/wrk_git.bb
+++ b/meta-oe/recipes-benchmark/wrk/wrk_git.bb
@@ -1,0 +1,32 @@
+SUMMARY = "HTTP benchmarking tool"
+DESCRIPTION = "wrk is a modern HTTP benchmarking tool capable of generating \
+significant load when run on a single multi-core CPU."
+HOMEPAGE = "https://github.com/wg/wrk"
+SECTION = "console/network"
+LICENSE = "LicenseRef-wrk"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1a1b7dfe4016fcf67ae4715f167a0043"
+
+DEPENDS = "luajit luajit-native openssl"
+
+SRC_URI = "git://github.com/wg/wrk.git;protocol=https;branch=master"
+SRCREV = "a211dd5a7050b1f9e8a9870b95513060e72ac4a0"
+
+# Use system luajit and openssl instead of bundled deps/
+# luajit headers install to a versioned subdir, point include path explicitly
+# LUA_PATH must point to luajit-native's jit.* modules for bytecode compilation (-b)
+EXTRA_OEMAKE = "\
+    WITH_LUAJIT=${RECIPE_SYSROOT}/usr \
+    WITH_OPENSSL=${RECIPE_SYSROOT}/usr \
+    CC='${CC}' \
+    CFLAGS='${CFLAGS} -I${RECIPE_SYSROOT}/usr/include/luajit-2.1' \
+"
+
+do_compile() {
+    export LUA_PATH="${RECIPE_SYSROOT_NATIVE}/usr/share/luajit-2.1/?.lua;;"
+    oe_runmake
+}
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 wrk ${D}${bindir}/wrk
+}

--- a/meta-oe/recipes-benchmark/wrk2/wrk2/0001-load-wrk-lua-from-filesystem.patch
+++ b/meta-oe/recipes-benchmark/wrk2/wrk2/0001-load-wrk-lua-from-filesystem.patch
@@ -1,0 +1,29 @@
+From: Vaibhav Jindal <vaibjind@qti.qualcomm.com>
+Date: Mon, 1 Jan 2024 00:00:00 +0000
+Subject: [PATCH] Load wrk.lua from filesystem instead of embedded bytecode
+
+This patch allows wrk2 to load the wrk.lua module from the filesystem
+instead of relying on embedded bytecode compilation. This solves
+cross-compilation issues where bytecode cannot be compiled for the
+target architecture.
+
+Upstream-Status: Inappropriate [cross-compilation]
+
+diff --git a/src/script.c b/src/script.c
+index 30ef4fd..38f97d6 100644
+--- a/src/script.c
++++ b/src/script.c
+@@ -48,7 +48,12 @@ static const struct luaL_Reg threadlib[] = {
+ lua_State *script_create(char *file, char *url, char **headers) {
+     lua_State *L = luaL_newstate();
+     luaL_openlibs(L);
+-    (void) luaL_dostring(L, "wrk = require \"wrk\"");
++    if (luaL_loadfile(L, "/usr/share/wrk2/wrk.lua") ||
++        lua_pcall(L, 0, 1, 0)) {
++        fprintf(stderr, "Failed to load /usr/share/wrk2/wrk.lua\n");
++        return NULL;
++    }
++    lua_setglobal(L, "wrk");
+ 
+     luaL_newmetatable(L, "wrk.addr");
+     luaL_register(L, NULL, addrlib);

--- a/meta-oe/recipes-benchmark/wrk2/wrk2_git.bb
+++ b/meta-oe/recipes-benchmark/wrk2/wrk2_git.bb
@@ -1,0 +1,46 @@
+SUMMARY = "HTTP benchmarking tool with constant throughput and latency details"
+DESCRIPTION = "wrk2 is a version of wrk modified to produce a constant throughput load and report accurate latency details."
+HOMEPAGE = "https://github.com/AmpereTravis/wrk2-aarch64"
+SECTION = "console/network"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=2ee41112a44fe7014dce33e26468ba93"
+DEPENDS = "luajit luajit-native openssl zlib"
+SRC_URI = "git://github.com/AmpereTravis/wrk2-aarch64.git;protocol=https;branch=master \
+           file://0001-load-wrk-lua-from-filesystem.patch"
+SRCREV = "59c09ad4442329ade4343e1ade683c4d12b0b370"
+
+do_configure() {
+    sed -i \
+    -e 's|LIBS := -lluajit|LIBS := -lluajit-5.1|' \
+    -e 's|$(LDIR)/libluajit.a||' \
+    -e 's|$(ODIR)/bytecode.o||g' \
+    Makefile
+    sed -i '/#include <x86intrin.h>/d' src/hdr_histogram.c
+    sed -i '/#include <zlib.h>/d' src/hdr_histogram.c
+    sed -i 's/struct luaL_reg/struct luaL_Reg/g' src/script.c
+}
+
+EXTRA_OEMAKE = "\
+    LDIR=${RECIPE_SYSROOT}/usr/include/luajit-2.1 \
+    LIBS='-lluajit-5.1 -lpthread -lm -lssl -lcrypto -ldl' \
+    CC='${CC}' \
+    CFLAGS='${CFLAGS} -I${RECIPE_SYSROOT}/usr/include/luajit-2.1' \
+    LDFLAGS='${LDFLAGS} -L${RECIPE_SYSROOT}/usr/lib' \
+"
+
+do_configure:append() {
+    sed -i \
+    's/signed char c, \*\*header = headers;/signed char c; char **header = headers;/' \
+    src/wrk.c
+}
+
+do_compile() {
+    oe_runmake V=1
+}
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 wrk ${D}${bindir}/wrk2
+    install -d ${D}${datadir}/wrk2
+    install -m 0644 src/wrk.lua ${D}${datadir}/wrk2/wrk.lua
+}

--- a/meta-oe/recipes-core/packagegroups/packagegroup-meta-oe.bb
+++ b/meta-oe/recipes-core/packagegroups/packagegroup-meta-oe.bb
@@ -58,6 +58,7 @@ RDEPENDS:packagegroup-meta-oe-benchmarks = "\
     dhrystone \
     fio \
     ${@bb.utils.contains("DISTRO_FEATURES", "x11 wayland opengl", "glmark2", "", d)} \
+    hackbench \
     iozone3 \
     iperf2 \
     iperf3 \

--- a/meta-oe/recipes-core/packagegroups/packagegroup-meta-oe.bb
+++ b/meta-oe/recipes-core/packagegroups/packagegroup-meta-oe.bb
@@ -52,6 +52,7 @@ RDEPENDS:packagegroup-meta-oe = "\
 
 RDEPENDS:packagegroup-meta-oe-benchmarks = "\
     bonnie++ \
+    coremark-pro \
     cpupower \
     dbench \
     dhrystone \
@@ -66,14 +67,20 @@ RDEPENDS:packagegroup-meta-oe-benchmarks = "\
     mbw \
     memtester \
     nbench-byte \
+    osbench \
     phoronix-test-suite \
     qperf \
+    ramspeed \
+    ramspeed-smp \
     rtla \
     s-suite \
+    sockperf \
     stressapptest \
     tinymembench \
     tiobench \
     whetstone \
+    wrk \
+    wrk2 \
 "
 RDEPENDS:packagegroup-meta-oe-benchmarks:append:armv7a = " cpuburn-arm sysbench"
 RDEPENDS:packagegroup-meta-oe-benchmarks:append:armv7ve = " cpuburn-arm sysbench"

--- a/meta-oe/recipes-core/packagegroups/packagegroup-meta-oe.bb
+++ b/meta-oe/recipes-core/packagegroups/packagegroup-meta-oe.bb
@@ -78,6 +78,7 @@ RDEPENDS:packagegroup-meta-oe-benchmarks = "\
     stressapptest \
     tinymembench \
     tiobench \
+    unixbench \
     whetstone \
     wrk \
     wrk2 \

--- a/meta-oe/recipes-core/packagegroups/packagegroup-meta-oe.bb
+++ b/meta-oe/recipes-core/packagegroups/packagegroup-meta-oe.bb
@@ -54,6 +54,7 @@ RDEPENDS:packagegroup-meta-oe-benchmarks = "\
     bonnie++ \
     coremark-pro \
     cpupower \
+    cyclictest \
     dbench \
     dhrystone \
     fio \


### PR DESCRIPTION
This series adds recipes for a collection of benchmarking,
performance analysis, and real-time evaluation tools to
meta-openembedded.

Added recipes:

* cyclictest
  - Real-time latency measurement tool from the rt-tests project
  - Used to evaluate scheduler latency and system jitter
  - NUMA support enabled

* hackbench
  - Linux scheduler benchmark
  - Measures scheduling and inter-process communication performance
  - NUMA support enabled

* unixbench
  - System benchmark suite covering CPU, memory, and overall system performance

* coremark-pro
  - EEMBC benchmark suite evaluating processor performance using
    integer, floating-point, and real-world workloads

* ramspeed-smp
  - Memory bandwidth and latency benchmark for SMP systems

* sockperf
  - Network latency and throughput benchmarking tool for TCP and UDP workloads

* wrk2
  - Constant-throughput HTTP benchmarking tool for web server and
    service performance evaluation

All recipes have been successfully built and validated on aarch64
targets. Functional testing confirmed that the installed binaries
execute correctly and produce expected benchmark results.

Signed-off-by: Vaibhav Jindal <vaibjind@qti.qualcomm.com>