### PR TITLE
libfaketime: extend to native

### DIFF
--- a/meta-oe/recipes-test/libfaketime/libfaketime_0.9.12.bb
+++ b/meta-oe/recipes-test/libfaketime/libfaketime_0.9.12.bb
@@ -26,3 +26,5 @@ do_install () {
 
 FILES:${PN} = "${bindir}/faketime ${libdir}/faketime/lib*${SOLIBS}"
 FILES:${PN}-dev += "${libdir}/faketime/lib*${SOLIBSDEV}"
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
It is needed for reproducible UEFI capsules in [meta-tegra](https://github.com/OE4T/meta-tegra). 
