### PR TITLE
boot-time-analysis-tools: add boot time profiling tools

### DIFF
--- a/meta-oe/dynamic-layers/meta-python/recipes-devtools/boot-time-analysis-tools/boot-time-analysis-tools_0.7.1.bb
+++ b/meta-oe/dynamic-layers/meta-python/recipes-devtools/boot-time-analysis-tools/boot-time-analysis-tools_0.7.1.bb
@@ -1,0 +1,16 @@
+SUMMARY = "Boot time analysis tools from CentOS Automotive SIG"
+DESCRIPTION = "Tools for analyzing and visualizing system boot time"
+HOMEPAGE = "https://gitlab.com/CentOS/automotive/src/boot-time-analysis-tools"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1c2e0cc0dec0b709fe547806b55737b0"
+
+SRC_URI = "git://gitlab.com/CentOS/automotive/src/boot-time-analysis-tools.git;protocol=https;branch=main;tag=${PV}"
+SRCREV = "2409ce37e7389d8079bdb8740cb6a44b505fb8d4"
+
+inherit setuptools3 features_check
+
+# This tool reads from the systemd journal and queries D-Bus via systemd;
+# it has no meaningful function without systemd as the init system.
+REQUIRED_DISTRO_FEATURES = "systemd"
+
+RDEPENDS:${PN} = "python3-dbus ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'python3-systemd', '', d)}"

--- a/meta-oe/recipes-devtools/cntvct-log/cntvct-log_0.7.1.bb
+++ b/meta-oe/recipes-devtools/cntvct-log/cntvct-log_0.7.1.bb
@@ -1,0 +1,31 @@
+SUMMARY = "cntvct-log - ARM virtual counter boot time logger"
+DESCRIPTION = "Userspace tool to log ARM CNTVCT_EL0 counter values for boot time analysis"
+HOMEPAGE = "https://gitlab.com/CentOS/automotive/src/boot-time-analysis-tools"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://../LICENSE;md5=1c2e0cc0dec0b709fe547806b55737b0"
+
+SRC_URI = "git://gitlab.com/CentOS/automotive/src/boot-time-analysis-tools.git;protocol=https;branch=main;tag=${PV}"
+SRCREV = "2409ce37e7389d8079bdb8740cb6a44b505fb8d4"
+
+S = "${UNPACKDIR}/cntvct-log-${PV}/cntvct-log"
+
+inherit meson systemd features_check
+
+# cntvct@.service is a systemd template unit; no function without systemd.
+REQUIRED_DISTRO_FEATURES = "systemd"
+
+# cntvct-log contains AArch64-specific inline assembly.
+COMPATIBLE_HOST = "aarch64.*-linux"
+
+SYSTEMD_SERVICE:${PN} = "cntvct@.service"
+SYSTEMD_AUTO_ENABLE = "disable"
+
+# The Meson build does not install the service file in cross-compilation
+# environments; install it explicitly from the source tree layout.
+do_install:append() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${S}/usr/lib/systemd/system/cntvct@.service \
+        ${D}${systemd_system_unitdir}/cntvct@.service
+}
+
+FILES:${PN} += "${systemd_system_unitdir}/cntvct@.service"


### PR DESCRIPTION
Add two new recipes from the CentOS Automotive SIG boot-time-analysis-tools project to enable boot time profiling and measurement.

boot-time-analysis-tools:
  Python-based toolset for collecting, analyzing and visualizing system
  boot timing data from the systemd journal. Provides the 'boot_timings'
  CLI utility which queries D-Bus and the systemd journal to produce
  structured boot time reports. Depends on python3-dbus and python3-systemd
  for runtime journal and D-Bus access.

cntvct-log:
  Userspace C utility built with Meson that logs ARM CNTVCT_EL0 virtual
  counter timestamps to correlate hardware-level timing with systemd boot
  events. Installs cntvct@.service as a systemd template unit (disabled
  by default) for on-demand per-instance activation. The service preset
  file (98-cntvct-log.preset) is installed for system-preset-based enablement.

Both recipes fetch from the same upstream git repository:
  https://gitlab.com/CentOS/automotive/src/boot-time-analysis-tools